### PR TITLE
feat: toast audience activity (live Convex)

### DIFF
--- a/components/MDXComponents.tsx
+++ b/components/MDXComponents.tsx
@@ -10,6 +10,7 @@ import CustomLink from './Link';
 import NoteBlock from './NoteBlock';
 import Pre from './Pre';
 import TOCInline from './TOCInline';
+import ActivityQR from './talks/ActivityQR';
 
 const Wrapper: React.ComponentType<{ layout: string }> = ({
   layout,
@@ -24,6 +25,7 @@ export const MDXComponents: MDXComponentsType = {
   TOCInline,
   Diagram,
   NoteBlock,
+  ActivityQR,
   a: CustomLink,
   pre: Pre,
   wrapper: Wrapper,

--- a/components/talks/ActivityQR.tsx
+++ b/components/talks/ActivityQR.tsx
@@ -1,0 +1,31 @@
+import { QRCodeSVG } from 'qrcode.react';
+import siteMetadata from '@/data/siteMetadata';
+
+interface ActivityQRProps {
+  /** Talk slug; the QR points at /talks/<slug>/activity. */
+  slug: string;
+  /** Optional call-to-action shown under the code. */
+  label?: string;
+}
+
+/**
+ * Renders a scannable QR code (and the plain URL) for a talk's audience
+ * activity. Used inside a deck slide so the room can join from their phones.
+ * Self-contained SVG — exports to PDF cleanly.
+ */
+export default function ActivityQR({ slug, label }: ActivityQRProps) {
+  const base = siteMetadata.siteUrl.replace(/\/$/, '');
+  const url = `${base}/talks/${slug}/activity`;
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div className="border-4 border-white bg-white p-3 shadow-hard-cyan">
+        <QRCodeSVG value={url} size={220} bgColor="#ffffff" fgColor="#000000" />
+      </div>
+      <p className="font-mono text-lg font-bold text-brutalist-yellow">
+        {label ?? 'Scan to join'}
+      </p>
+      <p className="font-mono text-sm text-brutalist-cyan">{url}</p>
+    </div>
+  );
+}

--- a/components/talks/toast/ToastActivityForm.tsx
+++ b/components/talks/toast/ToastActivityForm.tsx
@@ -1,0 +1,235 @@
+import { useMutation } from 'convex/react';
+import { ArrowDown, ArrowUp, Plus, X } from 'lucide-react';
+import { useState } from 'react';
+import { api } from '@/convex/_generated/api';
+import {
+  MAX_NICKNAME_LEN,
+  MAX_STEP_LEN,
+  MAX_STEPS,
+  TOAST_STEP_CARDS,
+} from './steps';
+
+interface ToastActivityFormProps {
+  talkSlug: string;
+}
+
+/**
+ * The student-facing submission form (the link/QR shared during the talk).
+ * Hybrid input: tap a preset card to append it, or type a custom step. Reorder
+ * with up/down (touch-friendly — no drag library), then submit the ordered list
+ * to Convex. The profanity filter + 5s moderation buffer live server-side.
+ */
+export default function ToastActivityForm({
+  talkSlug,
+}: ToastActivityFormProps) {
+  const submit = useMutation(api.toast.submit);
+  const [steps, setSteps] = useState<string[]>([]);
+  const [custom, setCustom] = useState('');
+  const [nickname, setNickname] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const addStep = (text: string) => {
+    const value = text.trim().slice(0, MAX_STEP_LEN);
+    if (!value || steps.length >= MAX_STEPS) return;
+    setSteps((prev) => [...prev, value]);
+  };
+
+  const move = (index: number, delta: number) => {
+    setSteps((prev) => {
+      const next = [...prev];
+      const target = index + delta;
+      if (target < 0 || target >= next.length) return prev;
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  };
+
+  const removeStep = (index: number) => {
+    setSteps((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const onSubmit = async () => {
+    if (steps.length === 0 || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await submit({
+        talkSlug,
+        nickname: nickname.trim() || undefined,
+        steps,
+      });
+      setDone(true);
+    } catch (_err) {
+      setError('Something went wrong. Try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const reset = () => {
+    setSteps([]);
+    setCustom('');
+    setDone(false);
+    setError(null);
+  };
+
+  if (done) {
+    return (
+      <div className="border-2 border-white bg-zinc-900 p-6 text-center shadow-hard-cyan">
+        <p className="font-mono text-2xl font-bold uppercase text-brutalist-cyan">
+          [ Sent! ]
+        </p>
+        <p className="mt-3 font-mono text-sm text-gray-200">
+          Watch the big screen — your steps will appear in a few seconds.
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          className="mt-6 border-2 border-white bg-brutalist-yellow px-5 py-2 font-mono font-bold uppercase text-black shadow-hard-md transition-all hover:shadow-hard-lg active:translate-x-1 active:translate-y-1 active:shadow-none"
+        >
+          Send another
+        </button>
+      </div>
+    );
+  }
+
+  const atMax = steps.length >= MAX_STEPS;
+
+  return (
+    <div className="space-y-6">
+      {/* Chosen, ordered steps */}
+      <div className="border-2 border-white bg-zinc-900 p-4">
+        <p className="mb-3 font-mono text-xs font-bold uppercase text-brutalist-yellow">
+          Your steps {steps.length > 0 ? `(${steps.length}/${MAX_STEPS})` : ''}
+        </p>
+        {steps.length === 0 ? (
+          <p className="font-mono text-sm text-zinc-400">
+            Add steps below, in the order you'd do them.
+          </p>
+        ) : (
+          <ol className="space-y-2">
+            {steps.map((step, index) => (
+              <li
+                key={index}
+                className="flex items-center gap-2 border-2 border-zinc-700 bg-black p-2"
+              >
+                <span className="font-mono text-sm font-bold text-brutalist-cyan">
+                  {index + 1}.
+                </span>
+                <span className="flex-1 font-mono text-sm text-gray-100">
+                  {step}
+                </span>
+                <button
+                  type="button"
+                  aria-label="Move up"
+                  onClick={() => move(index, -1)}
+                  disabled={index === 0}
+                  className="border border-zinc-600 p-1 text-zinc-300 disabled:opacity-30"
+                >
+                  <ArrowUp className="h-4 w-4" />
+                </button>
+                <button
+                  type="button"
+                  aria-label="Move down"
+                  onClick={() => move(index, 1)}
+                  disabled={index === steps.length - 1}
+                  className="border border-zinc-600 p-1 text-zinc-300 disabled:opacity-30"
+                >
+                  <ArrowDown className="h-4 w-4" />
+                </button>
+                <button
+                  type="button"
+                  aria-label="Remove"
+                  onClick={() => removeStep(index)}
+                  className="border border-zinc-600 p-1 text-brutalist-pink"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+
+      {/* Preset cards */}
+      <div>
+        <p className="mb-3 font-mono text-xs font-bold uppercase text-brutalist-yellow">
+          Tap to add
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {TOAST_STEP_CARDS.map((card) => (
+            <button
+              key={card}
+              type="button"
+              onClick={() => addStep(card)}
+              disabled={atMax}
+              className="border-2 border-white bg-black px-3 py-2 font-mono text-sm text-gray-100 transition-all hover:bg-brutalist-cyan hover:text-black disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              + {card}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Custom step */}
+      <div>
+        <p className="mb-3 font-mono text-xs font-bold uppercase text-brutalist-yellow">
+          Or write your own
+        </p>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={custom}
+            maxLength={MAX_STEP_LEN}
+            placeholder="e.g. plug the toaster in"
+            onChange={(e) => setCustom(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addStep(custom);
+                setCustom('');
+              }
+            }}
+            className="flex-1 border-2 border-white bg-black px-3 py-2 font-mono text-sm text-gray-100 placeholder:text-zinc-600 focus:border-brutalist-cyan focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={() => {
+              addStep(custom);
+              setCustom('');
+            }}
+            disabled={atMax || !custom.trim()}
+            className="flex items-center gap-1 border-2 border-white bg-brutalist-cyan px-3 py-2 font-mono text-sm font-bold uppercase text-black disabled:opacity-40"
+          >
+            <Plus className="h-4 w-4" /> Add
+          </button>
+        </div>
+      </div>
+
+      {/* Nickname + submit */}
+      <div className="border-t-2 border-white pt-6">
+        <input
+          type="text"
+          value={nickname}
+          maxLength={MAX_NICKNAME_LEN}
+          placeholder="Your name or nickname (optional)"
+          onChange={(e) => setNickname(e.target.value)}
+          className="mb-4 w-full border-2 border-white bg-black px-3 py-2 font-mono text-sm text-gray-100 placeholder:text-zinc-600 focus:border-brutalist-cyan focus:outline-none"
+        />
+        {error && (
+          <p className="mb-3 font-mono text-sm text-brutalist-pink">{error}</p>
+        )}
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={steps.length === 0 || submitting}
+          className="w-full border-2 border-white bg-brutalist-yellow px-6 py-3 font-mono text-lg font-bold uppercase text-black shadow-hard-md transition-all hover:shadow-hard-lg active:translate-x-1 active:translate-y-1 active:shadow-none disabled:cursor-not-allowed disabled:opacity-40 disabled:shadow-none"
+        >
+          {submitting ? 'Sending…' : 'Send my toast recipe'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/talks/toast/ToastModeration.tsx
+++ b/components/talks/toast/ToastModeration.tsx
@@ -1,0 +1,154 @@
+import { useMutation, useQuery } from 'convex/react';
+import { Eye, EyeOff, Trash2 } from 'lucide-react';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+
+interface ToastModerationProps {
+  talkSlug: string;
+  moderationKey: string;
+}
+
+/**
+ * Presenter moderation screen (gated by the `?key=` secret). Shows every
+ * submission the instant it lands — including not-yet-revealed and flagged ones
+ * — so the presenter can pull anything bad during the 5s buffer before it
+ * reaches the audience wall.
+ */
+export default function ToastModeration({
+  talkSlug,
+  moderationKey,
+}: ToastModerationProps) {
+  const result = useQuery(api.toast.feed, { talkSlug, key: moderationKey });
+  const setHidden = useMutation(api.toast.setHidden);
+  const remove = useMutation(api.toast.remove);
+  const clearAll = useMutation(api.toast.clearAll);
+
+  if (result === undefined) {
+    return <p className="p-6 font-mono text-zinc-500">Connecting…</p>;
+  }
+
+  if (!result.authorized) {
+    return (
+      <div className="p-6">
+        <p className="border-2 border-brutalist-pink bg-zinc-900 p-4 font-mono text-brutalist-pink">
+          [ Invalid or missing moderation key ]
+        </p>
+      </div>
+    );
+  }
+
+  const { submissions } = result;
+
+  const onClear = () => {
+    if (
+      window.confirm(
+        'Delete ALL submissions for this talk? This cannot be undone.',
+      )
+    ) {
+      clearAll({ talkSlug, key: moderationKey });
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-black px-6 py-8">
+      <div className="mb-6 flex items-center justify-between border-b-2 border-white pb-4">
+        <h1 className="font-mono text-2xl font-bold uppercase text-white">
+          [ Moderation ] {submissions.length}
+        </h1>
+        <button
+          type="button"
+          onClick={onClear}
+          className="border-2 border-brutalist-pink px-4 py-2 font-mono text-sm font-bold uppercase text-brutalist-pink transition-colors hover:bg-brutalist-pink hover:text-black"
+        >
+          Clear all
+        </button>
+      </div>
+
+      {submissions.length === 0 ? (
+        <p className="font-mono text-zinc-400">No submissions yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {submissions.map((entry) => {
+            const id = entry._id as Id<'toastSubmissions'>;
+            return (
+              <li
+                key={entry._id}
+                className={`border-2 p-4 ${
+                  entry.flagged
+                    ? 'border-brutalist-pink bg-pink-950/30'
+                    : 'border-zinc-700 bg-zinc-900'
+                } ${entry.hidden ? 'opacity-50' : ''}`}
+              >
+                <div className="mb-2 flex flex-wrap items-center gap-2">
+                  <span className="font-mono text-sm font-bold uppercase text-brutalist-cyan">
+                    {entry.nickname || 'Anonymous chef'}
+                  </span>
+                  {entry.flagged && (
+                    <span className="border border-brutalist-pink px-2 py-0.5 font-mono text-xs font-bold uppercase text-brutalist-pink">
+                      Flagged
+                    </span>
+                  )}
+                  <span
+                    className={`border px-2 py-0.5 font-mono text-xs font-bold uppercase ${
+                      entry.hidden
+                        ? 'border-zinc-500 text-zinc-500'
+                        : entry.revealed
+                          ? 'border-brutalist-cyan text-brutalist-cyan'
+                          : 'border-brutalist-yellow text-brutalist-yellow'
+                    }`}
+                  >
+                    {entry.hidden
+                      ? 'Hidden'
+                      : entry.revealed
+                        ? 'On wall'
+                        : 'Pending'}
+                  </span>
+                  <div className="ml-auto flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setHidden({
+                          id,
+                          key: moderationKey,
+                          hidden: !entry.hidden,
+                        })
+                      }
+                      className="flex items-center gap-1 border border-zinc-500 px-2 py-1 font-mono text-xs uppercase text-zinc-200 hover:border-white"
+                    >
+                      {entry.hidden ? (
+                        <>
+                          <Eye className="h-3 w-3" /> Show
+                        </>
+                      ) : (
+                        <>
+                          <EyeOff className="h-3 w-3" /> Hide
+                        </>
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => remove({ id, key: moderationKey })}
+                      className="flex items-center gap-1 border border-brutalist-pink px-2 py-1 font-mono text-xs uppercase text-brutalist-pink hover:bg-brutalist-pink hover:text-black"
+                    >
+                      <Trash2 className="h-3 w-3" /> Remove
+                    </button>
+                  </div>
+                </div>
+                <ol className="space-y-0.5">
+                  {entry.steps.map((step, index) => (
+                    <li key={index} className="font-mono text-sm text-gray-200">
+                      <span className="text-brutalist-yellow">
+                        {index + 1}.
+                      </span>{' '}
+                      {step}
+                    </li>
+                  ))}
+                </ol>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/talks/toast/ToastWall.tsx
+++ b/components/talks/toast/ToastWall.tsx
@@ -1,0 +1,60 @@
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+
+interface ToastWallProps {
+  talkSlug: string;
+}
+
+/**
+ * The projected audience wall. Subscribes to revealed submissions and updates
+ * live as students send them (after the 5s moderation buffer). Designed to be
+ * legible across a classroom.
+ */
+export default function ToastWall({ talkSlug }: ToastWallProps) {
+  const submissions = useQuery(api.toast.wall, { talkSlug });
+
+  return (
+    <div className="min-h-screen bg-black px-6 py-8">
+      <div className="mb-8 flex items-baseline justify-between border-b-2 border-white pb-4">
+        <h1 className="font-mono text-3xl font-bold uppercase text-white md:text-5xl">
+          [ How to make toast ]
+        </h1>
+        <span className="font-mono text-lg text-brutalist-yellow">
+          {submissions?.length ?? 0} recipes
+        </span>
+      </div>
+
+      {submissions === undefined ? (
+        <p className="font-mono text-xl text-zinc-500">Connecting…</p>
+      ) : submissions.length === 0 ? (
+        <p className="font-mono text-xl text-zinc-400">
+          <span className="text-brutalist-cyan">&gt;</span> Waiting for the
+          first recipe…
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {submissions.map((entry) => (
+            <div
+              key={entry._id}
+              className="border-2 border-white bg-zinc-900 p-5 shadow-hard-cyan"
+            >
+              <p className="mb-3 font-mono text-sm font-bold uppercase text-brutalist-cyan">
+                {entry.nickname || 'Anonymous chef'}
+              </p>
+              <ol className="space-y-1">
+                {entry.steps.map((step, index) => (
+                  <li key={index} className="font-mono text-base text-gray-100">
+                    <span className="font-bold text-brutalist-yellow">
+                      {index + 1}.
+                    </span>{' '}
+                    {step}
+                  </li>
+                ))}
+              </ol>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/talks/toast/steps.ts
+++ b/components/talks/toast/steps.ts
@@ -1,0 +1,21 @@
+// Preset step cards for the "how to make toast" exercise. They are deliberately
+// a mix of obvious and slightly-ambiguous instructions so that, when followed
+// literally, the gaps show — the whole point of the "exact instructions"
+// challenge. Students drag these into order and/or add their own.
+export const TOAST_STEP_CARDS: string[] = [
+  'Get the bread',
+  'Open the bag',
+  'Take out a slice',
+  'Put bread in the toaster',
+  'Push the lever down',
+  'Wait for it to toast',
+  'Pop it up',
+  'Get a plate',
+  'Get butter and a knife',
+  'Spread the butter',
+  'Eat the toast',
+];
+
+export const MAX_STEPS = 12;
+export const MAX_STEP_LEN = 140;
+export const MAX_NICKNAME_LEN = 24;

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "obscenity": "^0.4.6",
     "postcss": "^8.5.16",
     "preact": "^10.29.3",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "reading-time": "1.5.0",

--- a/pages/talks/[slug]/activity/index.tsx
+++ b/pages/talks/[slug]/activity/index.tsx
@@ -1,0 +1,67 @@
+import type { GetStaticProps, InferGetStaticPropsType } from 'next';
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+import { isConvexConfigured } from '@/lib/convexClient';
+import { getAllTalksFrontMatter, getTalkSlugs } from '@/lib/talks';
+
+// Convex hooks must not run during static generation, so load the form
+// client-side only (same pattern as the Spectacle deck).
+const ToastActivityForm = dynamic(
+  () => import('@/components/talks/toast/ToastActivityForm'),
+  {
+    ssr: false,
+    loading: () => (
+      <p className="font-mono text-zinc-500">Loading the activity…</p>
+    ),
+  },
+);
+
+export async function getStaticPaths() {
+  return {
+    paths: getTalkSlugs().map((slug) => ({ params: { slug } })),
+    fallback: false,
+  };
+}
+
+export const getStaticProps: GetStaticProps<{
+  slug: string;
+  title: string;
+}> = async ({ params }) => {
+  const slug = params?.slug as string;
+  const frontMatter = getAllTalksFrontMatter().find((t) => t.slug === slug);
+  return { props: { slug, title: frontMatter?.title ?? slug } };
+};
+
+export default function ActivityPage({
+  slug,
+  title,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  return (
+    <>
+      <Head>
+        <title>{`Activity — ${title}`}</title>
+        <meta name="robots" content="noindex, nofollow" />
+      </Head>
+      <div className="mx-auto max-w-2xl py-10">
+        <header className="mb-8 border-2 border-white bg-zinc-900 p-6">
+          <h1 className="font-mono text-3xl font-bold uppercase text-white md:text-4xl">
+            [ How to make toast ]
+          </h1>
+          <p className="mt-3 font-mono text-sm text-gray-200">
+            Write the exact steps to make a piece of toast — in order. We'll
+            follow your instructions <em>literally</em> on the big screen. Be as
+            precise as you can!
+          </p>
+        </header>
+
+        {isConvexConfigured ? (
+          <ToastActivityForm talkSlug={slug} />
+        ) : (
+          <p className="border-2 border-brutalist-pink bg-zinc-900 p-4 font-mono text-brutalist-pink">
+            [ This activity isn't configured yet. Set NEXT_PUBLIC_CONVEX_URL. ]
+          </p>
+        )}
+      </div>
+    </>
+  );
+}

--- a/pages/talks/[slug]/activity/manage.tsx
+++ b/pages/talks/[slug]/activity/manage.tsx
@@ -1,0 +1,58 @@
+import type { GetStaticProps, InferGetStaticPropsType } from 'next';
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import type { ReactElement } from 'react';
+import { isConvexConfigured } from '@/lib/convexClient';
+import { getTalkSlugs } from '@/lib/talks';
+
+const ToastModeration = dynamic(
+  () => import('@/components/talks/toast/ToastModeration'),
+  {
+    ssr: false,
+    loading: () => (
+      <p className="min-h-screen bg-black p-8 font-mono text-zinc-500">
+        Connecting…
+      </p>
+    ),
+  },
+);
+
+export async function getStaticPaths() {
+  return {
+    paths: getTalkSlugs().map((slug) => ({ params: { slug } })),
+    fallback: false,
+  };
+}
+
+export const getStaticProps: GetStaticProps<{ slug: string }> = async ({
+  params,
+}) => {
+  return { props: { slug: params?.slug as string } };
+};
+
+export default function ManagePage({
+  slug,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  const router = useRouter();
+  const key = typeof router.query.key === 'string' ? router.query.key : '';
+
+  return (
+    <>
+      <Head>
+        <title>Toast moderation</title>
+        <meta name="robots" content="noindex, nofollow" />
+      </Head>
+      {isConvexConfigured ? (
+        <ToastModeration talkSlug={slug} moderationKey={key} />
+      ) : (
+        <p className="min-h-screen bg-black p-8 font-mono text-brutalist-pink">
+          [ Activity not configured. Set NEXT_PUBLIC_CONVEX_URL. ]
+        </p>
+      )}
+    </>
+  );
+}
+
+// Presenter tool — no site header/footer.
+ManagePage.getLayout = (page: ReactElement) => page;

--- a/pages/talks/[slug]/activity/wall.tsx
+++ b/pages/talks/[slug]/activity/wall.tsx
@@ -1,0 +1,51 @@
+import type { GetStaticProps, InferGetStaticPropsType } from 'next';
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+import type { ReactElement } from 'react';
+import { isConvexConfigured } from '@/lib/convexClient';
+import { getTalkSlugs } from '@/lib/talks';
+
+const ToastWall = dynamic(() => import('@/components/talks/toast/ToastWall'), {
+  ssr: false,
+  loading: () => (
+    <p className="min-h-screen bg-black p-8 font-mono text-zinc-500">
+      Connecting…
+    </p>
+  ),
+});
+
+export async function getStaticPaths() {
+  return {
+    paths: getTalkSlugs().map((slug) => ({ params: { slug } })),
+    fallback: false,
+  };
+}
+
+export const getStaticProps: GetStaticProps<{ slug: string }> = async ({
+  params,
+}) => {
+  return { props: { slug: params?.slug as string } };
+};
+
+export default function WallPage({
+  slug,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  return (
+    <>
+      <Head>
+        <title>Toast wall</title>
+        <meta name="robots" content="noindex, nofollow" />
+      </Head>
+      {isConvexConfigured ? (
+        <ToastWall talkSlug={slug} />
+      ) : (
+        <p className="min-h-screen bg-black p-8 font-mono text-brutalist-pink">
+          [ Activity not configured. Set NEXT_PUBLIC_CONVEX_URL. ]
+        </p>
+      )}
+    </>
+  );
+}
+
+// Full-screen projector view — no site header/footer.
+WallPage.getLayout = (page: ReactElement) => page;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       preact:
         specifier: ^10.29.3
         version: 10.29.3
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.7)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -4872,6 +4875,11 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: 19.2.7
 
   qs@6.14.1:
     resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
@@ -10752,6 +10760,10 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  qrcode.react@4.2.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   qs@6.14.1:
     dependencies:


### PR DESCRIPTION
## Summary

The audience "how to make toast" activity for the careers talk — students submit ordered steps from their phones; submissions stream live to a projected wall, with a presenter moderation screen and a 5s reveal buffer.

**Stacked on #7 (talks).** Convex comes from main (#12, merged); this branch adds **only the frontend**, so the diff here is just the activity UI.

## What's included
- `components/talks/ActivityQR.tsx` — join QR (`qrcode.react`)
- `components/talks/toast/*` — form, projected wall, presenter moderation
- `pages/talks/[slug]/activity/{index,wall,manage}.tsx`
- `ActivityQR` registered in `MDXComponents`

The Convex backend (`convex/toast.ts`, schema, profanity helper) and the `react`→19.2.7 override (dedupes Spectacle's transitive react@18 so Convex SSR works) are inherited from the base.

## Verified
- Build green with Convex configured (activity/wall/manage prerender; `react@18` = 0); lint clean
- Two-tab realtime proven against the live deployment (wall updates ~5s after submit)

## Merge order
After #7 (talks) → main. Once #7 merges, retarget this to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)