### PR TITLE
fix: unblock next build (Storybook/vitest type resolution)

### DIFF
--- a/components/Button.stories.tsx
+++ b/components/Button.stories.tsx
@@ -95,6 +95,8 @@ export const Disabled: Story = {
 };
 
 export const AllVariants: Story = {
+  // `render` controls the output; args satisfy the required-prop type contract.
+  args: { children: 'BUTTON' },
   render: () => (
     <div className="flex flex-col gap-4 items-center">
       <div className="flex gap-4 flex-wrap justify-center">

--- a/stories/Cards.stories.tsx
+++ b/stories/Cards.stories.tsx
@@ -137,6 +137,11 @@ export const NoLink: Story = {
 };
 
 export const AllVariations: Story = {
+  // `render` controls the output; args satisfy the required-prop type contract.
+  args: {
+    title: 'Card',
+    description: 'Brutalist card component showcase.',
+  },
   render: () => (
     <div className="space-y-8 p-8">
       <div className="border-b-2 border-white pb-4">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Problem

`next build` currently fails during its TypeScript phase on `main`, independent of any feature work, due to the Storybook integration (commit f53ed30):

1. `@storybook/nextjs-vite` declares `Meta`/`StoryObj` locally but they failed to import
2. `vitest.config.ts` could not resolve `@storybook/addon-vitest/vitest-plugin`

Both stem from classic `moduleResolution: "node"` not honoring package `exports` maps.

## Fix

- Set tsconfig `moduleResolution: "node" → "bundler"` (the correct setting for this Next.js + Vite project)
- With CSF types now resolving, the two render-only showcase stories (`Button.stories.tsx` `AllVariants`, `Cards.stories.tsx` `AllVariations`) require explicit `args` — added minimal ones

## Verification

- `npx tsc --noEmit` — clean
- `npx next build` — completes, all 26 pages generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)