### PR TITLE
docs: add agent skills docs and gitignore worktree scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ storybook-static
 
 # git worktrees (scratch state for parallel branches)
 .worktrees/
+.claude/worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,20 @@ workflow_dispatch → playwright.yml      # manual-only: regenerate Linux snapsh
 - Mixed JS/TS in data layer (`siteMetadata.js` vs `headerNavLinks.ts`)
 - Storybook uses Vite adapter (`@storybook/nextjs-vite`)
 
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live as local markdown under `.scratch/<feature-slug>/`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Uses the five canonical roles with default strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
 ---
 
 _See also: [components/AGENTS.md](./components/AGENTS.md), [lib/AGENTS.md](./lib/AGENTS.md), [tests/AGENTS.md](./tests/AGENTS.md)_

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,52 @@ pnpm typecheck            # tsc --noEmit
 pnpm format               # Biome format
 ```
 
+## BROWSER CONTROL (agent-browser)
+
+For anything that needs a **real, logged-in session** (auth-gated pages, or live
+WebSocket features), don't use a throwaway headless browser — it isn't signed in.
+
+### Preferred: a dedicated dev profile (`~/.agent-browser-profiles/dev`)
+
+agent-browser drives its **own** Chrome for Testing against a persistent profile
+you sign into once — isolated from your daily Chrome, so no attach banner, no
+input-hijacking, no tab drift.
+
+```bash
+# One-time: sign in (a headed window opens; complete the login there)
+agent-browser --profile ~/.agent-browser-profiles/dev --headed open http://localhost:3000
+
+# Thereafter (headless or headed) — the session persists:
+agent-browser --profile ~/.agent-browser-profiles/dev open <url>
+```
+
+Set `AGENT_BROWSER_PROFILE=~/.agent-browser-profiles/dev` to make it the default
+and drop the flag. Re-sign-in only when the session expires.
+
+### Fallback: `--auto-connect` to your daily Chrome (avoid)
+
+`--auto-connect` discovers a *running* Chrome (launched with
+`--remote-debugging-port=9222 --remote-allow-origins=*`; Chrome 111+ needs the
+latter or it silently rejects CDP) and reuses its cookies. It works, but driving
+your **primary** profile is fragile:
+
+- The live CDP attach shows an "allow remote debugging" state that can **hang and
+  block your clicks**. Recover with `pkill -f agent-browser` (drops the daemon),
+  or quit Chrome (`osascript -e 'quit app "Google Chrome"'`).
+- Background tabs get their `setInterval` **throttled**, so timer-driven code
+  (heartbeats/polling) stalls in inactive tabs (WebSocket queries still update).
+- Active-tab drift: you're using the browser, so the "active" target moves under
+  automation between calls.
+
+### Gotcha: keep the tab count low
+
+Each open tab holds its own WebSocket/connection. Piling up tabs can **exhaust
+the connection pool and wedge new pages on "Connecting…"**. Keep it to the
+minimum you're testing (e.g. one driver + one viewer) and close stale tabs.
+
+Concept ref: Chrome DevTools MCP —
+https://developer.chrome.com/blog/chrome-devtools-mcp-debug-your-browser-session
+
 ## BUILD PIPELINE
 
 ```

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This is a single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-some-decision.md
+│   └── 0002-another-decision.md
+└── ...
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,19 @@
+# Issue tracker: Local Markdown
+
+Issues and PRDs for this repo live as markdown files in `.scratch/`.
+
+## Conventions
+
+- One feature per directory: `.scratch/<feature-slug>/`
+- The PRD is `.scratch/<feature-slug>/PRD.md`
+- Implementation issues are `.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01`
+- Triage state is recorded as a `Status:` line near the top of each issue file (see `triage-labels.md` for the role strings)
+- Comments and conversation history append to the bottom of the file under a `## Comments` heading
+
+## When a skill says "publish to the issue tracker"
+
+Create a new file under `.scratch/<feature-slug>/` (creating the directory if needed).
+
+## When a skill says "fetch the relevant ticket"
+
+Read the file at the referenced path. The user will normally pass the path or the issue number directly.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,17 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Because issues live as local markdown (see `issue-tracker.md`), record the label as the `Status:` line near the top of each issue file.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## What

- Add `docs/agents/{domain,issue-tracker,triage-labels}.md` describing the local issue-tracker, triage-label conventions, and single-context domain docs.
- Reference them from a new **Agent skills** section in `AGENTS.md` (reconciled with the visual-regression/deps edits already on main).
- Gitignore `.claude/worktrees/` — git worktree scratch state was leaking into `git status` (the existing `.worktrees/` rule didn't cover the `.claude/` location).

## Why

Cleans up the pending state in the working tree: real docs get committed, and the scratch worktree directory stops showing as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)