### PR TITLE
feat: pseudo-anonymous live presence (machine-ID de-duped)

### DIFF
--- a/components/MDXComponents.tsx
+++ b/components/MDXComponents.tsx
@@ -9,6 +9,7 @@ import Image from './Image';
 import CustomLink from './Link';
 import NoteBlock from './NoteBlock';
 import Pre from './Pre';
+import TalkStatsChart from './TalkStatsChart';
 import TOCInline from './TOCInline';
 
 const Wrapper: React.ComponentType<{ layout: string }> = ({
@@ -24,6 +25,7 @@ export const MDXComponents: MDXComponentsType = {
   TOCInline,
   Diagram,
   NoteBlock,
+  TalkStatsChart,
   a: CustomLink,
   pre: Pre,
   wrapper: Wrapper,

--- a/components/PresenceBadge.tsx
+++ b/components/PresenceBadge.tsx
@@ -1,0 +1,26 @@
+import { isConvexConfigured } from '@/lib/convexClient';
+import { usePresence } from '@/lib/usePresence';
+
+function LivePresence({ room }: { room: string }) {
+  const count = usePresence(room);
+  const label = count === 1 ? 'person' : 'people';
+  return (
+    <span className="inline-flex items-center gap-2 font-mono text-sm uppercase text-brutalist-cyan">
+      <span
+        className="inline-block h-2 w-2 animate-pulse rounded-full bg-brutalist-cyan"
+        aria-hidden
+      />
+      👥 {count ?? '—'} {label} here
+    </span>
+  );
+}
+
+/**
+ * Live, de-duplicated presence count for a room. Self-guarding: renders nothing
+ * when Convex isn't configured (so it's safe to drop into any page), and only
+ * mounts the heartbeat/query when the provider is present.
+ */
+export default function PresenceBadge({ room }: { room: string }) {
+  if (!isConvexConfigured) return null;
+  return <LivePresence room={room} />;
+}

--- a/components/PresenceBadge.tsx
+++ b/components/PresenceBadge.tsx
@@ -1,24 +1,69 @@
+import { useEffect, useRef, useState } from 'react';
 import { isConvexConfigured } from '@/lib/convexClient';
 import { usePresence } from '@/lib/usePresence';
 
+const TOAST_MS = 4000;
+
 function LivePresence({ room }: { room: string }) {
-  const count = usePresence(room);
+  const { count, joins } = usePresence(room);
   const label = count === 1 ? 'person' : 'people';
+
+  // One-shot join toasts. On first feed we "prime" — mark everything already
+  // present as seen (so we never toast pre-existing attendees or our own join).
+  // After that, each new id toasts exactly once; a machine returning after its
+  // TTL is already known server-side, so it never reappears here.
+  const seen = useRef<Set<string>>(new Set());
+  const primed = useRef(false);
+  const [toasts, setToasts] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!joins) return;
+    if (!primed.current) {
+      for (const j of joins) seen.current.add(j.id);
+      primed.current = true;
+      return;
+    }
+    const fresh = joins.filter((j) => !seen.current.has(j.id));
+    if (fresh.length === 0) return;
+    for (const j of fresh) seen.current.add(j.id);
+    const ids = fresh.map((j) => j.id);
+    setToasts((t) => [...t, ...ids]);
+    setTimeout(() => {
+      setToasts((t) => t.filter((id) => !ids.includes(id)));
+    }, TOAST_MS);
+  }, [joins]);
+
   return (
-    <span className="inline-flex items-center gap-2 font-mono text-sm uppercase text-brutalist-cyan">
-      <span
-        className="inline-block h-2 w-2 animate-pulse rounded-full bg-brutalist-cyan"
-        aria-hidden
-      />
-      👥 {count ?? '—'} {label} here
-    </span>
+    <>
+      <span className="inline-flex items-center gap-2 font-mono text-sm uppercase text-brutalist-cyan">
+        <span
+          className="inline-block h-2 w-2 animate-pulse rounded-full bg-brutalist-cyan"
+          aria-hidden
+        />
+        👥 {count ?? '—'} {label} here
+      </span>
+
+      {toasts.length > 0 && (
+        <div className="fixed right-4 bottom-4 z-50 flex flex-col gap-2">
+          {toasts.map((id) => (
+            <div
+              key={id}
+              aria-live="polite"
+              className="border-2 border-white bg-brutalist-cyan px-4 py-2 font-mono text-sm font-bold uppercase text-black shadow-hard-md"
+            >
+              👋 Someone joined{count ? ` · ${count} here` : ''}
+            </div>
+          ))}
+        </div>
+      )}
+    </>
   );
 }
 
 /**
- * Live, de-duplicated presence count for a room. Self-guarding: renders nothing
- * when Convex isn't configured (so it's safe to drop into any page), and only
- * mounts the heartbeat/query when the provider is present.
+ * Live, de-duplicated presence for a room: an inline "👥 N here" badge plus a
+ * one-shot toast when a *new* machine joins. Self-guarding — renders nothing
+ * when Convex is unconfigured, so it's safe to drop into any page.
  */
 export default function PresenceBadge({ room }: { room: string }) {
   if (!isConvexConfigured) return null;

--- a/components/Reactions.tsx
+++ b/components/Reactions.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from 'react';
+import { isConvexConfigured } from '@/lib/convexClient';
+import { useReactions } from '@/lib/useReactions';
+
+// Mirrors the server allow-list (convex/reactions.ts). Kept here so the client
+// bundle doesn't import server code.
+const EMOJIS = ['👍', '❤️', '😂', '🎉', '👏', '🔥'];
+const MAX_BUBBLES_PER_BATCH = 12;
+
+interface Bubble {
+  key: string;
+  emoji: string;
+  left: number;
+  delay: number;
+}
+
+function LiveReactions({ room }: { room: string }) {
+  const { recent, react } = useReactions(room);
+  const seen = useRef<Set<string>>(new Set());
+  const primed = useRef(false);
+  const [bubbles, setBubbles] = useState<Bubble[]>([]);
+
+  useEffect(() => {
+    if (!recent) return;
+    if (!primed.current) {
+      for (const r of recent) seen.current.add(r.id);
+      primed.current = true;
+      return;
+    }
+    const fresh = recent.filter((r) => !seen.current.has(r.id));
+    if (fresh.length === 0) return;
+
+    const spawned: Bubble[] = [];
+    for (const r of fresh) {
+      seen.current.add(r.id);
+      const n = Math.min(r.count, MAX_BUBBLES_PER_BATCH);
+      for (let i = 0; i < n; i++) {
+        spawned.push({
+          key: `${r.id}-${i}`,
+          emoji: r.emoji,
+          left: Math.random() * 80,
+          delay: i * 120,
+        });
+      }
+    }
+    setBubbles((b) => [...b, ...spawned]);
+    const keys = new Set(spawned.map((s) => s.key));
+    setTimeout(() => {
+      setBubbles((b) => b.filter((x) => !keys.has(x.key)));
+    }, 4000);
+  }, [recent]);
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2">
+        {EMOJIS.map((emoji) => (
+          <button
+            key={emoji}
+            type="button"
+            onClick={() => react(emoji)}
+            aria-label={`React ${emoji}`}
+            className="border-2 border-white bg-zinc-900 px-3 py-2 text-xl transition-transform hover:bg-zinc-800 active:translate-y-0.5"
+          >
+            {emoji}
+          </button>
+        ))}
+      </div>
+
+      {/* Floating reactions — bottom-right 20% of the viewport. */}
+      <div className="reaction-stream pointer-events-none fixed right-0 bottom-0 z-40 h-[45vh] w-[20vw] overflow-hidden">
+        {bubbles.map((b) => (
+          <span
+            key={b.key}
+            className="reaction-bubble absolute bottom-0"
+            style={{ left: `${b.left}%`, animationDelay: `${b.delay}ms` }}
+          >
+            {b.emoji}
+          </span>
+        ))}
+      </div>
+    </>
+  );
+}
+
+/**
+ * Emoji reaction bar + floating-bubble stream for a room. Taps are debounced
+ * per user (see useReactions) and validated against an allow-list server-side.
+ * Self-guarding — renders nothing without Convex.
+ */
+export default function Reactions({ room }: { room: string }) {
+  if (!isConvexConfigured) return null;
+  return <LiveReactions room={room} />;
+}

--- a/components/TalkStatsChart.tsx
+++ b/components/TalkStatsChart.tsx
@@ -1,0 +1,81 @@
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { isConvexConfigured } from '@/lib/convexClient';
+
+function Chart({ room }: { room: string }) {
+  const stats = useQuery(api.talks.stats, { room });
+
+  if (stats === undefined) {
+    return <p className="font-mono text-zinc-400">Tallying…</p>;
+  }
+
+  const max = Math.max(1, ...stats.reactions.map((r) => r.total));
+
+  return (
+    <div className="border-2 border-white bg-zinc-900 p-6">
+      <div className="mb-6 flex flex-wrap gap-x-10 gap-y-2 font-mono">
+        <div>
+          <div className="font-display text-5xl font-bold text-brutalist-cyan">
+            {stats.totalReactions}
+          </div>
+          <div className="text-xs uppercase text-zinc-400">reactions</div>
+        </div>
+        <div>
+          <div className="font-display text-5xl font-bold text-brutalist-yellow">
+            {stats.attendees}
+          </div>
+          <div className="text-xs uppercase text-zinc-400">people joined</div>
+        </div>
+      </div>
+
+      {stats.reactions.length === 0 ? (
+        <p className="font-mono text-sm text-zinc-500">
+          No reactions yet — tap some emojis!
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {stats.reactions.map((r) => (
+            <div key={r.emoji} className="flex items-center gap-3">
+              <span className="w-8 text-2xl">{r.emoji}</span>
+              <div className="h-6 flex-1 border-2 border-white bg-black">
+                <div
+                  className="h-full bg-brutalist-cyan transition-all duration-500"
+                  style={{ width: `${(r.total / max) * 100}%` }}
+                />
+              </div>
+              <span className="w-12 text-right font-mono font-bold text-white">
+                {r.total}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Resolver({ room }: { room?: string }) {
+  const current = useQuery(api.talks.current, room ? 'skip' : {});
+  const resolved = room ?? current?.room;
+
+  if (!room && current === undefined) {
+    return <p className="font-mono text-zinc-400">Tallying…</p>;
+  }
+  if (!resolved) {
+    return (
+      <p className="font-mono text-sm text-zinc-500">No live talk to chart.</p>
+    );
+  }
+  return <Chart room={resolved} />;
+}
+
+/**
+ * Closing stats for a talk: a live bar chart of reaction totals plus headline
+ * counts. With no `room` it resolves the currently-live talk — so as the deck's
+ * final slide it auto-charts whichever run is on (each of the day's 3 talks is
+ * its own session). Self-guarding without Convex.
+ */
+export default function TalkStatsChart({ room }: { room?: string }) {
+  if (!isConvexConfigured) return null;
+  return <Resolver room={room} />;
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as crons from "../crons.js";
 import type * as hello from "../hello.js";
 import type * as lib_profanity from "../lib/profanity.js";
 import type * as presence from "../presence.js";
+import type * as reactions from "../reactions.js";
 import type * as talks from "../talks.js";
 import type * as toast from "../toast.js";
 
@@ -26,6 +27,7 @@ declare const fullApi: ApiFromModules<{
   hello: typeof hello;
   "lib/profanity": typeof lib_profanity;
   presence: typeof presence;
+  reactions: typeof reactions;
   talks: typeof talks;
   toast: typeof toast;
 }>;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as crons from "../crons.js";
 import type * as hello from "../hello.js";
 import type * as lib_profanity from "../lib/profanity.js";
 import type * as presence from "../presence.js";
+import type * as talks from "../talks.js";
 import type * as toast from "../toast.js";
 
 import type {
@@ -25,6 +26,7 @@ declare const fullApi: ApiFromModules<{
   hello: typeof hello;
   "lib/profanity": typeof lib_profanity;
   presence: typeof presence;
+  talks: typeof talks;
   toast: typeof toast;
 }>;
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as hello from "../hello.js";
 import type * as lib_profanity from "../lib/profanity.js";
+import type * as presence from "../presence.js";
 import type * as toast from "../toast.js";
 
 import type {
@@ -21,6 +22,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   hello: typeof hello;
   "lib/profanity": typeof lib_profanity;
+  presence: typeof presence;
   toast: typeof toast;
 }>;
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import type * as crons from "../crons.js";
 import type * as hello from "../hello.js";
 import type * as lib_profanity from "../lib/profanity.js";
 import type * as presence from "../presence.js";
@@ -20,6 +21,7 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  crons: typeof crons;
   hello: typeof hello;
   "lib/profanity": typeof lib_profanity;
   presence: typeof presence;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,0 +1,15 @@
+import { cronJobs } from 'convex/server';
+import { internal } from './_generated/api';
+
+const crons = cronJobs();
+
+// Enforce the presence TTL server-side: prune machines that stopped pinging,
+// so the attachment count is correct even after everyone leaves a room.
+crons.interval(
+  'reap expired presence',
+  { minutes: 1 },
+  internal.presence.reapExpired,
+  {},
+);
+
+export default crons;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -12,4 +12,12 @@ crons.interval(
   {},
 );
 
+// Reactions are short-lived; sweep the leftovers.
+crons.interval(
+  'reap expired reactions',
+  { minutes: 1 },
+  internal.reactions.reapExpired,
+  {},
+);
+
 export default crons;

--- a/convex/presence.ts
+++ b/convex/presence.ts
@@ -1,20 +1,25 @@
 import { v } from 'convex/values';
-import { mutation, query } from './_generated/server';
+import { internalMutation, mutation, query } from './_generated/server';
 
-// A client is "present" if it has been seen within this window. Clients
-// heartbeat well inside it (see usePresence), so a few missed beats = gone.
-const WINDOW_MS = 30_000;
+// Presence TTL: a client counts as "here" only if it pinged within this window.
+// Clients heartbeat well inside it (see usePresence ~10s), so a couple of missed
+// pings drops them. The scheduled reaper (crons.ts) enforces the TTL server-side
+// so the count is correct even after a room empties out.
+export const TTL_MS = 30_000;
+// How long a first-seen join stays in the `recentJoins` feed for clients to toast.
+const JOIN_FEED_MS = 15_000;
 
 /**
- * Heartbeat: upsert this machine's presence in a room, and reap anyone in the
- * room who's gone stale. Reaping here (rather than on a timer) keeps the live
- * count accurate as long as *someone* is present — every beat prunes leavers.
+ * Heartbeat: continually ping last-seen for this machine in a room (pure upsert
+ * — expiry is handled by the TTL window in `count` and the scheduled reaper).
+ * The first time a machine is seen in a room it's also recorded in `attendees`,
+ * which makes it surface in `recentJoins` exactly once — a return after the TTL
+ * is already known, so it won't re-trigger.
  */
 export const heartbeat = mutation({
   args: { room: v.string(), machineId: v.string() },
   handler: async (ctx, { room, machineId }) => {
     const now = Date.now();
-
     const mine = await ctx.db
       .query('presence')
       .withIndex('by_room_machine', (q) =>
@@ -28,32 +33,71 @@ export const heartbeat = mutation({
       await ctx.db.insert('presence', { room, machineId, lastSeen: now });
     }
 
-    // Reap stale rows for this room.
-    const stale = await ctx.db
-      .query('presence')
-      .withIndex('by_room_lastSeen', (q) =>
-        q.eq('room', room).lt('lastSeen', now - WINDOW_MS),
+    // First-ever sighting in this room → record it (drives the one-time toast).
+    const known = await ctx.db
+      .query('attendees')
+      .withIndex('by_room_machine', (q) =>
+        q.eq('room', room).eq('machineId', machineId),
       )
-      .collect();
-    await Promise.all(stale.map((row) => ctx.db.delete(row._id)));
+      .unique();
+    if (!known) {
+      await ctx.db.insert('attendees', { room, machineId, firstSeen: now });
+    }
   },
 });
 
 /**
- * Live count of distinct machines present in a room. One row per machineId, so
- * the row count *is* the de-duplicated head-count. Reactive: re-runs whenever
- * the presence table changes (i.e. on every heartbeat / reap).
+ * Recent first-time joins for a room (within the feed window), newest data via
+ * reactive updates. Clients toast each id they haven't shown yet. Intentionally
+ * anonymous — just an id + timestamp, no machineId leaves the server.
+ */
+export const recentJoins = query({
+  args: { room: v.string() },
+  handler: async (ctx, { room }) => {
+    const cutoff = Date.now() - JOIN_FEED_MS;
+    const joins = await ctx.db
+      .query('attendees')
+      .withIndex('by_room_firstSeen', (q) =>
+        q.eq('room', room).gt('firstSeen', cutoff),
+      )
+      .collect();
+    return joins.map((j) => ({ id: j._id, at: j.firstSeen }));
+  },
+});
+
+/**
+ * Live, de-duplicated attachment count for a room: machines whose last ping is
+ * within the TTL. One row per machineId, so the row count *is* the head-count.
+ * Reactive — re-runs on every heartbeat / reap, so it stays current as the talk
+ * runs and decrements as people leave.
  */
 export const count = query({
   args: { room: v.string() },
   handler: async (ctx, { room }) => {
-    const cutoff = Date.now() - WINDOW_MS;
-    const live = await ctx.db
+    const cutoff = Date.now() - TTL_MS;
+    const here = await ctx.db
       .query('presence')
       .withIndex('by_room_lastSeen', (q) =>
         q.eq('room', room).gt('lastSeen', cutoff),
       )
       .collect();
-    return live.length;
+    return here.length;
+  },
+});
+
+/**
+ * Scheduled (crons.ts) TTL reaper: delete every presence row whose last ping is
+ * older than the TTL, across all rooms. Keeps the table bounded and enforces
+ * expiry independent of any client still heartbeating.
+ */
+export const reapExpired = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const cutoff = Date.now() - TTL_MS;
+    const expired = await ctx.db
+      .query('presence')
+      .withIndex('by_lastSeen', (q) => q.lt('lastSeen', cutoff))
+      .collect();
+    await Promise.all(expired.map((row) => ctx.db.delete(row._id)));
   },
 });

--- a/convex/presence.ts
+++ b/convex/presence.ts
@@ -1,0 +1,59 @@
+import { v } from 'convex/values';
+import { mutation, query } from './_generated/server';
+
+// A client is "present" if it has been seen within this window. Clients
+// heartbeat well inside it (see usePresence), so a few missed beats = gone.
+const WINDOW_MS = 30_000;
+
+/**
+ * Heartbeat: upsert this machine's presence in a room, and reap anyone in the
+ * room who's gone stale. Reaping here (rather than on a timer) keeps the live
+ * count accurate as long as *someone* is present — every beat prunes leavers.
+ */
+export const heartbeat = mutation({
+  args: { room: v.string(), machineId: v.string() },
+  handler: async (ctx, { room, machineId }) => {
+    const now = Date.now();
+
+    const mine = await ctx.db
+      .query('presence')
+      .withIndex('by_room_machine', (q) =>
+        q.eq('room', room).eq('machineId', machineId),
+      )
+      .unique();
+
+    if (mine) {
+      await ctx.db.patch(mine._id, { lastSeen: now });
+    } else {
+      await ctx.db.insert('presence', { room, machineId, lastSeen: now });
+    }
+
+    // Reap stale rows for this room.
+    const stale = await ctx.db
+      .query('presence')
+      .withIndex('by_room_lastSeen', (q) =>
+        q.eq('room', room).lt('lastSeen', now - WINDOW_MS),
+      )
+      .collect();
+    await Promise.all(stale.map((row) => ctx.db.delete(row._id)));
+  },
+});
+
+/**
+ * Live count of distinct machines present in a room. One row per machineId, so
+ * the row count *is* the de-duplicated head-count. Reactive: re-runs whenever
+ * the presence table changes (i.e. on every heartbeat / reap).
+ */
+export const count = query({
+  args: { room: v.string() },
+  handler: async (ctx, { room }) => {
+    const cutoff = Date.now() - WINDOW_MS;
+    const live = await ctx.db
+      .query('presence')
+      .withIndex('by_room_lastSeen', (q) =>
+        q.eq('room', room).gt('lastSeen', cutoff),
+      )
+      .collect();
+    return live.length;
+  },
+});

--- a/convex/reactions.ts
+++ b/convex/reactions.ts
@@ -17,6 +17,17 @@ export const send = mutation({
     if (!ALLOWED.has(emoji)) return; // silently drop anything off the allow-list
     const n = Math.min(Math.max(Math.floor(count), 1), 20);
     await ctx.db.insert('reactions', { room, emoji, count: n, at: Date.now() });
+
+    // Accumulate the persistent tally for the closing stats chart.
+    const tally = await ctx.db
+      .query('reactionTotals')
+      .withIndex('by_room_emoji', (q) => q.eq('room', room).eq('emoji', emoji))
+      .unique();
+    if (tally) {
+      await ctx.db.patch(tally._id, { total: tally.total + n });
+    } else {
+      await ctx.db.insert('reactionTotals', { room, emoji, total: n });
+    }
   },
 });
 

--- a/convex/reactions.ts
+++ b/convex/reactions.ts
@@ -1,0 +1,47 @@
+import { v } from 'convex/values';
+import { internalMutation, mutation, query } from './_generated/server';
+
+// Reactions only need to live long enough to animate on screen.
+const FEED_MS = 6_000;
+
+// Allow-list of basic, non-offensive emojis. Anything else is rejected so the
+// stream can't be used to push arbitrary/unpleasant content.
+const ALLOWED = new Set(['👍', '❤️', '😂', '🎉', '👏', '🔥']);
+
+export const ALLOWED_EMOJIS = ['👍', '❤️', '😂', '🎉', '👏', '🔥'];
+
+/** Send a batch of one emoji (count = debounced taps). Validated against the allow-list. */
+export const send = mutation({
+  args: { room: v.string(), emoji: v.string(), count: v.number() },
+  handler: async (ctx, { room, emoji, count }) => {
+    if (!ALLOWED.has(emoji)) return; // silently drop anything off the allow-list
+    const n = Math.min(Math.max(Math.floor(count), 1), 20);
+    await ctx.db.insert('reactions', { room, emoji, count: n, at: Date.now() });
+  },
+});
+
+/** Recent reactions for a room — clients animate `count` bubbles per row. */
+export const recent = query({
+  args: { room: v.string() },
+  handler: async (ctx, { room }) => {
+    const cutoff = Date.now() - FEED_MS;
+    const rows = await ctx.db
+      .query('reactions')
+      .withIndex('by_room_at', (q) => q.eq('room', room).gt('at', cutoff))
+      .collect();
+    return rows.map((r) => ({ id: r._id, emoji: r.emoji, count: r.count }));
+  },
+});
+
+/** Scheduled (crons.ts): drop reactions past the feed window. */
+export const reapExpired = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const cutoff = Date.now() - FEED_MS;
+    // Ephemeral + tiny (a few seconds of reactions) — a full scan is fine.
+    const all = await ctx.db.query('reactions').collect();
+    await Promise.all(
+      all.filter((r) => r.at < cutoff).map((r) => ctx.db.delete(r._id)),
+    );
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -63,6 +63,16 @@ export default defineSchema({
     at: v.number(),
   }).index('by_room_at', ['room', 'at']),
 
+  // Persistent per-talk tally of reactions (the ephemeral `reactions` rows are
+  // reaped, so totals for the closing stats chart accumulate here instead).
+  reactionTotals: defineTable({
+    room: v.string(),
+    emoji: v.string(),
+    total: v.number(),
+  })
+    .index('by_room', ['room'])
+    .index('by_room_emoji', ['room', 'emoji']),
+
   toastSubmissions: defineTable({
     talkSlug: v.string(),
     nickname: v.optional(v.string()),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -8,6 +8,18 @@ import { v } from 'convex/values';
 // flipped to `revealed: true` by a scheduled function ~5s later — unless the
 // presenter has `hidden` it first.
 export default defineSchema({
+  // A live talk SESSION (distinct from the MDX talk content). The presenter
+  // "starts" one; audience joins whichever is currently `live` — that's the
+  // abstraction that lets presence/chat attach to "the current talk" without
+  // anyone needing a room id. Each start is a fresh session (its _id is the room).
+  talks: defineTable({
+    slug: v.string(),
+    title: v.string(),
+    status: v.union(v.literal('live'), v.literal('ended')),
+    startedAt: v.number(),
+    endedAt: v.optional(v.number()),
+  }).index('by_status', ['status']),
+
   // Minimal "hello world" example: a single named counter, bumped by anyone,
   // streamed live to every connected client. See convex/hello.ts.
   counters: defineTable({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -54,6 +54,15 @@ export default defineSchema({
     .index('by_room_machine', ['room', 'machineId'])
     .index('by_room_firstSeen', ['room', 'firstSeen']),
 
+  // Ephemeral emoji reactions that float up on screen. A `count` lets a client
+  // debounce rapid taps into one row. Reaped on a short window by the cron.
+  reactions: defineTable({
+    room: v.string(),
+    emoji: v.string(),
+    count: v.number(),
+    at: v.number(),
+  }).index('by_room_at', ['room', 'at']),
+
   toastSubmissions: defineTable({
     talkSlug: v.string(),
     nickname: v.optional(v.string()),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -15,6 +15,19 @@ export default defineSchema({
     count: v.number(),
   }).index('by_name', ['name']),
 
+  // Pseudo-anonymous presence: one row per (room, machineId), refreshed by a
+  // client heartbeat. `machineId` is a random UUID the browser keeps in
+  // localStorage — no PII, and it de-duplicates a browser's tabs/reloads.
+  // Rows older than the liveness window are reaped on heartbeat. See
+  // convex/presence.ts.
+  presence: defineTable({
+    room: v.string(),
+    machineId: v.string(),
+    lastSeen: v.number(),
+  })
+    .index('by_room_lastSeen', ['room', 'lastSeen'])
+    .index('by_room_machine', ['room', 'machineId']),
+
   toastSubmissions: defineTable({
     talkSlug: v.string(),
     nickname: v.optional(v.string()),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -26,7 +26,21 @@ export default defineSchema({
     lastSeen: v.number(),
   })
     .index('by_room_lastSeen', ['room', 'lastSeen'])
-    .index('by_room_machine', ['room', 'machineId']),
+    .index('by_room_machine', ['room', 'machineId'])
+    // Global, room-agnostic range scan for the scheduled TTL reaper.
+    .index('by_lastSeen', ['lastSeen']),
+
+  // Persistent first-seen record per (room, machineId). Unlike `presence` this is
+  // never reaped — it's the memory that lets a machine fire a "joined" toast only
+  // the FIRST time it appears in a room. A machine that leaves (presence expires)
+  // and returns is already known here, so it doesn't re-trigger.
+  attendees: defineTable({
+    room: v.string(),
+    machineId: v.string(),
+    firstSeen: v.number(),
+  })
+    .index('by_room_machine', ['room', 'machineId'])
+    .index('by_room_firstSeen', ['room', 'firstSeen']),
 
   toastSubmissions: defineTable({
     talkSlug: v.string(),

--- a/convex/talks.ts
+++ b/convex/talks.ts
@@ -1,0 +1,71 @@
+import { v } from 'convex/values';
+import type { MutationCtx } from './_generated/server';
+import { mutation, query } from './_generated/server';
+
+// Presenter actions (start/end) are gated by the shared moderation secret,
+// stored in the Convex deployment env (the same MODERATION_KEY used elsewhere).
+function keyOk(key: string): boolean {
+  const expected = process.env.MODERATION_KEY;
+  return Boolean(expected) && key === expected;
+}
+
+async function endLiveTalks(ctx: MutationCtx): Promise<void> {
+  const live = await ctx.db
+    .query('talks')
+    .withIndex('by_status', (q) => q.eq('status', 'live'))
+    .collect();
+  await Promise.all(
+    live.map((t) =>
+      ctx.db.patch(t._id, { status: 'ended', endedAt: Date.now() }),
+    ),
+  );
+}
+
+/**
+ * The currently-live talk, or null. Public + reactive — this is the "easy to
+ * join" entry point: a client just asks for the current talk and attaches
+ * presence/chat to its id. The `room` is the talk's _id, so every start is a
+ * clean session.
+ */
+export const current = query({
+  args: {},
+  handler: async (ctx) => {
+    const live = await ctx.db
+      .query('talks')
+      .withIndex('by_status', (q) => q.eq('status', 'live'))
+      .order('desc')
+      .first();
+    if (!live) return null;
+    return {
+      room: live._id,
+      slug: live.slug,
+      title: live.title,
+      startedAt: live.startedAt,
+    };
+  },
+});
+
+/** Presenter: start a talk (ends any currently-live one first). */
+export const start = mutation({
+  args: { slug: v.string(), title: v.string(), key: v.string() },
+  handler: async (ctx, { slug, title, key }) => {
+    if (!keyOk(key)) throw new Error('Unauthorized: invalid moderation key.');
+    await endLiveTalks(ctx);
+    const id = await ctx.db.insert('talks', {
+      slug,
+      title,
+      status: 'live',
+      startedAt: Date.now(),
+    });
+    return { room: id };
+  },
+});
+
+/** Presenter: end the current talk. */
+export const end = mutation({
+  args: { key: v.string() },
+  handler: async (ctx, { key }) => {
+    if (!keyOk(key)) throw new Error('Unauthorized: invalid moderation key.');
+    await endLiveTalks(ctx);
+  },
+});

--- a/convex/talks.ts
+++ b/convex/talks.ts
@@ -45,6 +45,31 @@ export const current = query({
   },
 });
 
+/**
+ * Aggregated stats for a talk room — for the closing chart. Reactive, so the
+ * chart animates as reactions land right up to the final slide.
+ */
+export const stats = query({
+  args: { room: v.string() },
+  handler: async (ctx, { room }) => {
+    const tallies = await ctx.db
+      .query('reactionTotals')
+      .withIndex('by_room', (q) => q.eq('room', room))
+      .collect();
+    const reactions = tallies
+      .map((t) => ({ emoji: t.emoji, total: t.total }))
+      .sort((a, b) => b.total - a.total);
+    const totalReactions = reactions.reduce((sum, r) => sum + r.total, 0);
+
+    const attendeeRows = await ctx.db
+      .query('attendees')
+      .withIndex('by_room_firstSeen', (q) => q.eq('room', room))
+      .collect();
+
+    return { reactions, totalReactions, attendees: attendeeRows.length };
+  },
+});
+
 /** Presenter: start a talk (ends any currently-live one first). */
 export const start = mutation({
   args: { slug: v.string(), title: v.string(), key: v.string() },

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -199,3 +199,25 @@ html {
     font-weight: normal;
   }
 }
+
+/* Floating emoji reactions (see components/Reactions.tsx) */
+@keyframes reaction-float {
+  0% {
+    transform: translateY(0) scale(0.8);
+    opacity: 0;
+  }
+  12% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-42vh) scale(1.5);
+    opacity: 0;
+  }
+}
+
+.reaction-bubble {
+  font-size: 1.75rem;
+  line-height: 1;
+  animation: reaction-float 3.4s ease-out forwards;
+  will-change: transform, opacity;
+}

--- a/lib/usePresence.ts
+++ b/lib/usePresence.ts
@@ -1,0 +1,54 @@
+import { useMutation, useQuery } from 'convex/react';
+import { useEffect } from 'react';
+import { api } from '@/convex/_generated/api';
+
+const STORAGE_KEY = 'rk:machine-id';
+const HEARTBEAT_MS = 10_000;
+
+/**
+ * Pseudo-anonymous machine id: a random UUID kept in localStorage. No PII, not a
+ * real hardware id — it just de-duplicates this browser profile's tabs/reloads.
+ * Falls back to a per-session id if storage is unavailable (private mode etc.).
+ */
+function getMachineId(): string {
+  try {
+    let id = localStorage.getItem(STORAGE_KEY);
+    if (!id) {
+      id = crypto.randomUUID();
+      localStorage.setItem(STORAGE_KEY, id);
+    }
+    return id;
+  } catch {
+    return `ephemeral-${crypto.randomUUID()}`;
+  }
+}
+
+/**
+ * Heartbeat into a presence room and subscribe to its live, de-duplicated
+ * head-count. Only call this where ConvexProvider is mounted (i.e. behind an
+ * `isConvexConfigured` guard) — see PresenceBadge.
+ */
+export function usePresence(room: string): number | undefined {
+  const heartbeat = useMutation(api.presence.heartbeat);
+  const count = useQuery(api.presence.count, { room });
+
+  useEffect(() => {
+    const machineId = getMachineId();
+    const beat = () => {
+      void heartbeat({ room, machineId });
+    };
+    beat();
+    const interval = setInterval(beat, HEARTBEAT_MS);
+    // Beat again when the tab regains focus so a re-opened laptop counts fast.
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') beat();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [room, heartbeat]);
+
+  return count;
+}

--- a/lib/usePresence.ts
+++ b/lib/usePresence.ts
@@ -23,14 +23,23 @@ function getMachineId(): string {
   }
 }
 
+export interface PresenceState {
+  /** Live, de-duplicated count of machines currently present. */
+  count: number | undefined;
+  /** First-time joins in the recent window — for one-shot "joined" toasts. */
+  joins: { id: string; at: number }[] | undefined;
+}
+
 /**
- * Heartbeat into a presence room and subscribe to its live, de-duplicated
- * head-count. Only call this where ConvexProvider is mounted (i.e. behind an
- * `isConvexConfigured` guard) — see PresenceBadge.
+ * Heartbeat into a presence room and subscribe to its live head-count plus the
+ * recent first-join feed. One heartbeat per caller — render a single <Presence>
+ * per room. Only call where ConvexProvider is mounted (behind an
+ * `isConvexConfigured` guard).
  */
-export function usePresence(room: string): number | undefined {
+export function usePresence(room: string): PresenceState {
   const heartbeat = useMutation(api.presence.heartbeat);
   const count = useQuery(api.presence.count, { room });
+  const joins = useQuery(api.presence.recentJoins, { room });
 
   useEffect(() => {
     const machineId = getMachineId();
@@ -50,5 +59,5 @@ export function usePresence(room: string): number | undefined {
     };
   }, [room, heartbeat]);
 
-  return count;
+  return { count, joins };
 }

--- a/lib/useReactions.ts
+++ b/lib/useReactions.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQuery } from 'convex/react';
+import { useCallback, useEffect, useRef } from 'react';
+import { api } from '@/convex/_generated/api';
+
+// Batch this user's rapid taps: accumulate per-emoji counts and flush one
+// mutation per emoji after a short idle gap. Keeps spam off the wire while
+// still preserving "I tapped 8 times" as a single count=8 row.
+const DEBOUNCE_MS = 600;
+
+export interface ReactionsState {
+  recent: { id: string; emoji: string; count: number }[] | undefined;
+  react: (emoji: string) => void;
+}
+
+export function useReactions(room: string): ReactionsState {
+  const send = useMutation(api.reactions.send);
+  const recent = useQuery(api.reactions.recent, { room });
+  const pending = useRef<Map<string, number>>(new Map());
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const flush = useCallback(() => {
+    for (const [emoji, count] of pending.current) {
+      void send({ room, emoji, count });
+    }
+    pending.current.clear();
+    timer.current = null;
+  }, [room, send]);
+
+  const react = useCallback(
+    (emoji: string) => {
+      pending.current.set(emoji, (pending.current.get(emoji) ?? 0) + 1);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(flush, DEBOUNCE_MS);
+    },
+    [flush],
+  );
+
+  // Flush anything pending on unmount so a quick tap-then-leave still lands.
+  useEffect(() => {
+    return () => {
+      if (timer.current) {
+        clearTimeout(timer.current);
+        flush();
+      }
+    };
+  }, [flush]);
+
+  return { recent, react };
+}

--- a/pages/convex-hello.tsx
+++ b/pages/convex-hello.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQuery } from 'convex/react';
+import PresenceBadge from '@/components/PresenceBadge';
 import { PageSEO } from '@/components/SEO';
 import { api } from '@/convex/_generated/api';
 import siteMetadata from '@/data/siteMetadata';
@@ -57,10 +58,13 @@ export default function ConvexHello() {
         <h1 className="mb-2 font-display text-4xl font-bold uppercase text-white">
           [ Convex Hello World ]
         </h1>
-        <p className="mb-8 font-mono text-sm text-zinc-400">
+        <p className="mb-4 font-mono text-sm text-zinc-400">
           <span className="text-brutalist-yellow">&gt;</span> A reactive query +
           a mutation. Open this page in two tabs and click — both update live.
         </p>
+        <div className="mb-8">
+          <PresenceBadge room="convex-hello" />
+        </div>
         {isConvexConfigured ? <LiveHello /> : <NotConfigured />}
       </article>
     </>

--- a/pages/convex-hello.tsx
+++ b/pages/convex-hello.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from 'convex/react';
 import PresenceBadge from '@/components/PresenceBadge';
+import Reactions from '@/components/Reactions';
 import { PageSEO } from '@/components/SEO';
 import { api } from '@/convex/_generated/api';
 import siteMetadata from '@/data/siteMetadata';
@@ -62,8 +63,11 @@ export default function ConvexHello() {
           <span className="text-brutalist-yellow">&gt;</span> A reactive query +
           a mutation. Open this page in two tabs and click — both update live.
         </p>
-        <div className="mb-8">
+        <div className="mb-4">
           <PresenceBadge room="convex-hello" />
+        </div>
+        <div className="mb-8">
+          <Reactions room="convex-hello" />
         </div>
         {isConvexConfigured ? <LiveHello /> : <NotConfigured />}
       </article>

--- a/pages/live/index.tsx
+++ b/pages/live/index.tsx
@@ -2,6 +2,7 @@ import { useQuery } from 'convex/react';
 import PresenceBadge from '@/components/PresenceBadge';
 import Reactions from '@/components/Reactions';
 import { PageSEO } from '@/components/SEO';
+import TalkStatsChart from '@/components/TalkStatsChart';
 import { api } from '@/convex/_generated/api';
 import siteMetadata from '@/data/siteMetadata';
 import { isConvexConfigured } from '@/lib/convexClient';
@@ -42,6 +43,10 @@ function LiveRoom() {
         React:
       </p>
       <Reactions room={talk.room} />
+      <p className="mt-8 mb-3 font-mono text-sm uppercase text-zinc-400">
+        This talk so far:
+      </p>
+      <TalkStatsChart room={talk.room} />
       <p className="mt-6 font-mono text-sm text-zinc-400">
         <span className="text-brutalist-yellow">&gt;</span> You're in. Keep this
         tab open to stay counted.

--- a/pages/live/index.tsx
+++ b/pages/live/index.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from 'convex/react';
 import PresenceBadge from '@/components/PresenceBadge';
+import Reactions from '@/components/Reactions';
 import { PageSEO } from '@/components/SEO';
 import { api } from '@/convex/_generated/api';
 import siteMetadata from '@/data/siteMetadata';
@@ -37,6 +38,10 @@ function LiveRoom() {
       <div className="mt-4">
         <PresenceBadge room={talk.room} />
       </div>
+      <p className="mt-6 mb-3 font-mono text-sm uppercase text-zinc-400">
+        React:
+      </p>
+      <Reactions room={talk.room} />
       <p className="mt-6 font-mono text-sm text-zinc-400">
         <span className="text-brutalist-yellow">&gt;</span> You're in. Keep this
         tab open to stay counted.

--- a/pages/live/index.tsx
+++ b/pages/live/index.tsx
@@ -1,0 +1,75 @@
+import { useQuery } from 'convex/react';
+import PresenceBadge from '@/components/PresenceBadge';
+import { PageSEO } from '@/components/SEO';
+import { api } from '@/convex/_generated/api';
+import siteMetadata from '@/data/siteMetadata';
+import { isConvexConfigured } from '@/lib/convexClient';
+
+function LiveRoom() {
+  const talk = useQuery(api.talks.current);
+
+  if (talk === undefined) {
+    return <p className="font-mono text-zinc-400">Connecting…</p>;
+  }
+
+  if (talk === null) {
+    return (
+      <div className="border-2 border-white bg-zinc-900 p-8">
+        <p className="font-display text-2xl font-bold uppercase text-white">
+          No talk is live right now
+        </p>
+        <p className="mt-3 font-mono text-sm text-zinc-400">
+          <span className="text-brutalist-yellow">&gt;</span> This page joins
+          whatever talk is running — check back when one starts.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-2 border-white bg-zinc-900 p-8">
+      <p className="font-mono text-sm uppercase text-brutalist-pink">
+        ● Live now
+      </p>
+      <h2 className="mt-2 font-display text-3xl font-bold uppercase text-white">
+        {talk.title}
+      </h2>
+      <div className="mt-4">
+        <PresenceBadge room={talk.room} />
+      </div>
+      <p className="mt-6 font-mono text-sm text-zinc-400">
+        <span className="text-brutalist-yellow">&gt;</span> You're in. Keep this
+        tab open to stay counted.
+      </p>
+    </div>
+  );
+}
+
+function NotConfigured() {
+  return (
+    <div className="border-2 border-brutalist-pink bg-zinc-900 p-8 font-mono text-sm text-gray-300">
+      Live talks aren't configured here (no Convex deployment).
+    </div>
+  );
+}
+
+export default function LivePage() {
+  return (
+    <>
+      <PageSEO
+        title={`Live - ${siteMetadata.author}`}
+        description="Join the talk that's running right now."
+      />
+      <article className="mx-auto max-w-2xl py-10">
+        <h1 className="mb-2 font-display text-4xl font-bold uppercase text-white">
+          [ Live ]
+        </h1>
+        <p className="mb-8 font-mono text-sm text-zinc-400">
+          <span className="text-brutalist-yellow">&gt;</span> Auto-joins the
+          current talk — no code or link needed.
+        </p>
+        {isConvexConfigured ? <LiveRoom /> : <NotConfigured />}
+      </article>
+    </>
+  );
+}

--- a/pages/live/manage.tsx
+++ b/pages/live/manage.tsx
@@ -1,0 +1,98 @@
+import { useMutation, useQuery } from 'convex/react';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { PageSEO } from '@/components/SEO';
+import { api } from '@/convex/_generated/api';
+import siteMetadata from '@/data/siteMetadata';
+import { isConvexConfigured } from '@/lib/convexClient';
+
+function Manage({ talkKey }: { talkKey: string }) {
+  const current = useQuery(api.talks.current);
+  const start = useMutation(api.talks.start);
+  const end = useMutation(api.talks.end);
+  const [slug, setSlug] = useState('so-you-want-to-build-software');
+  const [title, setTitle] = useState('So You Want To Build Software?');
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (fn: () => Promise<unknown>) => {
+    setError(null);
+    try {
+      await fn();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong');
+    }
+  };
+
+  return (
+    <div className="border-2 border-white bg-zinc-900 p-6 font-mono">
+      <p className="text-sm uppercase text-brutalist-cyan">
+        {current ? `● Live: ${current.title}` : 'Nothing live'}
+      </p>
+
+      <div className="mt-6 space-y-3">
+        <input
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          placeholder="talk slug"
+          className="w-full border-2 border-white bg-black px-3 py-2 text-white"
+        />
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="talk title"
+          className="w-full border-2 border-white bg-black px-3 py-2 text-white"
+        />
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={() => run(() => start({ slug, title, key: talkKey }))}
+            className="border-2 border-white bg-brutalist-cyan px-5 py-2 font-bold uppercase text-black shadow-hard-md"
+          >
+            Start talk
+          </button>
+          <button
+            type="button"
+            onClick={() => run(() => end({ key: talkKey }))}
+            disabled={!current}
+            className="border-2 border-white bg-brutalist-pink px-5 py-2 font-bold uppercase text-black shadow-hard-md disabled:opacity-50"
+          >
+            End talk
+          </button>
+        </div>
+      </div>
+
+      {error && <p className="mt-4 text-sm text-brutalist-pink">{error}</p>}
+    </div>
+  );
+}
+
+export default function LiveManagePage() {
+  const router = useRouter();
+  const talkKey = typeof router.query.key === 'string' ? router.query.key : '';
+
+  return (
+    <>
+      <PageSEO title={`Manage live - ${siteMetadata.author}`} description="" />
+      <article className="mx-auto max-w-2xl py-10">
+        <h1 className="mb-6 font-display text-3xl font-bold uppercase text-white">
+          [ Presenter ]
+        </h1>
+        {!isConvexConfigured ? (
+          <p className="font-mono text-brutalist-pink">
+            Convex not configured.
+          </p>
+        ) : !talkKey ? (
+          <p className="font-mono text-sm text-zinc-400">
+            Add{' '}
+            <code className="text-brutalist-cyan">
+              ?key=&lt;moderation key&gt;
+            </code>{' '}
+            to the URL to start/end talks.
+          </p>
+        ) : (
+          <Manage talkKey={talkKey} />
+        )}
+      </article>
+    </>
+  );
+}

--- a/pages/live/manage.tsx
+++ b/pages/live/manage.tsx
@@ -1,23 +1,37 @@
 import { useMutation, useQuery } from 'convex/react';
-import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { PageSEO } from '@/components/SEO';
 import { api } from '@/convex/_generated/api';
 import siteMetadata from '@/data/siteMetadata';
 import { isConvexConfigured } from '@/lib/convexClient';
 
-function Manage({ talkKey }: { talkKey: string }) {
+// Kept in sessionStorage (this tab only, cleared on close) rather than the URL —
+// so the moderation key is never shown in the address bar / projected screen or
+// left in browser history.
+const KEY_STORAGE = 'rk:moderation-key';
+
+function Manage() {
   const current = useQuery(api.talks.current);
   const start = useMutation(api.talks.start);
   const end = useMutation(api.talks.end);
+
+  const [talkKey, setTalkKey] = useState('');
   const [slug, setSlug] = useState('so-you-want-to-build-software');
   const [title, setTitle] = useState('So You Want To Build Software?');
   const [error, setError] = useState<string | null>(null);
+
+  // Restore a previously-entered key for this tab (survives refresh, not the URL).
+  useEffect(() => {
+    const saved = sessionStorage.getItem(KEY_STORAGE);
+    if (saved) setTalkKey(saved);
+  }, []);
 
   const run = async (fn: () => Promise<unknown>) => {
     setError(null);
     try {
       await fn();
+      // Only remember the key once it's proven to work (no error thrown).
+      sessionStorage.setItem(KEY_STORAGE, talkKey);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Something went wrong');
     }
@@ -29,7 +43,19 @@ function Manage({ talkKey }: { talkKey: string }) {
         {current ? `● Live: ${current.title}` : 'Nothing live'}
       </p>
 
-      <div className="mt-6 space-y-3">
+      <label className="mt-6 block text-xs uppercase text-zinc-400">
+        Moderation key
+        <input
+          type="password"
+          value={talkKey}
+          onChange={(e) => setTalkKey(e.target.value)}
+          placeholder="enter moderation key"
+          autoComplete="off"
+          className="mt-1 w-full border-2 border-white bg-black px-3 py-2 text-white"
+        />
+      </label>
+
+      <div className="mt-4 space-y-3">
         <input
           value={slug}
           onChange={(e) => setSlug(e.target.value)}
@@ -45,15 +71,16 @@ function Manage({ talkKey }: { talkKey: string }) {
         <div className="flex gap-3">
           <button
             type="button"
+            disabled={!talkKey}
             onClick={() => run(() => start({ slug, title, key: talkKey }))}
-            className="border-2 border-white bg-brutalist-cyan px-5 py-2 font-bold uppercase text-black shadow-hard-md"
+            className="border-2 border-white bg-brutalist-cyan px-5 py-2 font-bold uppercase text-black shadow-hard-md disabled:opacity-50"
           >
             Start talk
           </button>
           <button
             type="button"
+            disabled={!talkKey || !current}
             onClick={() => run(() => end({ key: talkKey }))}
-            disabled={!current}
             className="border-2 border-white bg-brutalist-pink px-5 py-2 font-bold uppercase text-black shadow-hard-md disabled:opacity-50"
           >
             End talk
@@ -67,9 +94,6 @@ function Manage({ talkKey }: { talkKey: string }) {
 }
 
 export default function LiveManagePage() {
-  const router = useRouter();
-  const talkKey = typeof router.query.key === 'string' ? router.query.key : '';
-
   return (
     <>
       <PageSEO title={`Manage live - ${siteMetadata.author}`} description="" />
@@ -77,20 +101,12 @@ export default function LiveManagePage() {
         <h1 className="mb-6 font-display text-3xl font-bold uppercase text-white">
           [ Presenter ]
         </h1>
-        {!isConvexConfigured ? (
+        {isConvexConfigured ? (
+          <Manage />
+        ) : (
           <p className="font-mono text-brutalist-pink">
             Convex not configured.
           </p>
-        ) : !talkKey ? (
-          <p className="font-mono text-sm text-zinc-400">
-            Add{' '}
-            <code className="text-brutalist-cyan">
-              ?key=&lt;moderation key&gt;
-            </code>{' '}
-            to the URL to start/end talks.
-          </p>
-        ) : (
-          <Manage talkKey={talkKey} />
         )}
       </article>
     </>


### PR DESCRIPTION
## Summary

A pseudo-anonymous **"who's here" presence count** for talks (and any page), built on the Convex/hello-world foundation. Shows how many people are connected, **de-duplicated by a machine ID, with no PII**.

## How it works
- **Machine ID** = a random `crypto.randomUUID()` kept in `localStorage` (`lib/usePresence`). No PII, not a real hardware id — it de-dupes a browser profile's tabs/reloads. (A true hardware id isn't available to a browser without invasive fingerprinting.)
- **Heartbeat** (`convex/presence.ts` `heartbeat`): every ~10s a client upserts `(room, machineId, lastSeen)` and reaps rows older than the 30s window — so leavers drop off as long as anyone's present.
- **Count** (`count` query): reactive; one row per machineId, so the row count *is* the de-duplicated head-count.
- **`<PresenceBadge room=… />`**: self-guarding ("👥 N people here"), renders nothing when Convex is unconfigured — drop it into any page (e.g. a talk's activity/wall).

Demoed on `/convex-hello`.

## Verified (agent-browser)
- Two separate browsers → **2**; the first updates live when the second joins.
- A **second tab in the same browser** stays at the same machine → count **does not** increment (de-dup proven).
- `tsc` clean, build green, lint clean.

## Notes
- De-dupes per **browser profile**, not per human (incognito / a different browser counts separately) — the right trade-off for a no-PII audience headcount.
- Standalone (off main); independent of the talks/toast PRs. Merging it auto-deploys the `presence` functions via the new Convex deploy workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)