### PR TITLE
feat: adopt Proposal C (Editorial Three-Role) typography

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,10 @@ PostCSS uses `@tailwindcss/postcss` (not `tailwindcss`).
 | Borders            | 2px solid white   | All borders, always |
 | Border-radius      | 0px               | Globally enforced   |
 | Shadows            | `hard-*`          | 4px offset, no blur |
-| Font               | Courier New, mono | Body and headings   |
+| Display font       | Space Grotesk (`font-display`) | Headings / page titles |
+| Body font          | Inter (default `font-sans`)    | Body / reading copy    |
+| Mono font          | IBM Plex Mono (`font-mono`)    | Code + UI / metadata   |
+| Pixel font         | VT323 (`font-pixel`)           | Logo + hero accents    |
 
 ### MDX Content
 

--- a/components/BlogActions.tsx
+++ b/components/BlogActions.tsx
@@ -132,7 +132,7 @@ const BlogActions = ({ toc, activeId }: BlogActionsProps) => {
             <div className="flex items-center justify-between mb-6 pb-4 border-b-2 border-white">
               <div className="flex items-center gap-2">
                 <FileText className="w-5 h-5 text-brutalist-cyan" />
-                <h2 className="font-mono text-sm font-bold uppercase text-brutalist-yellow">
+                <h2 className="font-display text-sm font-bold uppercase text-brutalist-yellow">
                   [ CONTENTS ]
                 </h2>
               </div>

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -56,7 +56,7 @@ const Card = ({
       )}
 
       <div className="p-6">
-        <h2 className="mb-3 text-2xl font-mono font-bold leading-8 tracking-tight uppercase text-white">
+        <h2 className="mb-3 text-2xl font-display font-bold leading-8 tracking-tight uppercase text-white">
           {href ? (
             <Link
               href={href}

--- a/components/CyberHero.tsx
+++ b/components/CyberHero.tsx
@@ -18,7 +18,7 @@ const CyberHero = () => {
       style={{ width: '100vw', marginLeft: 'calc(-50vw + 50%)' }}
     >
       {/* Background Grid */}
-      <div 
+      <div
         className="absolute inset-0 pointer-events-none"
         style={{
           backgroundSize: '50px 50px',
@@ -26,12 +26,13 @@ const CyberHero = () => {
             linear-gradient(to right, rgba(57, 255, 20, 0.1) 1px, transparent 1px),
             linear-gradient(to bottom, rgba(57, 255, 20, 0.1) 1px, transparent 1px)
           `,
-          transform: 'perspective(500px) rotateX(60deg) translateY(-100px) translateZ(-200px)',
+          transform:
+            'perspective(500px) rotateX(60deg) translateY(-100px) translateZ(-200px)',
           transformOrigin: 'top center',
           opacity: 0.6,
         }}
       />
-      <div 
+      <div
         className="absolute inset-0 bottom-0 top-auto h-1/2 pointer-events-none"
         style={{
           backgroundSize: '50px 50px',
@@ -39,7 +40,8 @@ const CyberHero = () => {
             linear-gradient(to right, rgba(57, 255, 20, 0.2) 1px, transparent 1px),
             linear-gradient(to bottom, rgba(57, 255, 20, 0.2) 1px, transparent 1px)
           `,
-          transform: 'perspective(500px) rotateX(60deg) translateY(100px) translateZ(50px)',
+          transform:
+            'perspective(500px) rotateX(60deg) translateY(100px) translateZ(50px)',
           transformOrigin: 'bottom center',
           opacity: 0.8,
         }}
@@ -52,11 +54,30 @@ const CyberHero = () => {
       </div>
 
       {/* Cyberpunk lines/circuits connecting to circle */}
-      <svg className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full h-full opacity-30 pointer-events-none stroke-brutalist-cyberOrange" viewBox="0 0 1000 1000">
-        <path d="M 0 450 L 200 450 L 250 400 L 350 400" fill="none" strokeWidth="2" />
-        <path d="M 0 550 L 150 550 L 200 600 L 350 600" fill="none" strokeWidth="2" />
-        <path d="M 1000 450 L 800 450 L 750 400 L 650 400" fill="none" strokeWidth="2" />
-        <path d="M 1000 550 L 850 550 L 800 600 L 650 600" fill="none" strokeWidth="2" />
+      <svg
+        className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full h-full opacity-30 pointer-events-none stroke-brutalist-cyberOrange"
+        viewBox="0 0 1000 1000"
+      >
+        <path
+          d="M 0 450 L 200 450 L 250 400 L 350 400"
+          fill="none"
+          strokeWidth="2"
+        />
+        <path
+          d="M 0 550 L 150 550 L 200 600 L 350 600"
+          fill="none"
+          strokeWidth="2"
+        />
+        <path
+          d="M 1000 450 L 800 450 L 750 400 L 650 400"
+          fill="none"
+          strokeWidth="2"
+        />
+        <path
+          d="M 1000 550 L 850 550 L 800 600 L 650 600"
+          fill="none"
+          strokeWidth="2"
+        />
       </svg>
 
       {/* Center Text */}
@@ -69,9 +90,7 @@ const CyberHero = () => {
         <h1 className="text-5xl md:text-7xl lg:text-8xl font-bold font-sans text-white mb-2 tracking-widest drop-shadow-[0_0_10px_rgba(255,255,255,0.5)]">
           RYAN KELLY
         </h1>
-        <p
-          className="text-lg md:text-2xl font-mono text-brutalist-neonGreen bg-black/50 px-4 py-1 drop-shadow-[0_0_8px_rgba(57,255,20,1)]"
-        >
+        <p className="text-lg md:text-2xl font-mono text-brutalist-neonGreen bg-black/50 px-4 py-1 drop-shadow-[0_0_8px_rgba(57,255,20,1)]">
           {'>'} FULL_STACK_ENGINEER.exe
         </p>
       </div>
@@ -79,8 +98,8 @@ const CyberHero = () => {
       {/* Scroll indicator */}
       <div
         className="absolute bottom-12 left-1/2 -translate-x-1/2 z-20 flex flex-col items-center gap-2 text-brutalist-neonGreen transition-opacity duration-300 drop-shadow-[0_0_8px_rgba(57,255,20,1)]"
-        style={{ 
-          opacity: scrollY > 100 ? 0 : 1
+        style={{
+          opacity: scrollY > 100 ? 0 : 1,
         }}
       >
         <div className="text-xl md:text-2xl font-pixel uppercase tracking-widest animate-pulse flex items-center gap-4 border border-brutalist-neonGreen px-4 py-2 bg-black/40">

--- a/components/CyberHero.tsx
+++ b/components/CyberHero.tsx
@@ -87,7 +87,7 @@ const CyberHero = () => {
           transform: `translateY(calc(-50% + ${scrollY * 0.2}px))`,
         }}
       >
-        <h1 className="text-5xl md:text-7xl lg:text-8xl font-bold font-sans text-white mb-2 tracking-widest drop-shadow-[0_0_10px_rgba(255,255,255,0.5)]">
+        <h1 className="text-5xl md:text-7xl lg:text-8xl font-bold font-display text-white mb-2 tracking-widest drop-shadow-[0_0_10px_rgba(255,255,255,0.5)]">
           RYAN KELLY
         </h1>
         <p className="text-lg md:text-2xl font-mono text-brutalist-neonGreen bg-black/50 px-4 py-1 drop-shadow-[0_0_8px_rgba(57,255,20,1)]">

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -14,14 +14,23 @@ export default function Footer() {
           />
           <SocialIcon kind="github" href={siteMetadata.github} size={8} />
           <SocialIcon kind="linkedin" href={siteMetadata.linkedin} size={8} />
-          <SocialIcon kind="twitter" href={siteMetadata.x || siteMetadata.twitter} size={8} />
+          <SocialIcon
+            kind="twitter"
+            href={siteMetadata.x || siteMetadata.twitter}
+            size={8}
+          />
         </div>
         <div className="flex space-x-2 text-sm font-mono text-white">
           <div>{siteMetadata.author}</div>
           <div>{` • `}</div>
           <div>{`© ${new Date().getFullYear()}`}</div>
           <div>{` • `}</div>
-          <Link href="/" className="hover:text-brutalist-cyan transition-colors">{siteMetadata.title}</Link>
+          <Link
+            href="/"
+            className="hover:text-brutalist-cyan transition-colors"
+          >
+            {siteMetadata.title}
+          </Link>
         </div>
       </div>
     </footer>

--- a/components/LayoutWrapper.tsx
+++ b/components/LayoutWrapper.tsx
@@ -14,13 +14,18 @@ interface Props {
 const LayoutWrapper = ({ children }: Props) => {
   return (
     <SectionContainer>
-      <div className="flex flex-col justify-between min-h-screen bg-black" style={{
-        backgroundImage: `linear-gradient(rgba(0, 255, 0, 0.03) 1px, transparent 1px)`,
-        backgroundSize: '100% 4px',
-      }}>
+      <div
+        className="flex flex-col justify-between min-h-screen bg-black"
+        style={{
+          backgroundImage: `linear-gradient(rgba(0, 255, 0, 0.03) 1px, transparent 1px)`,
+          backgroundSize: '100% 4px',
+        }}
+      >
         <header
           className={`flex items-center justify-between py-6 px-4 border-b border-gray-800 ${
-            siteMetadata.stickyNav ? 'sticky top-0 z-50 bg-black/90 backdrop-blur' : ''
+            siteMetadata.stickyNav
+              ? 'sticky top-0 z-50 bg-black/90 backdrop-blur'
+              : ''
           } text-white`}
         >
           <div>

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -33,9 +33,17 @@ const MobileNav = () => {
           className="text-current w-6 h-6 m-auto"
         >
           {navShow ? (
-            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M6 18L18 6M6 6l12 12"
+            />
           ) : (
-            <path strokeLinecap="round" strokeLinejoin="round" d="M3 12h18M3 6h18M3 18h18" />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M3 12h18M3 6h18M3 18h18"
+            />
           )}
         </svg>
       </button>

--- a/components/NewsletterForm.tsx
+++ b/components/NewsletterForm.tsx
@@ -59,7 +59,9 @@ const NewsletterForm = ({
               id="email-input"
               name="email"
               placeholder={
-                subscribed ? "subscribed_successfully" : 'enter_email_address...|'
+                subscribed
+                  ? 'subscribed_successfully'
+                  : 'enter_email_address...|'
               }
               ref={inputEl}
               required
@@ -85,9 +87,7 @@ const NewsletterForm = ({
       {(message || error) && (
         <div
           className={`pt-2 text-sm uppercase ${
-            error
-              ? 'text-brutalist-pink'
-              : 'text-brutalist-neonGreen'
+            error ? 'text-brutalist-pink' : 'text-brutalist-neonGreen'
           }`}
         >
           {error ? `[ERROR]: ${message}` : `[SUCCESS]: ${message}`}

--- a/components/PageTitle.tsx
+++ b/components/PageTitle.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export default function PageTitle({ children }: Props) {
   return (
-    <h1 className="text-3xl font-mono font-bold leading-9 tracking-tight text-white uppercase sm:text-4xl sm:leading-10 md:text-5xl md:leading-14 border-4 border-double border-white inline-block px-6 py-4">
+    <h1 className="text-3xl font-display font-bold leading-9 tracking-tight text-white uppercase sm:text-4xl sm:leading-10 md:text-5xl md:leading-14 border-4 border-double border-white inline-block px-6 py-4">
       [ {children} ]
     </h1>
   );

--- a/components/SeriesNavigation.tsx
+++ b/components/SeriesNavigation.tsx
@@ -25,7 +25,7 @@ export default function SeriesNavigation({
           </span>
           <div className="flex-1 h-px bg-brutalist-cyan" />
         </div>
-        <h3 className="font-mono font-bold text-xl text-white uppercase">
+        <h3 className="font-display font-bold text-xl text-white uppercase">
           <Link
             href={`/series/${series.slug}`}
             className="text-brutalist-cyan hover:text-brutalist-pink transition-colors"
@@ -39,7 +39,7 @@ export default function SeriesNavigation({
       </div>
 
       <div className="space-y-2">
-        <h4 className="font-mono text-xs uppercase text-brutalist-yellow tracking-wider">
+        <h4 className="font-display text-xs uppercase text-brutalist-yellow tracking-wider">
           All Parts ({allInSeries.length})
         </h4>
         <ol className="space-y-2">

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -42,6 +42,13 @@
   }
 }
 
+/* Proposal C: MDX/prose headings use the display face (Space Grotesk).
+   The @tailwindcss/typography plugin does not emit a per-heading
+   font-family, so headings would otherwise inherit the Inter body font. */
+.prose :where(h1, h2, h3, h4, h5, h6):not(:where([class~="not-prose"] *)) {
+  font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+}
+
 .remark-code-title {
   @apply px-5 py-3 font-mono text-sm font-bold text-white bg-black border-2 border-white border-b-0;
 }

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -29,7 +29,7 @@
   }
 
   body {
-    font-family: "Share Tech Mono", "Courier New", Courier, monospace;
+    font-family: Inter, system-ui, sans-serif;
     background-color: #000000;
     color: #ffffff;
   }
@@ -73,29 +73,29 @@ html {
 
 /* Diagram theming with CSS variables */
 :root {
-  --diagram-bg: theme('colors.black');
-  --diagram-bg-secondary: theme('colors.zinc.900');
-  --diagram-stroke: theme('colors.white');
-  --diagram-stroke-light: theme('colors.zinc.500');
-  --diagram-fill-primary: theme('colors.brutalist.cyan');
-  --diagram-fill-secondary: theme('colors.brutalist.pink');
-  --diagram-fill-tertiary: theme('colors.brutalist.yellow');
-  --diagram-fill-quaternary: theme('colors.white');
-  --diagram-text: theme('colors.white');
-  --diagram-text-light: theme('colors.zinc.400');
+  --diagram-bg: #000000;
+  --diagram-bg-secondary: #18181b;
+  --diagram-stroke: #ffffff;
+  --diagram-stroke-light: #71717a;
+  --diagram-fill-primary: #22d3ee;
+  --diagram-fill-secondary: #ec4899;
+  --diagram-fill-tertiary: #facc15;
+  --diagram-fill-quaternary: #ffffff;
+  --diagram-text: #ffffff;
+  --diagram-text-light: #a1a1aa;
 }
 
 .dark {
-  --diagram-bg: theme('colors.black');
-  --diagram-bg-secondary: theme('colors.zinc.900');
-  --diagram-stroke: theme('colors.white');
-  --diagram-stroke-light: theme('colors.zinc.500');
-  --diagram-fill-primary: theme('colors.brutalist.cyan');
-  --diagram-fill-secondary: theme('colors.brutalist.pink');
-  --diagram-fill-tertiary: theme('colors.brutalist.yellow');
-  --diagram-fill-quaternary: theme('colors.white');
-  --diagram-text: theme('colors.white');
-  --diagram-text-light: theme('colors.zinc.400');
+  --diagram-bg: #000000;
+  --diagram-bg-secondary: #18181b;
+  --diagram-stroke: #ffffff;
+  --diagram-stroke-light: #71717a;
+  --diagram-fill-primary: #22d3ee;
+  --diagram-fill-secondary: #ec4899;
+  --diagram-fill-tertiary: #facc15;
+  --diagram-fill-quaternary: #ffffff;
+  --diagram-text: #ffffff;
+  --diagram-text-light: #a1a1aa;
 }
 
 /* SVG diagrams using CSS variables */
@@ -129,7 +129,7 @@ html {
 /* Brutalist Utilities */
 @layer utilities {
   .brutalist-border {
-    border: 2px solid theme('colors.white');
+    border: 2px solid #ffffff;
     border-radius: 0px;
   }
 
@@ -165,21 +165,21 @@ html {
   .ascii-divider::after {
     content: "//========================================//";
     display: block;
-    font-family: "Share Tech Mono", "Courier New", Courier, monospace;
-    color: theme('colors.white');
+    font-family: "IBM Plex Mono", "Courier New", Courier, monospace;
+    color: #ffffff;
     text-align: center;
     margin: 1rem 0;
   }
 
   .terminal-prompt::before {
     content: "> ";
-    color: theme('colors.brutalist.cyan');
+    color: #22d3ee;
     font-weight: bold;
   }
 
   .file-extension::after {
     content: ".md";
-    color: theme('colors.brutalist.yellow');
+    color: #facc15;
     font-weight: normal;
   }
 }

--- a/layouts/AuthorLayout.tsx
+++ b/layouts/AuthorLayout.tsx
@@ -26,7 +26,7 @@ export default function AuthorLayout({ children, frontMatter }: Props) {
       <PageSEO title={`About - ${name}`} description={`About me - ${name}`} />
       <div className="divide-y divide-zinc-800 font-mono">
         <div className="pt-6 pb-8 space-y-2 md:space-y-5">
-          <h1 className="text-3xl font-pixel font-bold leading-9 tracking-widest text-white uppercase sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 drop-shadow-[0_0_8px_rgba(255,255,255,0.8)] pb-4 inline-block relative">
+          <h1 className="text-3xl font-display font-bold leading-9 tracking-widest text-white uppercase sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 drop-shadow-[0_0_8px_rgba(255,255,255,0.8)] pb-4 inline-block relative">
             [ ABOUT_ME ]
             <div className="absolute bottom-0 left-0 w-full h-[4px] bg-brutalist-pink shadow-glow-pink" />
           </h1>
@@ -43,7 +43,9 @@ export default function AuthorLayout({ children, frontMatter }: Props) {
             <h3 className="pt-4 pb-2 text-2xl font-bold leading-8 tracking-tight uppercase text-white mt-4">
               {name}
             </h3>
-            <div className="text-brutalist-cyberOrange mb-1">{'>'} {occupation}</div>
+            <div className="text-brutalist-cyberOrange mb-1">
+              {'>'} {occupation}
+            </div>
             <div className="text-zinc-400">{company}</div>
             <div className="flex pt-6 space-x-3">
               <SocialIcon kind="mail" href={`mailto:${email}`} />

--- a/layouts/ListLayout.tsx
+++ b/layouts/ListLayout.tsx
@@ -199,7 +199,7 @@ export default function ListLayout({
                 Part {frontMatter.series.order}
               </div>
             )}
-            <h3 className="text-2xl font-mono font-bold leading-8 tracking-tight uppercase">
+            <h3 className="text-2xl font-display font-bold leading-8 tracking-tight uppercase">
               <Link
                 href={`/blog/${slug}`}
                 className="text-white hover:text-brutalist-cyan transition-colors"
@@ -228,7 +228,7 @@ export default function ListLayout({
       <div className="max-w-3xl mx-auto px-4 sm:px-6 xl:max-w-5xl xl:px-0">
         <div className="pt-6 pb-8 space-y-8">
           <div className="text-center mb-10">
-            <h1 className="text-4xl font-pixel font-bold leading-9 tracking-widest text-white uppercase sm:text-5xl sm:leading-10 md:text-7xl md:leading-14 drop-shadow-[0_0_8px_rgba(255,255,255,0.8)] pb-4 inline-block relative">
+            <h1 className="text-4xl font-display font-bold leading-9 tracking-widest text-white uppercase sm:text-5xl sm:leading-10 md:text-7xl md:leading-14 drop-shadow-[0_0_8px_rgba(255,255,255,0.8)] pb-4 inline-block relative">
               [ {title} ]
               <div className="absolute bottom-0 left-0 w-full h-[4px] bg-brutalist-cyan shadow-glow-cyan" />
             </h1>
@@ -283,7 +283,9 @@ export default function ListLayout({
                 <article className="space-y-2 p-5">
                   <div className="font-mono text-sm leading-6 text-brutalist-cyberOrange flex items-center gap-2">
                     <div>
-                      <span className="text-brutalist-cyberOrange font-bold">&gt;</span>{' '}
+                      <span className="text-brutalist-cyberOrange font-bold">
+                        &gt;
+                      </span>{' '}
                       <time dateTime={seriesGroup.latestDate}>
                         {formatDate(seriesGroup.latestDate)}
                       </time>
@@ -323,7 +325,7 @@ export default function ListLayout({
                         )}
                       </button>
                     </div>
-                    <h3 className="text-2xl font-mono font-bold leading-8 tracking-tight uppercase">
+                    <h3 className="text-2xl font-display font-bold leading-8 tracking-tight uppercase">
                       {seriesGroup.slug ? (
                         <Link
                           href={`/series/${seriesGroup.slug}`}

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -149,9 +149,7 @@ export default function PostLayout({
                       )}
                       <dl className="text-sm font-mono font-bold leading-5 whitespace-nowrap px-2">
                         <dt className="sr-only">Name</dt>
-                        <dd className="text-white uppercase">
-                          {author.name}
-                        </dd>
+                        <dd className="text-white uppercase">{author.name}</dd>
                         <dt className="sr-only">Twitter</dt>
                         <dd>
                           {author.twitter && (
@@ -188,11 +186,20 @@ export default function PostLayout({
             )}
 
             <div className="pt-6 pb-6 font-mono text-sm text-zinc-400">
-              <Link href={discussUrl(slug)} rel="nofollow" className="hover:text-white transition-colors">
+              <Link
+                href={discussUrl(slug)}
+                rel="nofollow"
+                className="hover:text-white transition-colors"
+              >
                 {'Discuss on Twitter'}
               </Link>
               {` • `}
-              <Link href={editUrl(fileName)} className="hover:text-white transition-colors">{'View on GitHub'}</Link>
+              <Link
+                href={editUrl(fileName)}
+                className="hover:text-white transition-colors"
+              >
+                {'View on GitHub'}
+              </Link>
             </div>
 
             {siteMetadata.newsletter?.enabled && (
@@ -225,7 +232,9 @@ export default function PostLayout({
                         &lt; Previous Article
                       </h2>
                       <div className="text-brutalist-cyan hover:text-brutalist-pink font-bold transition-colors">
-                        <Link href={`/blog/${prev.slug}`}>[ {prev.title} ]</Link>
+                        <Link href={`/blog/${prev.slug}`}>
+                          [ {prev.title} ]
+                        </Link>
                       </div>
                     </div>
                   ) : (
@@ -237,7 +246,9 @@ export default function PostLayout({
                         Next Article &gt;
                       </h2>
                       <div className="text-brutalist-cyan hover:text-brutalist-pink font-bold transition-colors">
-                        <Link href={`/blog/${next.slug}`}>[ {next.title} ]</Link>
+                        <Link href={`/blog/${next.slug}`}>
+                          [ {next.title} ]
+                        </Link>
                       </div>
                     </div>
                   )}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@fontsource/ibm-plex-mono": "^5.2.7",
+    "@fontsource/inter": "^5.2.8",
     "@fontsource/share-tech-mono": "^5.2.7",
+    "@fontsource/space-grotesk": "^5.2.10",
     "@fontsource/vt323": "^5.2.7",
     "@rtkelly/mermaid-toolkit": "github:rtkelly13/mermaid-toolkit#a91c9d3",
     "@tailwindcss/forms": "^0.5.11",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,19 @@
 import '@fontsource/vt323';
-import '@fontsource/share-tech-mono';
+// Proposal C — Editorial Three-Role typography
+// Display: Space Grotesk · Body: Inter · Code/UI: IBM Plex Mono
+import '@fontsource/space-grotesk/400.css';
+import '@fontsource/space-grotesk/500.css';
+import '@fontsource/space-grotesk/600.css';
+import '@fontsource/space-grotesk/700.css';
+import '@fontsource/inter/400.css';
+import '@fontsource/inter/500.css';
+import '@fontsource/inter/600.css';
+import '@fontsource/inter/700.css';
+import '@fontsource/inter/800.css';
+import '@fontsource/ibm-plex-mono/400.css';
+import '@fontsource/ibm-plex-mono/500.css';
+import '@fontsource/ibm-plex-mono/600.css';
+import '@fontsource/ibm-plex-mono/700.css';
 import '@/css/tailwind.css';
 
 import type { AppProps } from 'next/app';

--- a/pages/design-sandbox/article-heroes.tsx
+++ b/pages/design-sandbox/article-heroes.tsx
@@ -8,7 +8,7 @@ const HeroMinimal = () => (
       <div className="inline-block bg-brutalist-cyan text-black font-bold px-2 py-1 mb-4 text-xs font-mono">
         STATUS: ONLINE
       </div>
-      <h1 className="text-4xl md:text-6xl font-bold font-mono mb-6 text-white uppercase">
+      <h1 className="text-4xl md:text-6xl font-bold font-display mb-6 text-white uppercase">
         RYAN_KELLY.DEV
       </h1>
       <p className="text-lg md:text-xl font-mono text-zinc-400">
@@ -33,7 +33,7 @@ const HeroGrid = () => (
         <div className="inline-block bg-brutalist-cyan text-black font-bold px-2 py-1 mb-4 text-xs font-mono">
           STATUS: ONLINE
         </div>
-        <h1 className="text-3xl md:text-5xl font-bold font-mono mb-6 leading-tight text-white">
+        <h1 className="text-3xl md:text-5xl font-bold font-display mb-6 leading-tight text-white">
           HELLO_WORLD.
           <br />I BUILD{' '}
           <span className="text-brutalist-pink bg-brutalist-pink/10 px-1">
@@ -89,7 +89,7 @@ export default function ArticleHeroes() {
           >
             {'<'} BACK_TO_SANDBOX
           </Link>
-          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-mono uppercase border-2 border-white inline-block px-4 py-2">
+          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-display uppercase border-2 border-white inline-block px-4 py-2">
             [ ARTICLE_HEROES ]
           </h1>
           <p className="text-lg leading-7 text-zinc-400 font-mono">
@@ -99,7 +99,7 @@ export default function ArticleHeroes() {
 
         <div className="py-12 space-y-16">
           <div>
-            <h2 className="font-mono font-bold text-2xl text-white mb-2 uppercase">
+            <h2 className="font-display font-bold text-2xl text-white mb-2 uppercase">
               01. MINIMAL_CENTERED
             </h2>
             <p className="text-zinc-400 font-mono text-sm mb-6">
@@ -111,7 +111,7 @@ export default function ArticleHeroes() {
           </div>
 
           <div>
-            <h2 className="font-mono font-bold text-2xl text-white mb-2 uppercase">
+            <h2 className="font-display font-bold text-2xl text-white mb-2 uppercase">
               02. GRID_BACKGROUND
             </h2>
             <p className="text-zinc-400 font-mono text-sm mb-6">
@@ -123,7 +123,7 @@ export default function ArticleHeroes() {
           </div>
 
           <div>
-            <h2 className="font-mono font-bold text-2xl text-white mb-2 uppercase">
+            <h2 className="font-display font-bold text-2xl text-white mb-2 uppercase">
               03. TERMINAL_INTERFACE
             </h2>
             <p className="text-zinc-400 font-mono text-sm mb-6">

--- a/pages/design-sandbox/buttons.tsx
+++ b/pages/design-sandbox/buttons.tsx
@@ -149,7 +149,7 @@ export default function Buttons() {
           >
             {'<'} BACK_TO_SANDBOX
           </Link>
-          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-mono uppercase border-2 border-white inline-block px-4 py-2">
+          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-display uppercase border-2 border-white inline-block px-4 py-2">
             [ BUTTON_VARIATIONS ]
           </h1>
           <p className="text-lg leading-7 text-zinc-400 font-mono">
@@ -165,7 +165,7 @@ export default function Buttons() {
                 className="bg-zinc-900 border-2 border-white p-6"
               >
                 <div className="flex items-center justify-between mb-4">
-                  <h3 className="font-mono font-bold text-lg text-white uppercase">
+                  <h3 className="font-display font-bold text-lg text-white uppercase">
                     {String(index + 1).padStart(2, '0')}. {variant.name}
                   </h3>
                   <button
@@ -190,7 +190,7 @@ export default function Buttons() {
           </div>
 
           <div className="mt-12 border-2 border-brutalist-yellow bg-zinc-900 p-6">
-            <h2 className="font-mono font-bold text-xl text-brutalist-yellow mb-4 uppercase">
+            <h2 className="font-display font-bold text-xl text-brutalist-yellow mb-4 uppercase">
               [ USAGE_NOTES ]
             </h2>
             <ul className="text-white font-mono text-sm space-y-2">

--- a/pages/design-sandbox/cards.tsx
+++ b/pages/design-sandbox/cards.tsx
@@ -108,7 +108,7 @@ export default function Cards() {
       />
       <div className="divide-y divide-white">
         <div className="pt-6 pb-8 space-y-2 md:space-y-5">
-          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-mono uppercase border-2 border-white inline-block px-4 py-2">
+          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-display uppercase border-2 border-white inline-block px-4 py-2">
             [ CARD_COMPONENTS ]
           </h1>
           <p className="text-lg leading-7 text-zinc-400 font-mono">
@@ -121,7 +121,7 @@ export default function Cards() {
             <div key={variation.id} className="space-y-4">
               {/* Variation Header */}
               <div className="border-l-4 border-brutalist-cyan pl-4">
-                <h2 className="text-2xl font-mono font-bold text-white uppercase">
+                <h2 className="text-2xl font-display font-bold text-white uppercase">
                   {String(variation.id).padStart(2, '0')}. {variation.name}
                 </h2>
               </div>
@@ -145,7 +145,7 @@ export default function Cards() {
 
           {/* Usage Notes */}
           <div className="border-2 border-brutalist-yellow bg-zinc-900 p-6 mt-12">
-            <h3 className="font-mono font-bold text-xl text-brutalist-yellow uppercase mb-4">
+            <h3 className="font-display font-bold text-xl text-brutalist-yellow uppercase mb-4">
               [ USAGE_NOTES ]
             </h3>
             <ul className="space-y-2 font-mono text-sm text-zinc-300">

--- a/pages/design-sandbox/diagrams.tsx
+++ b/pages/design-sandbox/diagrams.tsx
@@ -260,7 +260,7 @@ export default function DiagramsPage() {
               <ChevronLeft className="h-4 w-4" />
               Back to Sandbox
             </Link>
-            <h1 className="mt-4 font-mono text-4xl font-bold uppercase text-white">
+            <h1 className="mt-4 font-display text-4xl font-bold uppercase text-white">
               [DIAGRAMS]
             </h1>
             <p className="mt-2 font-mono text-zinc-400">
@@ -271,7 +271,7 @@ export default function DiagramsPage() {
 
         <div className="mx-auto max-w-7xl px-4 py-12">
           <div className="mb-8">
-            <h2 className="mb-4 font-mono text-xl font-bold uppercase text-brutalist-cyan">
+            <h2 className="mb-4 font-display text-xl font-bold uppercase text-brutalist-cyan">
               &gt; SELECT VARIANT
             </h2>
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
@@ -304,7 +304,7 @@ export default function DiagramsPage() {
           <div className="border-2 border-white bg-black p-8">
             <div className="mb-6 flex items-center justify-between">
               <div>
-                <h2 className="font-mono text-2xl font-bold uppercase text-white">
+                <h2 className="font-display text-2xl font-bold uppercase text-white">
                   {variants[activeVariant].name}
                 </h2>
                 <p className="mt-1 font-mono text-sm text-zinc-400">
@@ -329,7 +329,7 @@ export default function DiagramsPage() {
             </div>
 
             <div className="mt-8">
-              <h3 className="mb-3 font-mono text-sm font-bold uppercase text-brutalist-yellow">
+              <h3 className="mb-3 font-display text-sm font-bold uppercase text-brutalist-yellow">
                 $ CODE
               </h3>
               <pre className="overflow-x-auto border-2 border-zinc-800 bg-black p-4 font-mono text-xs text-brutalist-green">

--- a/pages/design-sandbox/homepage-heroes.tsx
+++ b/pages/design-sandbox/homepage-heroes.tsx
@@ -115,7 +115,7 @@ const Hero80sWaves = ({ textVariation = 0 }) => {
         className="absolute top-1/2 left-0 right-0 text-center z-10 -translate-y-1/2"
         style={{ textShadow: '0 0 20px #ff00ff, 0 0 40px #00ffff' }}
       >
-        <h1 className="text-3xl md:text-5xl font-bold font-mono text-transparent bg-clip-text bg-gradient-to-r from-[#00ffff] via-[#ff00ff] to-[#ffff00] mb-3">
+        <h1 className="text-3xl md:text-5xl font-bold font-display text-transparent bg-clip-text bg-gradient-to-r from-[#00ffff] via-[#ff00ff] to-[#ffff00] mb-3">
           {currentText.name}
         </h1>
         <p
@@ -186,7 +186,7 @@ const Hero80sCompact = ({ textVariation = 0 }) => {
         className="absolute top-1/2 left-0 right-0 text-center z-10 -translate-y-1/2"
         style={{ textShadow: '0 0 20px #ff00ff, 0 0 40px #00ffff' }}
       >
-        <h1 className="text-4xl md:text-6xl font-bold font-mono text-transparent bg-clip-text bg-gradient-to-r from-[#00ffff] via-[#ff00ff] to-[#ffff00] mb-3">
+        <h1 className="text-4xl md:text-6xl font-bold font-display text-transparent bg-clip-text bg-gradient-to-r from-[#00ffff] via-[#ff00ff] to-[#ffff00] mb-3">
           {currentText.name}
         </h1>
         <p
@@ -309,7 +309,7 @@ const Hero80sMinimal = ({ textVariation = 0 }) => {
         className="absolute top-1/2 left-0 right-0 text-center z-10 -translate-y-1/2"
         style={{ textShadow: '0 0 20px #00ffff' }}
       >
-        <h1 className="text-5xl md:text-7xl font-bold font-mono text-white mb-4 tracking-widest">
+        <h1 className="text-5xl md:text-7xl font-bold font-display text-white mb-4 tracking-widest">
           {currentText.name}
         </h1>
         <p className="text-xl md:text-2xl font-mono text-[#00ffff]">
@@ -358,7 +358,7 @@ export default function HomepageHeroes() {
           >
             {'<'} BACK_TO_SANDBOX
           </Link>
-          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-mono uppercase border-2 border-white inline-block px-4 py-2">
+          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-display uppercase border-2 border-white inline-block px-4 py-2">
             [ HOMEPAGE_HEROES ]
           </h1>
           <p className="text-lg leading-7 text-zinc-400 font-mono">
@@ -370,7 +370,7 @@ export default function HomepageHeroes() {
           <div>
             <div className="flex items-center justify-between mb-6">
               <div>
-                <h2 className="font-mono font-bold text-2xl text-white mb-2 uppercase">
+                <h2 className="font-display font-bold text-2xl text-white mb-2 uppercase">
                   01. 80S_RETRO_WAVES
                 </h2>
                 <p className="text-zinc-400 font-mono text-sm">
@@ -412,7 +412,7 @@ export default function HomepageHeroes() {
           <div>
             <div className="flex items-center justify-between mb-6">
               <div>
-                <h2 className="font-mono font-bold text-2xl text-white mb-2 uppercase">
+                <h2 className="font-display font-bold text-2xl text-white mb-2 uppercase">
                   02. 80S_COMPACT
                 </h2>
                 <p className="text-zinc-400 font-mono text-sm">
@@ -442,7 +442,7 @@ export default function HomepageHeroes() {
           <div>
             <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6 gap-4">
               <div>
-                <h2 className="font-mono font-bold text-2xl text-white mb-2 uppercase">
+                <h2 className="font-display font-bold text-2xl text-white mb-2 uppercase">
                   03. 80S_SUNSET (PRODUCTION)
                 </h2>
                 <p className="text-zinc-400 font-mono text-sm">
@@ -523,7 +523,7 @@ export default function HomepageHeroes() {
           <div>
             <div className="flex items-center justify-between mb-6">
               <div>
-                <h2 className="font-mono font-bold text-2xl text-white mb-2 uppercase">
+                <h2 className="font-display font-bold text-2xl text-white mb-2 uppercase">
                   04. 80S_MINIMAL
                 </h2>
                 <p className="text-zinc-400 font-mono text-sm">

--- a/pages/design-sandbox/index.tsx
+++ b/pages/design-sandbox/index.tsx
@@ -40,6 +40,12 @@ const components = [
     icon: '📝',
   },
   {
+    name: 'Typography Proposals',
+    path: '/design-sandbox/typography-proposals',
+    description: 'Font pairing + weight proposals to evaluate',
+    icon: '🔤',
+  },
+  {
     name: 'Logos',
     path: '/design-sandbox/logos',
     description: 'ASCII art logo variations',

--- a/pages/design-sandbox/index.tsx
+++ b/pages/design-sandbox/index.tsx
@@ -68,7 +68,7 @@ export default function DesignSandbox() {
       />
       <div className="divide-y divide-white">
         <div className="pt-6 pb-8 space-y-2 md:space-y-5">
-          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-mono uppercase border-2 border-white inline-block px-4 py-2">
+          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-display uppercase border-2 border-white inline-block px-4 py-2">
             [ DESIGN_SANDBOX ]
           </h1>
           <p className="text-lg leading-7 text-zinc-400 font-mono">
@@ -82,7 +82,7 @@ export default function DesignSandbox() {
               <Link key={component.path} href={component.path}>
                 <div className="bg-zinc-900 border-2 border-white p-6 hover:border-brutalist-cyan transition-all shadow-[8px_8px_0px_0px_rgba(255,255,255,1)] hover:shadow-[12px_12px_0px_0px_rgba(34,211,238,1)] active:translate-x-1 active:translate-y-1 h-full cursor-pointer group">
                   <div className="text-4xl mb-4">{component.icon}</div>
-                  <h3 className="font-mono font-bold text-xl text-white mb-2 uppercase group-hover:text-brutalist-cyan transition-colors">
+                  <h3 className="font-display font-bold text-xl text-white mb-2 uppercase group-hover:text-brutalist-cyan transition-colors">
                     {component.name}
                   </h3>
                   <p className="text-zinc-400 font-mono text-sm">
@@ -94,7 +94,7 @@ export default function DesignSandbox() {
           </div>
 
           <div className="mt-12 border-2 border-brutalist-yellow bg-zinc-900 p-6">
-            <h2 className="font-mono font-bold text-xl text-brutalist-yellow mb-4 uppercase">
+            <h2 className="font-display font-bold text-xl text-brutalist-yellow mb-4 uppercase">
               [ SANDBOX_INFO ]
             </h2>
             <p className="text-white font-mono text-sm leading-relaxed mb-4">

--- a/pages/design-sandbox/logos.tsx
+++ b/pages/design-sandbox/logos.tsx
@@ -124,7 +124,7 @@ export default function Logos() {
       />
       <div className="divide-y divide-white">
         <div className="pt-6 pb-8 space-y-2 md:space-y-5">
-          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-mono uppercase border-2 border-white inline-block px-4 py-2">
+          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-display uppercase border-2 border-white inline-block px-4 py-2">
             [ LOGO_VARIATIONS ]
           </h1>
           <p className="text-lg leading-7 text-zinc-400 font-mono">
@@ -139,7 +139,7 @@ export default function Logos() {
                 className="bg-zinc-900 border-2 border-white p-6 hover:border-brutalist-cyan transition-all shadow-[8px_8px_0px_0px_rgba(255,255,255,1)] hover:shadow-[12px_12px_0px_0px_rgba(34,211,238,1)] active:translate-x-1 active:translate-y-1"
               >
                 <div className="border-b-2 border-dashed border-white/20 pb-2 mb-4">
-                  <h3 className="font-mono font-bold text-lg text-white">
+                  <h3 className="font-display font-bold text-lg text-white">
                     {`0${logo.id}`.slice(-2)}. {logo.name.toUpperCase()}
                   </h3>
                 </div>

--- a/pages/design-sandbox/navigation.tsx
+++ b/pages/design-sandbox/navigation.tsx
@@ -83,7 +83,7 @@ const DemoContainer = ({
     <div className="bg-zinc-900 border-2 border-white p-6 flex flex-col h-full">
       <div className="flex items-start justify-between mb-4">
         <div>
-          <h3 className="font-mono font-bold text-lg text-white uppercase">
+          <h3 className="font-display font-bold text-lg text-white uppercase">
             {title}
           </h3>
           <p className="text-zinc-400 text-sm font-mono mt-1">{description}</p>
@@ -264,7 +264,7 @@ export default function NavigationSandbox() {
           >
             {'<'} BACK_TO_SANDBOX
           </Link>
-          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-mono uppercase border-2 border-white inline-block px-4 py-2">
+          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-display uppercase border-2 border-white inline-block px-4 py-2">
             [ NAVIGATION_FAB ]
           </h1>
           <p className="text-lg leading-7 text-zinc-400 font-mono">
@@ -347,7 +347,7 @@ export default function NavigationSandbox() {
           </div>
 
           <div className="mt-12 border-2 border-brutalist-yellow bg-zinc-900 p-6">
-            <h2 className="font-mono font-bold text-xl text-brutalist-yellow mb-4 uppercase">
+            <h2 className="font-display font-bold text-xl text-brutalist-yellow mb-4 uppercase">
               [ DESIGN_NOTES ]
             </h2>
             <ul className="text-white font-mono text-sm space-y-2">

--- a/pages/design-sandbox/typography-proposals.tsx
+++ b/pages/design-sandbox/typography-proposals.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from '@/components/Link';
 import { PageSEO } from '@/components/SEO';
 import siteMetadata from '@/data/siteMetadata';
@@ -16,10 +16,11 @@ import siteMetadata from '@/data/siteMetadata';
  *   2. `sans` and `mono` both resolve to Share Tech Mono, so there is no
  *      typeface pairing and no display/body contrast anywhere.
  *
- * Each proposal below pairs a display face with a body/code face and uses
- * a typeface that has a REAL weight axis, so the hierarchy is genuine.
- * Fonts are loaded from Google Fonts on this page only (no global change)
- * so you can compare before committing anything to the design tokens.
+ * Every section below is rendered in the actual fonts it proposes. The
+ * webfonts are LAZY-LOADED per section (IntersectionObserver + the CSS
+ * Font Loading API) so a proposal's fonts only hit the network when you
+ * scroll its section into view — nothing is loaded up front, and no
+ * global design tokens are changed.
  */
 
 type Role = {
@@ -47,6 +48,9 @@ type System = {
   cons: string[];
   tokens: string; // tailwind.config fontFamily snippet
   install: string;
+  // lazy loading: stylesheet href + the font faces to await (null = global)
+  fontHref: string | null;
+  fontFaces: string[];
 };
 
 const JETBRAINS = '"JetBrains Mono", "Courier New", monospace';
@@ -54,6 +58,11 @@ const SPACE_GROTESK = '"Space Grotesk", system-ui, sans-serif';
 const INTER = 'Inter, system-ui, sans-serif';
 const PLEX_MONO = '"IBM Plex Mono", "Courier New", monospace';
 const SHARE_TECH = '"Share Tech Mono", "Courier New", monospace';
+
+const GF = 'https://fonts.googleapis.com/css2';
+const HREF_A = `${GF}?family=JetBrains+Mono:wght@400;500;700;800&display=swap`;
+const HREF_B = `${GF}?family=JetBrains+Mono:wght@400;500;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap`;
+const HREF_C = `${GF}?family=IBM+Plex+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap`;
 
 const CURRENT: System = {
   id: 'current',
@@ -90,6 +99,8 @@ const CURRENT: System = {
 sans: ['"Share Tech Mono"', ...],
 mono: ['"Share Tech Mono"', 'Courier New', ...],`,
   install: 'already installed (@fontsource/share-tech-mono)',
+  fontHref: null, // loaded globally, nothing to lazy-load
+  fontFaces: [],
 };
 
 const PROPOSALS: System[] = [
@@ -138,6 +149,8 @@ const PROPOSALS: System[] = [
 mono: ['"JetBrains Mono"', 'Courier New', ...defaultTheme.fontFamily.mono],
 // display weight 800 available via font-extrabold`,
     install: 'pnpm add @fontsource/jetbrains-mono',
+    fontHref: HREF_A,
+    fontFaces: ["400 1em 'JetBrains Mono'", "800 1em 'JetBrains Mono'"],
   },
   {
     id: 'b',
@@ -184,6 +197,8 @@ mono: ['"JetBrains Mono"', 'Courier New', ...defaultTheme.fontFamily.mono],
 mono: ['"JetBrains Mono"', 'Courier New', ...defaultTheme.fontFamily.mono], // body/code
 // headings switch from font-mono -> font-sans`,
     install: 'pnpm add @fontsource/space-grotesk @fontsource/jetbrains-mono',
+    fontHref: HREF_B,
+    fontFaces: ["700 1em 'Space Grotesk'", "400 1em 'JetBrains Mono'"],
   },
   {
     id: 'c',
@@ -232,8 +247,88 @@ serif: ['Inter', ...],          // (used for body via prose)
 mono: ['"IBM Plex Mono"', ...], // code + metadata only`,
     install:
       'pnpm add @fontsource/space-grotesk @fontsource/inter @fontsource/ibm-plex-mono',
+    fontHref: HREF_C,
+    fontFaces: [
+      "700 1em 'Space Grotesk'",
+      "400 1em 'Inter'",
+      "500 1em 'IBM Plex Mono'",
+    ],
   },
 ];
+
+// Inject a Google Fonts stylesheet at most once per href.
+const injectedHrefs = new Set<string>();
+function injectFontStylesheet(href: string) {
+  if (typeof document === 'undefined' || injectedHrefs.has(href)) return;
+  injectedHrefs.add(href);
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = href;
+  document.head.appendChild(link);
+}
+
+type LoadStatus = 'idle' | 'loading' | 'ready';
+
+/**
+ * Lazy-loads a proposal's webfonts the first time its section scrolls near
+ * the viewport, then resolves once the actual font faces are ready.
+ */
+function useLazyFonts(href: string | null, faces: string[]) {
+  const ref = useRef<HTMLElement>(null);
+  const [status, setStatus] = useState<LoadStatus>(href ? 'idle' : 'ready');
+
+  useEffect(() => {
+    if (!href) return; // global font (current) — nothing to lazy-load
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((e) => e.isIntersecting)) return;
+        observer.disconnect();
+        setStatus('loading');
+        injectFontStylesheet(href);
+
+        const fonts = document.fonts;
+        if (fonts?.load) {
+          Promise.all(faces.map((f) => fonts.load(f)))
+            .then(() => setStatus('ready'))
+            .catch(() => setStatus('ready'));
+        } else {
+          setStatus('ready');
+        }
+      },
+      { rootMargin: '300px' },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [href, faces]);
+
+  return { ref, status };
+}
+
+const StatusPill = ({ status }: { status: LoadStatus }) => {
+  const map: Record<LoadStatus, { label: string; cls: string }> = {
+    idle: { label: 'FONTS ▸ NOT LOADED', cls: 'border-zinc-600 text-zinc-500' },
+    loading: {
+      label: 'FONTS ▸ LOADING…',
+      cls: 'border-brutalist-yellow text-brutalist-yellow animate-pulse',
+    },
+    ready: {
+      label: 'FONTS ▸ READY',
+      cls: 'border-brutalist-neonGreen text-brutalist-neonGreen',
+    },
+  };
+  const { label, cls } = map[status];
+  return (
+    <span
+      className={`font-mono text-[10px] font-bold px-2 py-1 border-2 uppercase ${cls}`}
+    >
+      {label}
+    </span>
+  );
+};
 
 const Specimen = ({ s }: { s: System }) => (
   <div className="bg-black border-2 border-white p-6 space-y-6">
@@ -243,17 +338,17 @@ const Specimen = ({ s }: { s: System }) => (
     </p>
 
     {/* display */}
-    <h1
+    <h2
       className="text-4xl md:text-5xl text-white leading-none"
       style={s.display}
     >
       Rebuilding the type system
-    </h1>
+    </h2>
 
     {/* heading */}
-    <h2 className="text-2xl text-white" style={s.heading}>
+    <h3 className="text-2xl text-white" style={s.heading}>
       {'>'} Why weight matters
-    </h2>
+    </h3>
 
     {/* body */}
     <p className="text-base text-zinc-200 leading-relaxed" style={s.body}>
@@ -270,9 +365,9 @@ const Specimen = ({ s }: { s: System }) => (
     </p>
 
     {/* subheading */}
-    <h3 className="text-lg text-white" style={s.subheading}>
+    <h4 className="text-lg text-white" style={s.subheading}>
       {'// secondary heading'}
-    </h3>
+    </h4>
 
     <p className="text-sm text-zinc-400 leading-relaxed" style={s.body}>
       Secondary copy sits a step down in weight and colour. Good systems give
@@ -327,10 +422,95 @@ const Specimen = ({ s }: { s: System }) => (
   </div>
 );
 
-export default function TypographyProposals() {
-  const [selected, setSelected] = useState<System>(PROPOSALS[1]); // default: B
-  const [compare, setCompare] = useState(true);
+const SystemSection = ({ s }: { s: System }) => {
+  const { ref, status } = useLazyFonts(s.fontHref, s.fontFaces);
 
+  return (
+    <section
+      id={s.id}
+      ref={ref}
+      className="container py-12 scroll-mt-24 space-y-6"
+    >
+      {/* section header */}
+      <div className="flex flex-wrap items-center gap-3">
+        <h2 className={`font-mono font-bold text-2xl uppercase ${s.accent}`}>
+          {s.name}
+        </h2>
+        <span
+          className={`font-mono text-xs font-bold px-2 py-1 border-2 uppercase border-current ${s.accent}`}
+        >
+          {s.badge}
+        </span>
+        <span className="ml-auto">
+          <StatusPill status={status} />
+        </span>
+      </div>
+      <p className="font-mono text-sm text-zinc-400">{s.tagline}</p>
+
+      {/* pros / cons */}
+      <div className="grid md:grid-cols-2 gap-4">
+        <div>
+          <p className="font-mono text-xs text-brutalist-cyan uppercase mb-1">
+            + Strengths
+          </p>
+          <ul className="space-y-1 font-mono text-xs text-zinc-300">
+            {s.pros.map((x) => (
+              <li key={x}>
+                <span className="text-brutalist-cyan mr-1">{'>'}</span>
+                {x}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <p className="font-mono text-xs text-brutalist-pink uppercase mb-1">
+            - Trade-offs
+          </p>
+          <ul className="space-y-1 font-mono text-xs text-zinc-300">
+            {s.cons.map((x) => (
+              <li key={x}>
+                <span className="text-brutalist-pink mr-1">!</span>
+                {x}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      {/* live specimen, rendered in this proposal's fonts */}
+      <Specimen s={s} />
+
+      {/* adoption (skip for current) */}
+      {s.fontHref && (
+        <div className="border-2 border-brutalist-cyan bg-zinc-900 p-6 space-y-4">
+          <h3 className="font-mono font-bold text-lg text-brutalist-cyan uppercase">
+            [ HOW_TO_ADOPT ]
+          </h3>
+          <div>
+            <p className="font-mono text-xs text-zinc-500 uppercase mb-1">
+              1. install
+            </p>
+            <pre className="bg-black border-2 border-white p-3 text-xs font-mono text-brutalist-neonGreen overflow-x-auto">
+              {s.install}
+            </pre>
+          </div>
+          <div>
+            <p className="font-mono text-xs text-zinc-500 uppercase mb-1">
+              2. tailwind.config.js → fontFamily
+            </p>
+            <pre className="bg-black border-2 border-white p-3 text-xs font-mono text-brutalist-cyan overflow-x-auto">
+              {s.tokens}
+            </pre>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};
+
+const ALL: System[] = [CURRENT, ...PROPOSALS];
+
+export default function TypographyProposals() {
   return (
     <>
       <PageSEO
@@ -338,15 +518,12 @@ export default function TypographyProposals() {
         description="Evaluate font-pairing and weight-system proposals for the blog"
       />
       <Head>
+        {/* Only preconnect up front — actual stylesheets are injected lazily. */}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"
           href="https://fonts.gstatic.com"
           crossOrigin="anonymous"
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap"
-          rel="stylesheet"
         />
       </Head>
 
@@ -362,8 +539,8 @@ export default function TypographyProposals() {
             [ TYPOGRAPHY_PROPOSALS ]
           </h1>
           <p className="text-lg leading-7 text-zinc-400 font-mono">
-            {'>'} Pick a direction for font pairing + weight. Rendered live, no
-            tokens changed yet.
+            {'>'} Every section is rendered in its own fonts. Fonts lazy-load as
+            you scroll — no tokens changed yet.
           </p>
         </div>
 
@@ -400,130 +577,26 @@ export default function TypographyProposals() {
           </div>
         </div>
 
-        {/* controls */}
-        <div className="container py-8 space-y-6">
-          <div className="flex flex-wrap items-center gap-3">
-            {PROPOSALS.map((p) => {
-              const active = selected.id === p.id;
-              return (
-                <button
-                  key={p.id}
-                  type="button"
-                  onClick={() => setSelected(p)}
-                  className={`font-mono text-sm font-bold px-4 py-2 border-2 uppercase transition-colors ${
-                    active
-                      ? 'bg-white text-black border-white'
-                      : 'bg-black text-white border-white hover:border-brutalist-cyan hover:text-brutalist-cyan'
-                  }`}
-                >
-                  {p.name}
-                </button>
-              );
-            })}
-            <label className="ml-auto flex items-center gap-2 font-mono text-xs text-zinc-400 uppercase cursor-pointer select-none">
-              <input
-                type="checkbox"
-                checked={compare}
-                onChange={(e) => setCompare(e.target.checked)}
-                className="accent-brutalist-cyan"
-              />
-              Compare vs. current
-            </label>
-          </div>
-
-          {/* proposal summary */}
-          <div className="border-2 border-white bg-zinc-900 p-6">
-            <div className="flex flex-wrap items-center gap-3 mb-3">
-              <h3
-                className={`font-mono font-bold text-2xl uppercase ${selected.accent}`}
+        {/* jump nav */}
+        <div className="container py-4">
+          <div className="flex flex-wrap items-center gap-3 font-mono text-xs uppercase">
+            <span className="text-zinc-500">jump:</span>
+            {ALL.map((s) => (
+              <Link
+                key={s.id}
+                href={`#${s.id}`}
+                className={`border-2 border-current px-2 py-1 hover:bg-white hover:text-black transition-colors ${s.accent}`}
               >
-                {selected.name}
-              </h3>
-              <span
-                className={`font-mono text-xs font-bold px-2 py-1 border-2 uppercase ${selected.accent} border-current`}
-              >
-                {selected.badge}
-              </span>
-            </div>
-            <p className="font-mono text-sm text-zinc-400 mb-4">
-              {selected.tagline}
-            </p>
-            <div className="grid md:grid-cols-2 gap-4">
-              <div>
-                <p className="font-mono text-xs text-brutalist-cyan uppercase mb-1">
-                  + Strengths
-                </p>
-                <ul className="space-y-1 font-mono text-xs text-zinc-300">
-                  {selected.pros.map((x) => (
-                    <li key={x}>
-                      <span className="text-brutalist-cyan mr-1">{'>'}</span>
-                      {x}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-              <div>
-                <p className="font-mono text-xs text-brutalist-pink uppercase mb-1">
-                  - Trade-offs
-                </p>
-                <ul className="space-y-1 font-mono text-xs text-zinc-300">
-                  {selected.cons.map((x) => (
-                    <li key={x}>
-                      <span className="text-brutalist-pink mr-1">!</span>
-                      {x}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          {/* specimens */}
-          <div className={`grid gap-6 ${compare ? 'lg:grid-cols-2' : ''}`}>
-            {compare && (
-              <div className="space-y-2">
-                <p className="font-mono text-xs text-zinc-500 uppercase">
-                  ▾ current (share tech mono)
-                </p>
-                <Specimen s={CURRENT} />
-              </div>
-            )}
-            <div className="space-y-2">
-              <p className={`font-mono text-xs uppercase ${selected.accent}`}>
-                ▾ {selected.name}
-              </p>
-              <Specimen s={selected} />
-            </div>
-          </div>
-
-          {/* adoption */}
-          <div className="border-2 border-brutalist-cyan bg-zinc-900 p-6 space-y-4">
-            <h3 className="font-mono font-bold text-xl text-brutalist-cyan uppercase">
-              [ HOW_TO_ADOPT — {selected.name} ]
-            </h3>
-            <div>
-              <p className="font-mono text-xs text-zinc-500 uppercase mb-1">
-                1. install
-              </p>
-              <pre className="bg-black border-2 border-white p-3 text-xs font-mono text-brutalist-neonGreen overflow-x-auto">
-                {selected.install}
-              </pre>
-            </div>
-            <div>
-              <p className="font-mono text-xs text-zinc-500 uppercase mb-1">
-                2. tailwind.config.js → fontFamily
-              </p>
-              <pre className="bg-black border-2 border-white p-3 text-xs font-mono text-brutalist-cyan overflow-x-auto">
-                {selected.tokens}
-              </pre>
-            </div>
-            <p className="font-mono text-xs text-zinc-400">
-              {'>'} Then import the @fontsource packages in{' '}
-              <code className="text-brutalist-neonGreen">pages/_app.tsx</code>{' '}
-              (same place Share Tech Mono / VT323 are imported today).
-            </p>
+                {s.id === 'current' ? 'current' : s.id.toUpperCase()}
+              </Link>
+            ))}
           </div>
         </div>
+
+        {/* one section per system, each lazy-loading its own fonts */}
+        {ALL.map((s) => (
+          <SystemSection key={s.id} s={s} />
+        ))}
       </div>
     </>
   );

--- a/pages/design-sandbox/typography-proposals.tsx
+++ b/pages/design-sandbox/typography-proposals.tsx
@@ -1,0 +1,530 @@
+import Head from 'next/head';
+import { useState } from 'react';
+import Link from '@/components/Link';
+import { PageSEO } from '@/components/SEO';
+import siteMetadata from '@/data/siteMetadata';
+
+/**
+ * TYPOGRAPHY PROPOSALS
+ * --------------------
+ * An evaluation surface for fixing two concrete problems with the current
+ * (hacker-theme) type system:
+ *
+ *   1. Share Tech Mono ships a SINGLE weight (400). Every `font-bold`
+ *      heading on the site is therefore *synthetic* (faux) bold — the
+ *      smeared, low-contrast heaviness you see on headings.
+ *   2. `sans` and `mono` both resolve to Share Tech Mono, so there is no
+ *      typeface pairing and no display/body contrast anywhere.
+ *
+ * Each proposal below pairs a display face with a body/code face and uses
+ * a typeface that has a REAL weight axis, so the hierarchy is genuine.
+ * Fonts are loaded from Google Fonts on this page only (no global change)
+ * so you can compare before committing anything to the design tokens.
+ */
+
+type Role = {
+  fontFamily: string;
+  fontWeight: number;
+  letterSpacing?: string;
+  textTransform?: 'uppercase' | 'none';
+};
+
+type System = {
+  id: string;
+  name: string;
+  tagline: string;
+  badge: string;
+  accent: string; // tailwind text color class for the accent
+  // role -> css
+  display: Role;
+  heading: Role;
+  subheading: Role;
+  body: Role;
+  code: Role;
+  meta: Role;
+  weightLadder: { family: string; weights: number[] };
+  pros: string[];
+  cons: string[];
+  tokens: string; // tailwind.config fontFamily snippet
+  install: string;
+};
+
+const JETBRAINS = '"JetBrains Mono", "Courier New", monospace';
+const SPACE_GROTESK = '"Space Grotesk", system-ui, sans-serif';
+const INTER = 'Inter, system-ui, sans-serif';
+const PLEX_MONO = '"IBM Plex Mono", "Courier New", monospace';
+const SHARE_TECH = '"Share Tech Mono", "Courier New", monospace';
+
+const CURRENT: System = {
+  id: 'current',
+  name: 'CURRENT — Share Tech Mono',
+  tagline: 'What ships today on the hacker-theme branch',
+  badge: 'LIVE',
+  accent: 'text-zinc-400',
+  display: {
+    fontFamily: SHARE_TECH,
+    fontWeight: 700,
+    textTransform: 'uppercase',
+  },
+  heading: {
+    fontFamily: SHARE_TECH,
+    fontWeight: 700,
+    textTransform: 'uppercase',
+  },
+  subheading: {
+    fontFamily: SHARE_TECH,
+    fontWeight: 700,
+    textTransform: 'uppercase',
+  },
+  body: { fontFamily: SHARE_TECH, fontWeight: 400 },
+  code: { fontFamily: SHARE_TECH, fontWeight: 400 },
+  meta: { fontFamily: SHARE_TECH, fontWeight: 400, textTransform: 'uppercase' },
+  weightLadder: { family: SHARE_TECH, weights: [400, 700] },
+  pros: ['Strong terminal identity', 'Already wired up'],
+  cons: [
+    'Only one real weight (400) — every bold heading is FAUX bold',
+    'sans === mono: zero typeface pairing or contrast',
+    'No mid-weights for UI / emphasis hierarchy',
+  ],
+  tokens: `// today
+sans: ['"Share Tech Mono"', ...],
+mono: ['"Share Tech Mono"', 'Courier New', ...],`,
+  install: 'already installed (@fontsource/share-tech-mono)',
+};
+
+const PROPOSALS: System[] = [
+  {
+    id: 'a',
+    name: 'A · Refined Terminal',
+    tagline: 'Stay all-mono, but on a face with a real weight axis',
+    badge: 'LOWEST RISK',
+    accent: 'text-brutalist-cyan',
+    display: {
+      fontFamily: JETBRAINS,
+      fontWeight: 800,
+      letterSpacing: '-0.02em',
+      textTransform: 'uppercase',
+    },
+    heading: {
+      fontFamily: JETBRAINS,
+      fontWeight: 700,
+      textTransform: 'uppercase',
+    },
+    subheading: {
+      fontFamily: JETBRAINS,
+      fontWeight: 600,
+      textTransform: 'uppercase',
+    },
+    body: { fontFamily: JETBRAINS, fontWeight: 400 },
+    code: { fontFamily: JETBRAINS, fontWeight: 500 },
+    meta: {
+      fontFamily: JETBRAINS,
+      fontWeight: 500,
+      letterSpacing: '0.05em',
+      textTransform: 'uppercase',
+    },
+    weightLadder: { family: JETBRAINS, weights: [400, 500, 700, 800] },
+    pros: [
+      'Keeps the terminal/brutalist identity intact',
+      'JetBrains Mono ships 100–800 — bold is REAL, not synthetic',
+      'Drop-in: only the font tokens change, every existing class still works',
+      '800 display weight gives headings genuine punch',
+    ],
+    cons: [
+      'Still a single-voice system — limited display/body contrast',
+      'Long-form body text remains monospace (lower reading density)',
+    ],
+    tokens: `sans: ['"JetBrains Mono"', ...defaultTheme.fontFamily.mono],
+mono: ['"JetBrains Mono"', 'Courier New', ...defaultTheme.fontFamily.mono],
+// display weight 800 available via font-extrabold`,
+    install: 'pnpm add @fontsource/jetbrains-mono',
+  },
+  {
+    id: 'b',
+    name: 'B · Grotesk × Mono',
+    tagline: 'Geometric display face paired with a mono body — true contrast',
+    badge: 'RECOMMENDED',
+    accent: 'text-brutalist-pink',
+    display: {
+      fontFamily: SPACE_GROTESK,
+      fontWeight: 700,
+      letterSpacing: '-0.03em',
+      textTransform: 'uppercase',
+    },
+    heading: {
+      fontFamily: SPACE_GROTESK,
+      fontWeight: 700,
+      textTransform: 'uppercase',
+    },
+    subheading: {
+      fontFamily: SPACE_GROTESK,
+      fontWeight: 600,
+      textTransform: 'uppercase',
+    },
+    body: { fontFamily: JETBRAINS, fontWeight: 400 },
+    code: { fontFamily: JETBRAINS, fontWeight: 500 },
+    meta: {
+      fontFamily: JETBRAINS,
+      fontWeight: 500,
+      letterSpacing: '0.05em',
+      textTransform: 'uppercase',
+    },
+    weightLadder: { family: SPACE_GROTESK, weights: [400, 500, 600, 700] },
+    pros: [
+      'Real pairing: heavy geometric headlines vs. mono body texture',
+      'Both faces have full weight axes — genuine hierarchy',
+      'Space Grotesk reads as "techy" — keeps cyberpunk spirit',
+      'Mono stays where it earns its keep: body, code, metadata',
+    ],
+    cons: [
+      'Two font families to load & maintain',
+      'Headings lose the pure-terminal look (a feature for some, not all)',
+    ],
+    tokens: `sans: ['"Space Grotesk"', ...defaultTheme.fontFamily.sans], // display/headings
+mono: ['"JetBrains Mono"', 'Courier New', ...defaultTheme.fontFamily.mono], // body/code
+// headings switch from font-mono -> font-sans`,
+    install: 'pnpm add @fontsource/space-grotesk @fontsource/jetbrains-mono',
+  },
+  {
+    id: 'c',
+    name: 'C · Editorial Three-Role',
+    tagline: 'Display + readable sans body + mono for code only',
+    badge: 'MOST READABLE',
+    accent: 'text-brutalist-yellow',
+    display: {
+      fontFamily: SPACE_GROTESK,
+      fontWeight: 700,
+      letterSpacing: '-0.03em',
+      textTransform: 'uppercase',
+    },
+    heading: {
+      fontFamily: SPACE_GROTESK,
+      fontWeight: 700,
+      textTransform: 'uppercase',
+    },
+    subheading: {
+      fontFamily: SPACE_GROTESK,
+      fontWeight: 600,
+      textTransform: 'none',
+    },
+    body: { fontFamily: INTER, fontWeight: 400 },
+    code: { fontFamily: PLEX_MONO, fontWeight: 500 },
+    meta: {
+      fontFamily: PLEX_MONO,
+      fontWeight: 500,
+      letterSpacing: '0.05em',
+      textTransform: 'uppercase',
+    },
+    weightLadder: { family: INTER, weights: [400, 500, 600, 700, 800] },
+    pros: [
+      'Best long-form reading by far (Inter body)',
+      'Three clear roles: display / reading / code',
+      'Full weight scale for nuanced UI hierarchy (400→800)',
+      'Mono confined to code & terminal accents — used intentionally',
+    ],
+    cons: [
+      'Furthest from the current all-mono aesthetic',
+      'Three families to load; biggest visual departure',
+      'Risks softening the brutalist edge if borders/colors not kept loud',
+    ],
+    tokens: `sans: ['"Space Grotesk"', ...],  // headings/display
+serif: ['Inter', ...],          // (used for body via prose)
+mono: ['"IBM Plex Mono"', ...], // code + metadata only`,
+    install:
+      'pnpm add @fontsource/space-grotesk @fontsource/inter @fontsource/ibm-plex-mono',
+  },
+];
+
+const Specimen = ({ s }: { s: System }) => (
+  <div className="bg-black border-2 border-white p-6 space-y-6">
+    {/* meta / eyebrow */}
+    <p className="text-xs text-brutalist-cyan" style={s.meta}>
+      [ 2026-06-28 ] · 7 MIN READ · #typography #design-systems
+    </p>
+
+    {/* display */}
+    <h1
+      className="text-4xl md:text-5xl text-white leading-none"
+      style={s.display}
+    >
+      Rebuilding the type system
+    </h1>
+
+    {/* heading */}
+    <h2 className="text-2xl text-white" style={s.heading}>
+      {'>'} Why weight matters
+    </h2>
+
+    {/* body */}
+    <p className="text-base text-zinc-200 leading-relaxed" style={s.body}>
+      A typeface with a real weight axis lets headings carry genuine emphasis
+      instead of the browser faking it. The quick brown fox jumps over the lazy
+      dog — 0123456789 — and the difference between{' '}
+      <code
+        className="text-brutalist-neonGreen border border-white px-1"
+        style={s.code}
+      >
+        font-bold
+      </code>{' '}
+      that is drawn vs. synthesised is immediately visible at this size.
+    </p>
+
+    {/* subheading */}
+    <h3 className="text-lg text-white" style={s.subheading}>
+      {'// secondary heading'}
+    </h3>
+
+    <p className="text-sm text-zinc-400 leading-relaxed" style={s.body}>
+      Secondary copy sits a step down in weight and colour. Good systems give
+      you at least three usable steps so hierarchy never depends on size alone.
+    </p>
+
+    {/* code block */}
+    <pre
+      className="bg-zinc-900 border-2 border-white p-4 text-sm text-brutalist-neonGreen overflow-x-auto"
+      style={s.code}
+    >{`function greet(name: string) {
+  console.log(\`> hello, \${name}\`);
+}`}</pre>
+
+    {/* link + tags */}
+    <div className="flex flex-wrap items-center gap-3">
+      <span
+        className="bg-brutalist-cyan text-black text-xs font-bold px-3 py-1 border-2 border-white uppercase"
+        style={s.meta}
+      >
+        FEATURED
+      </span>
+      <span
+        className="bg-brutalist-pink text-black text-xs font-bold px-3 py-1 border-2 border-white uppercase"
+        style={s.meta}
+      >
+        NEW
+      </span>
+      <span className="text-brutalist-cyan underline" style={s.body}>
+        {'>'} read more →
+      </span>
+    </div>
+
+    {/* weight ladder */}
+    <div className="pt-2 border-t-2 border-white/20">
+      <p className="text-xs text-zinc-500 mb-2" style={s.meta}>
+        WEIGHT LADDER (real cuts)
+      </p>
+      <div className="space-y-1">
+        {s.weightLadder.weights.map((w) => (
+          <div
+            key={w}
+            className="text-xl text-white flex items-baseline gap-3"
+            style={{ fontFamily: s.weightLadder.family, fontWeight: w }}
+          >
+            <span className="text-xs text-zinc-500 w-10 shrink-0">{w}</span>
+            <span>Sphinx of black quartz, judge my vow</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+export default function TypographyProposals() {
+  const [selected, setSelected] = useState<System>(PROPOSALS[1]); // default: B
+  const [compare, setCompare] = useState(true);
+
+  return (
+    <>
+      <PageSEO
+        title={`Typography Proposals - Design Sandbox - ${siteMetadata.author}`}
+        description="Evaluate font-pairing and weight-system proposals for the blog"
+      />
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+
+      <div className="divide-y divide-white">
+        {/* header */}
+        <div className="pt-6 pb-8 space-y-2 md:space-y-5">
+          <p className="font-mono text-sm text-zinc-500">
+            <Link href="/design-sandbox" className="hover:text-brutalist-cyan">
+              {'<'} design_sandbox
+            </Link>
+          </p>
+          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-mono uppercase border-2 border-white inline-block px-4 py-2">
+            [ TYPOGRAPHY_PROPOSALS ]
+          </h1>
+          <p className="text-lg leading-7 text-zinc-400 font-mono">
+            {'>'} Pick a direction for font pairing + weight. Rendered live, no
+            tokens changed yet.
+          </p>
+        </div>
+
+        {/* diagnosis */}
+        <div className="container py-8">
+          <div className="border-2 border-brutalist-pink bg-zinc-900 p-6">
+            <h2 className="font-mono font-bold text-xl text-brutalist-pink mb-4 uppercase">
+              [ DIAGNOSIS ]
+            </h2>
+            <ul className="space-y-2 font-mono text-sm text-zinc-200">
+              <li>
+                <span className="text-brutalist-pink mr-2">!</span>
+                <strong className="text-white">
+                  Share Tech Mono has one weight (400).
+                </strong>{' '}
+                Every{' '}
+                <code className="text-brutalist-neonGreen">font-bold</code>{' '}
+                heading is browser-synthesised faux bold — smeared and
+                low-contrast.
+              </li>
+              <li>
+                <span className="text-brutalist-pink mr-2">!</span>
+                <strong className="text-white">No pairing.</strong> `sans` and
+                `mono` both map to Share Tech Mono, so display and body text
+                have zero contrast.
+              </li>
+              <li>
+                <span className="text-brutalist-pink mr-2">!</span>
+                <strong className="text-white">No mid-weights.</strong>{' '}
+                Hierarchy relies on size + colour alone; there is no 500/600
+                step for UI.
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        {/* controls */}
+        <div className="container py-8 space-y-6">
+          <div className="flex flex-wrap items-center gap-3">
+            {PROPOSALS.map((p) => {
+              const active = selected.id === p.id;
+              return (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => setSelected(p)}
+                  className={`font-mono text-sm font-bold px-4 py-2 border-2 uppercase transition-colors ${
+                    active
+                      ? 'bg-white text-black border-white'
+                      : 'bg-black text-white border-white hover:border-brutalist-cyan hover:text-brutalist-cyan'
+                  }`}
+                >
+                  {p.name}
+                </button>
+              );
+            })}
+            <label className="ml-auto flex items-center gap-2 font-mono text-xs text-zinc-400 uppercase cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={compare}
+                onChange={(e) => setCompare(e.target.checked)}
+                className="accent-brutalist-cyan"
+              />
+              Compare vs. current
+            </label>
+          </div>
+
+          {/* proposal summary */}
+          <div className="border-2 border-white bg-zinc-900 p-6">
+            <div className="flex flex-wrap items-center gap-3 mb-3">
+              <h3
+                className={`font-mono font-bold text-2xl uppercase ${selected.accent}`}
+              >
+                {selected.name}
+              </h3>
+              <span
+                className={`font-mono text-xs font-bold px-2 py-1 border-2 uppercase ${selected.accent} border-current`}
+              >
+                {selected.badge}
+              </span>
+            </div>
+            <p className="font-mono text-sm text-zinc-400 mb-4">
+              {selected.tagline}
+            </p>
+            <div className="grid md:grid-cols-2 gap-4">
+              <div>
+                <p className="font-mono text-xs text-brutalist-cyan uppercase mb-1">
+                  + Strengths
+                </p>
+                <ul className="space-y-1 font-mono text-xs text-zinc-300">
+                  {selected.pros.map((x) => (
+                    <li key={x}>
+                      <span className="text-brutalist-cyan mr-1">{'>'}</span>
+                      {x}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <p className="font-mono text-xs text-brutalist-pink uppercase mb-1">
+                  - Trade-offs
+                </p>
+                <ul className="space-y-1 font-mono text-xs text-zinc-300">
+                  {selected.cons.map((x) => (
+                    <li key={x}>
+                      <span className="text-brutalist-pink mr-1">!</span>
+                      {x}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          {/* specimens */}
+          <div className={`grid gap-6 ${compare ? 'lg:grid-cols-2' : ''}`}>
+            {compare && (
+              <div className="space-y-2">
+                <p className="font-mono text-xs text-zinc-500 uppercase">
+                  ▾ current (share tech mono)
+                </p>
+                <Specimen s={CURRENT} />
+              </div>
+            )}
+            <div className="space-y-2">
+              <p className={`font-mono text-xs uppercase ${selected.accent}`}>
+                ▾ {selected.name}
+              </p>
+              <Specimen s={selected} />
+            </div>
+          </div>
+
+          {/* adoption */}
+          <div className="border-2 border-brutalist-cyan bg-zinc-900 p-6 space-y-4">
+            <h3 className="font-mono font-bold text-xl text-brutalist-cyan uppercase">
+              [ HOW_TO_ADOPT — {selected.name} ]
+            </h3>
+            <div>
+              <p className="font-mono text-xs text-zinc-500 uppercase mb-1">
+                1. install
+              </p>
+              <pre className="bg-black border-2 border-white p-3 text-xs font-mono text-brutalist-neonGreen overflow-x-auto">
+                {selected.install}
+              </pre>
+            </div>
+            <div>
+              <p className="font-mono text-xs text-zinc-500 uppercase mb-1">
+                2. tailwind.config.js → fontFamily
+              </p>
+              <pre className="bg-black border-2 border-white p-3 text-xs font-mono text-brutalist-cyan overflow-x-auto">
+                {selected.tokens}
+              </pre>
+            </div>
+            <p className="font-mono text-xs text-zinc-400">
+              {'>'} Then import the @fontsource packages in{' '}
+              <code className="text-brutalist-neonGreen">pages/_app.tsx</code>{' '}
+              (same place Share Tech Mono / VT323 are imported today).
+            </p>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/pages/design-sandbox/typography.tsx
+++ b/pages/design-sandbox/typography.tsx
@@ -36,7 +36,7 @@ export default function Typography() {
       />
       <div className="divide-y divide-white">
         <div className="pt-6 pb-8 space-y-2 md:space-y-5">
-          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-mono uppercase border-2 border-white inline-block px-4 py-2">
+          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-white sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 font-display uppercase border-2 border-white inline-block px-4 py-2">
             [ TYPOGRAPHY_SYSTEM ]
           </h1>
           <p className="text-lg leading-7 text-zinc-400 font-mono">
@@ -48,46 +48,46 @@ export default function Typography() {
         <div className="container py-12 space-y-16">
           <section className="space-y-4">
             <div className="border-l-4 border-brutalist-cyan pl-4">
-              <h2 className="text-2xl font-mono font-bold text-white uppercase">
+              <h2 className="text-2xl font-display font-bold text-white uppercase">
                 01. HEADINGS
               </h2>
             </div>
 
             <div className="bg-black border-2 border-white p-8 space-y-6">
-              <h1 className="text-3xl md:text-6xl font-mono font-bold uppercase text-white border-2 border-white inline-block px-4 py-2">
+              <h1 className="text-3xl md:text-6xl font-display font-bold uppercase text-white border-2 border-white inline-block px-4 py-2">
                 [ H1_HEADING ]
               </h1>
-              <h2 className="text-2xl md:text-4xl font-mono font-bold uppercase text-white">
+              <h2 className="text-2xl md:text-4xl font-display font-bold uppercase text-white">
                 {'>'} H2_HEADING
               </h2>
-              <h3 className="text-xl md:text-3xl font-mono font-bold uppercase text-white border-b-2 border-white/20 pb-2">
+              <h3 className="text-xl md:text-3xl font-display font-bold uppercase text-white border-b-2 border-white/20 pb-2">
                 {'// H3_HEADING'}
               </h3>
-              <h4 className="text-lg md:text-2xl font-mono font-bold uppercase text-brutalist-cyan">
+              <h4 className="text-lg md:text-2xl font-display font-bold uppercase text-brutalist-cyan">
                 $ H4_HEADING
               </h4>
-              <h5 className="text-base md:text-xl font-mono font-bold uppercase text-brutalist-pink">
+              <h5 className="text-base md:text-xl font-display font-bold uppercase text-brutalist-pink">
                 * H5_HEADING
               </h5>
-              <h6 className="text-sm md:text-lg font-mono font-bold uppercase text-brutalist-yellow">
+              <h6 className="text-sm md:text-lg font-display font-bold uppercase text-brutalist-yellow">
                 # H6_HEADING
               </h6>
             </div>
 
             <CodePreview
-              code={`<h1 className="text-3xl md:text-6xl font-mono font-bold uppercase text-white border-2 border-white inline-block px-4 py-2">
+              code={`<h1 className="text-3xl md:text-6xl font-display font-bold uppercase text-white border-2 border-white inline-block px-4 py-2">
   [ H1_HEADING ]
 </h1>
 
-<h2 className="text-2xl md:text-4xl font-mono font-bold uppercase text-white">
+<h2 className="text-2xl md:text-4xl font-display font-bold uppercase text-white">
   {'>'} H2_HEADING
 </h2>
 
-<h3 className="text-xl md:text-3xl font-mono font-bold uppercase text-white border-b-2 border-white/20 pb-2">
+<h3 className="text-xl md:text-3xl font-display font-bold uppercase text-white border-b-2 border-white/20 pb-2">
   {'// H3_HEADING'}
 </h3>
 
-<h4 className="text-lg md:text-2xl font-mono font-bold uppercase text-brutalist-cyan">
+<h4 className="text-lg md:text-2xl font-display font-bold uppercase text-brutalist-cyan">
   $ H4_HEADING
 </h4>`}
             />
@@ -95,7 +95,7 @@ export default function Typography() {
 
           <section className="space-y-4">
             <div className="border-l-4 border-brutalist-pink pl-4">
-              <h2 className="text-2xl font-mono font-bold text-white uppercase">
+              <h2 className="text-2xl font-display font-bold text-white uppercase">
                 02. BODY_TEXT
               </h2>
             </div>
@@ -134,7 +134,7 @@ export default function Typography() {
 
           <section className="space-y-4">
             <div className="border-l-4 border-brutalist-yellow pl-4">
-              <h2 className="text-2xl font-mono font-bold text-white uppercase">
+              <h2 className="text-2xl font-display font-bold text-white uppercase">
                 03. TERMINAL_PROMPTS
               </h2>
             </div>
@@ -190,7 +190,7 @@ export default function Typography() {
 
           <section className="space-y-4">
             <div className="border-l-4 border-brutalist-cyan pl-4">
-              <h2 className="text-2xl font-mono font-bold text-white uppercase">
+              <h2 className="text-2xl font-display font-bold text-white uppercase">
                 04. CODE_BLOCKS
               </h2>
             </div>
@@ -234,7 +234,7 @@ greet('WORLD');`}
 
           <section className="space-y-4">
             <div className="border-l-4 border-brutalist-pink pl-4">
-              <h2 className="text-2xl font-mono font-bold text-white uppercase">
+              <h2 className="text-2xl font-display font-bold text-white uppercase">
                 05. LINKS
               </h2>
             </div>
@@ -285,7 +285,7 @@ greet('WORLD');`}
 
           <section className="space-y-4">
             <div className="border-l-4 border-brutalist-yellow pl-4">
-              <h2 className="text-2xl font-mono font-bold text-white uppercase">
+              <h2 className="text-2xl font-display font-bold text-white uppercase">
                 06. TAGS_AND_BADGES
               </h2>
             </div>
@@ -322,29 +322,31 @@ greet('WORLD');`}
           </section>
 
           <div className="border-2 border-brutalist-cyan bg-zinc-900 p-6 mt-12">
-            <h3 className="font-mono font-bold text-xl text-brutalist-cyan uppercase mb-4">
+            <h3 className="font-display font-bold text-xl text-brutalist-cyan uppercase mb-4">
               [ TYPOGRAPHY_RULES ]
             </h3>
             <ul className="space-y-2 font-mono text-sm text-zinc-300">
               <li className="flex items-start">
                 <span className="text-brutalist-cyan mr-2">{'>'}</span>
                 <span>
-                  <strong className="text-white">Font:</strong> Always use
-                  monospace (font-mono)
+                  <strong className="text-white">Three roles:</strong> Space
+                  Grotesk for display/headings (font-display), Inter for body
+                  (default sans), IBM Plex Mono for code + UI/metadata
+                  (font-mono)
                 </span>
               </li>
               <li className="flex items-start">
                 <span className="text-brutalist-cyan mr-2">{'>'}</span>
                 <span>
-                  <strong className="text-white">Headings:</strong> Always
-                  uppercase, bold, with terminal prefixes
+                  <strong className="text-white">Headings:</strong>{' '}
+                  font-display, uppercase, bold (700) — real weight, never faux
                 </span>
               </li>
               <li className="flex items-start">
                 <span className="text-brutalist-cyan mr-2">{'>'}</span>
                 <span>
-                  <strong className="text-white">Code:</strong> Neon green
-                  (#39ff14) on black background
+                  <strong className="text-white">Code:</strong> IBM Plex Mono,
+                  neon green (#39ff14) on black background
                 </span>
               </li>
               <li className="flex items-start">

--- a/pages/experiments.tsx
+++ b/pages/experiments.tsx
@@ -1,4 +1,4 @@
-import { Beaker, Palette, Terminal } from 'lucide-react';
+import { Beaker, Palette, Terminal, Type } from 'lucide-react';
 import Link from '@/components/Link';
 import { PageSEO } from '@/components/SEO';
 import siteMetadata from '@/data/siteMetadata';
@@ -10,7 +10,16 @@ const experiments = [
     description: 'Component variations and design system playground',
     icon: <Palette className="w-12 h-12" />,
     status: 'active',
-    components: 7,
+    components: 9,
+  },
+  {
+    name: 'Typography Proposals',
+    path: '/design-sandbox/typography-proposals',
+    description:
+      'Font pairing + weight-system proposals to fix the design system',
+    icon: <Type className="w-12 h-12" />,
+    status: 'active',
+    components: 3,
   },
 ];
 

--- a/pages/experiments.tsx
+++ b/pages/experiments.tsx
@@ -34,7 +34,7 @@ export default function ExperimentsPage() {
         <div className="pt-8 pb-10 px-6 bg-zinc-900">
           <div className="flex items-center gap-4 mb-4">
             <Beaker className="w-10 h-10 text-brutalist-cyan" />
-            <h1 className="text-4xl font-mono font-bold uppercase text-white md:text-6xl">
+            <h1 className="text-4xl font-display font-bold uppercase text-white md:text-6xl">
               [ EXPERIMENTS ]
             </h1>
           </div>
@@ -55,7 +55,7 @@ export default function ExperimentsPage() {
                     </div>
                     <div className="flex-1">
                       <div className="flex items-center gap-3 mb-2">
-                        <h3 className="font-mono font-bold text-2xl text-white uppercase group-hover:text-brutalist-cyan transition-colors">
+                        <h3 className="font-display font-bold text-2xl text-white uppercase group-hover:text-brutalist-cyan transition-colors">
                           {experiment.name}
                         </h3>
                         <span
@@ -86,7 +86,7 @@ export default function ExperimentsPage() {
           </div>
 
           <div className="mt-12 max-w-4xl mx-auto border-2 border-brutalist-yellow bg-zinc-900 p-6">
-            <h2 className="font-mono font-bold text-xl text-brutalist-yellow mb-4 uppercase">
+            <h2 className="font-display font-bold text-xl text-brutalist-yellow mb-4 uppercase">
               [ ABOUT_EXPERIMENTS ]
             </h2>
             <div className="space-y-3 text-white font-mono text-sm">

--- a/pages/series/index.tsx
+++ b/pages/series/index.tsx
@@ -24,7 +24,7 @@ export default function Series({
       />
       <div className="divide-y divide-white border-2 border-white bg-black">
         <div className="pt-6 pb-8 space-y-4 md:space-y-6 bg-zinc-900 px-6">
-          <h1 className="text-3xl font-mono font-bold leading-9 tracking-tight text-white uppercase sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 border-4 border-double border-brutalist-cyan inline-block px-8 py-4">
+          <h1 className="text-3xl font-display font-bold leading-9 tracking-tight text-white uppercase sm:text-4xl sm:leading-10 md:text-6xl md:leading-14 border-4 border-double border-brutalist-cyan inline-block px-8 py-4">
             &gt; SERIES
           </h1>
           <p className="font-mono text-lg leading-7 text-gray-200 border-l-4 border-brutalist-pink pl-4">
@@ -64,7 +64,7 @@ export default function Series({
                         {series.postCount === 1 ? 'part' : 'parts'}
                       </span>
                     </div>
-                    <h2 className="text-2xl font-mono font-bold leading-8 tracking-tight uppercase border-l-4 border-brutalist-cyan pl-4">
+                    <h2 className="text-2xl font-display font-bold leading-8 tracking-tight uppercase border-l-4 border-brutalist-cyan pl-4">
                       <Link
                         href={`/series/${series.slug}`}
                         className="text-white hover:text-brutalist-cyan transition-colors"
@@ -83,7 +83,7 @@ export default function Series({
                   </div>
                   {series.posts.length > 0 && (
                     <div className="pl-4">
-                      <h3 className="font-mono text-xs uppercase text-brutalist-yellow tracking-wider mb-2">
+                      <h3 className="font-display text-xs uppercase text-brutalist-yellow tracking-wider mb-2">
                         Posts in Series:
                       </h3>
                       <ol className="space-y-1">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.2.7
+        version: 5.2.7
+      '@fontsource/inter':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@fontsource/share-tech-mono':
         specifier: ^5.2.7
         version: 5.2.7
+      '@fontsource/space-grotesk':
+        specifier: ^5.2.10
+        version: 5.2.10
       '@fontsource/vt323':
         specifier: ^5.2.7
         version: 5.2.7
@@ -544,8 +553,17 @@ packages:
   '@fal-works/esbuild-plugin-global-externals@2.1.2':
     resolution: {integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==}
 
+  '@fontsource/ibm-plex-mono@5.2.7':
+    resolution: {integrity: sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==}
+
+  '@fontsource/inter@5.2.8':
+    resolution: {integrity: sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==}
+
   '@fontsource/share-tech-mono@5.2.7':
     resolution: {integrity: sha512-1JBJ6CU9u5av8aFEUOGOJkq60/IEVVOZDCmiU8X3i0skk0Pp69GngDwlBUHaTZa4G6pbF1UDrC+Fm7XSckW6TQ==}
+
+  '@fontsource/space-grotesk@5.2.10':
+    resolution: {integrity: sha512-XNXEbT74OIITPqw2H6HXwPDp85fy43uxfBwFR5PU+9sLnjuLj12KlhVM9nZVN6q6dlKjkuN8JisW/OBxwxgUew==}
 
   '@fontsource/vt323@5.2.7':
     resolution: {integrity: sha512-8JTMM23vMhQxin9Cn/ijty8cNwXW4INrln0VAJ2227Rz0CVfkzM3qr3l/CqudZJ6BXCnbCGUTdf2ym3cTNex8A==}
@@ -4355,7 +4373,13 @@ snapshots:
 
   '@fal-works/esbuild-plugin-global-externals@2.1.2': {}
 
+  '@fontsource/ibm-plex-mono@5.2.7': {}
+
+  '@fontsource/inter@5.2.8': {}
+
   '@fontsource/share-tech-mono@5.2.7': {}
+
+  '@fontsource/space-grotesk@5.2.10': {}
 
   '@fontsource/vt323@5.2.7': {}
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,15 +25,17 @@ module.exports = {
         14: '3.5rem',
       },
       fontFamily: {
-        sans: ['"Share Tech Mono"', ...defaultTheme.fontFamily.sans],
+        // Proposal C — Editorial Three-Role
+        sans: ['Inter', ...defaultTheme.fontFamily.sans], // body / reading
+        display: ['"Space Grotesk"', ...defaultTheme.fontFamily.sans], // headings / display
         mono: [
-          '"Share Tech Mono"',
+          '"IBM Plex Mono"',
           'Courier New',
           'Courier',
           'monospace',
           ...defaultTheme.fontFamily.mono,
-        ],
-        pixel: ['"VT323"', 'monospace'],
+        ], // code + UI / metadata
+        pixel: ['"VT323"', 'monospace'], // decorative accent (hero/logo)
       },
       colors: {
         primary: colors.teal,
@@ -67,13 +69,15 @@ module.exports = {
         'hard-cyan': '4px 4px 0px 0px rgba(34, 211, 238, 1)',
         'hard-pink': '4px 4px 0px 0px rgba(236, 72, 153, 1)',
         'hard-yellow': '4px 4px 0px 0px rgba(250, 204, 21, 1)',
-        'glow-cyan': '0 0 10px rgba(34, 211, 238, 0.5), 0 0 20px rgba(34, 211, 238, 0.3)',
-        'glow-orange': '0 0 20px rgba(255, 140, 0, 0.8), 0 0 40px rgba(255, 140, 0, 0.5)',
+        'glow-cyan':
+          '0 0 10px rgba(34, 211, 238, 0.5), 0 0 20px rgba(34, 211, 238, 0.3)',
+        'glow-orange':
+          '0 0 20px rgba(255, 140, 0, 0.8), 0 0 40px rgba(255, 140, 0, 0.5)',
       },
       typography: (theme) => ({
         DEFAULT: {
           css: {
-            fontFamily: theme('fontFamily.mono'),
+            fontFamily: theme('fontFamily.sans'),
             color: theme('colors.gray.200'),
             a: {
               color: theme('colors.brutalist.cyan'),
@@ -85,27 +89,27 @@ module.exports = {
               code: { color: theme('colors.brutalist.cyan') },
             },
             h1: {
-              fontFamily: theme('fontFamily.mono'),
+              fontFamily: theme('fontFamily.display'),
               fontWeight: '700',
               textTransform: 'uppercase',
               letterSpacing: theme('letterSpacing.tight'),
               color: theme('colors.white'),
             },
             h2: {
-              fontFamily: theme('fontFamily.mono'),
+              fontFamily: theme('fontFamily.display'),
               fontWeight: '700',
               textTransform: 'uppercase',
               letterSpacing: theme('letterSpacing.tight'),
               color: theme('colors.white'),
             },
             h3: {
-              fontFamily: theme('fontFamily.mono'),
+              fontFamily: theme('fontFamily.display'),
               fontWeight: '700',
               textTransform: 'uppercase',
               color: theme('colors.white'),
             },
             'h4,h5,h6': {
-              fontFamily: theme('fontFamily.mono'),
+              fontFamily: theme('fontFamily.display'),
               fontWeight: '700',
               textTransform: 'uppercase',
               color: theme('colors.white'),
@@ -164,7 +168,7 @@ module.exports = {
         },
         dark: {
           css: {
-            fontFamily: theme('fontFamily.mono'),
+            fontFamily: theme('fontFamily.sans'),
             color: theme('colors.gray.200'),
             a: {
               color: theme('colors.brutalist.cyan'),
@@ -176,27 +180,27 @@ module.exports = {
               code: { color: theme('colors.brutalist.cyan') },
             },
             h1: {
-              fontFamily: theme('fontFamily.mono'),
+              fontFamily: theme('fontFamily.display'),
               fontWeight: '700',
               textTransform: 'uppercase',
               letterSpacing: theme('letterSpacing.tight'),
               color: theme('colors.white'),
             },
             h2: {
-              fontFamily: theme('fontFamily.mono'),
+              fontFamily: theme('fontFamily.display'),
               fontWeight: '700',
               textTransform: 'uppercase',
               letterSpacing: theme('letterSpacing.tight'),
               color: theme('colors.white'),
             },
             h3: {
-              fontFamily: theme('fontFamily.mono'),
+              fontFamily: theme('fontFamily.display'),
               fontWeight: '700',
               textTransform: 'uppercase',
               color: theme('colors.white'),
             },
             'h4,h5,h6': {
-              fontFamily: theme('fontFamily.mono'),
+              fontFamily: theme('fontFamily.display'),
               fontWeight: '700',
               textTransform: 'uppercase',
               color: theme('colors.white'),


### PR DESCRIPTION
## Summary

Adopts **Proposal C — Editorial Three-Role** typography across the blog, and keeps the interactive **Typography Proposals** experiment page used to evaluate the options.

### The problem (on the hacker-theme branch)
- **Share Tech Mono ships a single weight (400)**, so every `font-bold` heading was browser-synthesised *faux bold* — smeared and low-contrast.
- **`sans` and `mono` both resolved to Share Tech Mono** → zero display/body contrast, no real pairing, no mid-weights.

### The fix — a three-role system
| Role | Font | Utility |
| --- | --- | --- |
| Display / headings | **Space Grotesk** | `font-display` (new token) |
| Body / reading | **Inter** | default `font-sans` |
| Code + UI / metadata | **IBM Plex Mono** | `font-mono` (real 400–700 weights) |
| Decorative accent | VT323 | `font-pixel` (logo + hero only) |

## Changes
- Install `@fontsource/{space-grotesk,inter,ibm-plex-mono}`; import the needed weights in `_app.tsx` (drop Share Tech Mono).
- `tailwind.config.js`: new `font*` tokens + prose/typography config (headings → display, body → sans, code → mono).
- `css/tailwind.css`: base `body` font → Inter; converted fragile `theme()` calls in the diagram CSS vars to literal hex.
- Swept every heading element (`h1`–`h6`, `PageTitle`) from `font-mono`/`font-pixel` → `font-display` across components, layouts and pages. Non-heading `font-mono` stays (now IBM Plex Mono, with real weights).
- Documented the new system in the Typography sandbox page and `AGENTS.md`.

## How to review
The `feat/typography-proposals` worktree runs at `http://localhost:3001`. Compare the still-live experiment page (`/design-sandbox/typography-proposals`) against the now-converted site:
- `/` · `/blog` · `/design-sandbox` · `/design-sandbox/typography`

## Verification
- `tsc --noEmit` ✅ · Biome ✅ · all key routes return 200 with no compile errors.
- Confirmed the served CSS bundle includes `@font-face` for Space Grotesk, Inter and IBM Plex Mono (fonts load, no fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
