### PR TITLE
fix(talks): port code-review fixes onto the live-talk platform

### DIFF
--- a/components/talks/SpectacleDeck.tsx
+++ b/components/talks/SpectacleDeck.tsx
@@ -20,6 +20,7 @@ import { brutalistTheme } from './theme';
 export interface DeckSlide {
   code: string;
   notes: string | null;
+  notesCode: string | null;
 }
 
 interface SpectacleDeckProps {
@@ -69,7 +70,11 @@ function renderSlides(slides: DeckSlide[]) {
   return slides.map((slide, i) => (
     <Slide key={i} backgroundColor="#000000">
       <SlideBody code={slide.code} />
-      {slide.notes ? <Notes>{slide.notes}</Notes> : null}
+      {slide.notesCode ? (
+        <Notes>
+          <SlideBody code={slide.notesCode} />
+        </Notes>
+      ) : null}
     </Slide>
   ));
 }

--- a/lib/mdx.ts
+++ b/lib/mdx.ts
@@ -87,7 +87,11 @@ export function getRehypePlugins(): Pluggable[] {
         visit(tree, 'element', (node: any) => {
           const [token, type] = node.properties.className || [];
           if (token === 'token') {
-            node.properties.className = [tokenClassNames[type]];
+            // Only remap tokens we have a brutalist class for; leaving the
+            // original className avoids emitting `[undefined]` (which strips
+            // the token's syntax color) for unmapped Prism token types.
+            const mapped = tokenClassNames[type];
+            if (mapped) node.properties.className = [mapped];
           }
         });
       };

--- a/lib/talks.ts
+++ b/lib/talks.ts
@@ -21,22 +21,50 @@ function resolveTalkFile(slug: string): string | null {
   return null;
 }
 
-export function getTalkSlugs(): string[] {
-  if (!fs.existsSync(talksPath)) return [];
-  const showDrafts = show_drafts();
-  return fs
-    .readdirSync(talksPath)
-    .filter((file) => /\.(mdx|md)$/.test(file))
-    .filter((file) => {
-      if (showDrafts) return true;
-      // Draft talks (e.g. the E2E debug deck) are only routable in debug mode
-      // (dev or SHOW_DRAFTS) — excluded from the production build entirely.
-      const { data } = matter(
-        fs.readFileSync(path.join(talksPath, file), 'utf8'),
-      );
-      return data.draft !== true;
-    })
-    .map((file) => file.replace(/\.(mdx|md)$/, ''));
+/**
+ * A talk is published unless it explicitly sets `draft: true`. Drafts are shown
+ * in development (SHOW_DRAFTS). Applied to slug enumeration, detail loading, and
+ * the listing so draft talks never leak into the production static build.
+ */
+function isPublished(frontmatter: { draft?: boolean }): boolean {
+  return frontmatter.draft !== true || show_drafts();
+}
+
+function normalizeFrontMatter(
+  data: TalkFrontMatter,
+  slug: string,
+): TalkFrontMatter {
+  return {
+    ...data,
+    slug,
+    date: data.date ? new Date(data.date).toISOString() : null,
+  };
+}
+
+/**
+ * Split a talk body (frontmatter already stripped) into slide chunks on lines
+ * that contain only `---`. Fenced code blocks (``` / ~~~) are tracked so a
+ * `---` line *inside* a code sample never splits a slide. Authors who want a
+ * horizontal rule within a single slide should use `***` or `___`.
+ */
+function splitSlides(content: string): string[] {
+  const chunks: string[][] = [[]];
+  let fence: string | null = null;
+
+  for (const line of content.split('\n')) {
+    const fenceMatch = line.match(/^\s*(```+|~~~+)/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1].startsWith('~') ? '~~~' : '```';
+      if (!fence) fence = marker;
+      else if (fence === marker) fence = null;
+    } else if (!fence && line.trim() === '---') {
+      chunks.push([]);
+      continue;
+    }
+    chunks[chunks.length - 1].push(line);
+  }
+
+  return chunks.map((chunk) => chunk.join('\n').trim()).filter(Boolean);
 }
 
 export function getAllTalksFrontMatter(): TalkFrontMatter[] {
@@ -47,17 +75,16 @@ export function getAllTalksFrontMatter(): TalkFrontMatter[] {
   for (const file of fs.readdirSync(talksPath)) {
     if (!/\.(mdx|md)$/.test(file)) continue;
 
-    const source = fs.readFileSync(path.join(talksPath, file), 'utf8');
-    const { data } = matter(source);
+    const { data } = matter(
+      fs.readFileSync(path.join(talksPath, file), 'utf8'),
+    );
     const frontmatter = data as TalkFrontMatter;
 
-    if (frontmatter.draft === true && !show_drafts()) continue;
+    if (!isPublished(frontmatter)) continue;
 
-    talks.push({
-      ...frontmatter,
-      slug: file.replace(/\.(mdx|md)$/, ''),
-      date: frontmatter.date ? new Date(frontmatter.date).toISOString() : null,
-    });
+    talks.push(
+      normalizeFrontMatter(frontmatter, file.replace(/\.(mdx|md)$/, '')),
+    );
   }
 
   return talks.sort((a, b) => {
@@ -65,6 +92,43 @@ export function getAllTalksFrontMatter(): TalkFrontMatter[] {
     const dateB = b.date ? new Date(b.date).getTime() : 0;
     return dateB - dateA;
   });
+}
+
+/**
+ * Published talk slugs only. Derived from getAllTalksFrontMatter so the draft
+ * filter lives in exactly one place (getStaticPaths must not enumerate drafts).
+ */
+export function getTalkSlugs(): string[] {
+  return getAllTalksFrontMatter().map((talk) => talk.slug);
+}
+
+/** Shared getStaticPaths body for the talk landing + present routes. */
+export function getTalkStaticPaths() {
+  return {
+    paths: getTalkSlugs().map((slug) => ({ params: { slug } })),
+    fallback: false as const,
+  };
+}
+
+/**
+ * Lightweight metadata (front matter + slide count) without compiling any MDX —
+ * used by the landing page, which only needs the count. Returns null for a
+ * missing or draft (in production) talk.
+ */
+export function getTalkMeta(
+  slug: string,
+): { frontMatter: TalkFrontMatter; slideCount: number } | null {
+  const filePath = resolveTalkFile(slug);
+  if (!filePath) return null;
+
+  const { data, content } = matter(fs.readFileSync(filePath, 'utf8'));
+  const frontmatter = data as TalkFrontMatter;
+  if (!isPublished(frontmatter)) return null;
+
+  return {
+    frontMatter: normalizeFrontMatter(frontmatter, slug),
+    slideCount: splitSlides(content).length,
+  };
 }
 
 /**
@@ -102,7 +166,13 @@ async function compileSlide(source: string): Promise<string> {
   return code;
 }
 
-export type TalkSlide = { code: string; notes: string | null };
+export type TalkSlide = {
+  code: string;
+  /** Raw notes markdown — a compact text preview in the presenter console. */
+  notes: string | null;
+  /** Compiled notes MDX — rendered (formatted) in Spectacle's presenter view. */
+  notesCode: string | null;
+};
 
 export async function getTalkBySlug(
   slug: string,
@@ -112,33 +182,28 @@ export async function getTalkBySlug(
 
   const { data, content } = matter(fs.readFileSync(filePath, 'utf8'));
   const frontmatter = data as TalkFrontMatter;
+  if (!isPublished(frontmatter)) return null;
 
-  // Draft talks are debug-only: unavailable unless dev / SHOW_DRAFTS.
-  if (frontmatter.draft === true && !show_drafts()) return null;
-
-  // Split the (frontmatter-stripped) body into individual slides on a line
-  // containing only `---`. Within a slide, an optional `???` line separates the
-  // slide body from speaker notes (shown in Spectacle's presenter mode).
-  const chunks = content
-    .split(/^---$/m)
-    .map((chunk) => chunk.trim())
-    .filter(Boolean);
+  // Split the (frontmatter-stripped) body into individual slides. Within a
+  // slide, an optional `???` line separates the slide body from speaker notes
+  // (shown in Spectacle's presenter mode). Both body and notes are compiled
+  // through the same MDX pipeline so formatting renders identically.
+  const chunks = splitSlides(content);
 
   const slides: TalkSlide[] = await Promise.all(
     chunks.map(async (chunk) => {
       const [body, ...noteParts] = chunk.split(/^\?\?\?$/m);
       const notes = noteParts.join('\n').trim();
-      const code = await compileSlide(body.trim());
-      return { code, notes: notes || null };
+      const [code, notesCode] = await Promise.all([
+        compileSlide(body.trim()),
+        notes ? compileSlide(notes) : Promise.resolve(null),
+      ]);
+      return { code, notes: notes || null, notesCode };
     }),
   );
 
   return {
-    frontMatter: {
-      ...frontmatter,
-      slug,
-      date: frontmatter.date ? new Date(frontmatter.date).toISOString() : null,
-    },
+    frontMatter: normalizeFrontMatter(frontmatter, slug),
     slides,
   };
 }

--- a/pages/talks/[slug]/index.tsx
+++ b/pages/talks/[slug]/index.tsx
@@ -6,26 +6,21 @@ import LiveTalkBanner from '@/components/LiveTalkBanner';
 import { PageSEO } from '@/components/SEO';
 import Tag from '@/components/Tag';
 import siteMetadata from '@/data/siteMetadata';
-import { getTalkBySlug, getTalkSlugs } from '@/lib/talks';
+import { getTalkMeta, getTalkStaticPaths } from '@/lib/talks';
 import formatDate from '@/lib/utils/formatDate';
 
-export async function getStaticPaths() {
-  return {
-    paths: getTalkSlugs().map((slug) => ({ params: { slug } })),
-    fallback: false,
-  };
-}
+export const getStaticPaths = getTalkStaticPaths;
 
 export const getStaticProps: GetStaticProps<{
   frontMatter: TalkFrontMatter;
   slideCount: number;
 }> = async ({ params }) => {
   const slug = params.slug as string;
-  const talk = await getTalkBySlug(slug);
-  if (!talk) return { notFound: true };
+  const meta = getTalkMeta(slug);
+  if (!meta) return { notFound: true };
 
   return {
-    props: { frontMatter: talk.frontMatter, slideCount: talk.slides.length },
+    props: { frontMatter: meta.frontMatter, slideCount: meta.slideCount },
   };
 };
 
@@ -43,6 +38,7 @@ export default function TalkLanding({
     summary,
     tags,
     videoUrl,
+    pdf,
   } = frontMatter;
 
   return (
@@ -108,7 +104,7 @@ export default function TalkLanding({
             <Play className="h-4 w-4" /> Present
           </Link>
           <Link
-            href={`/talks/${slug}/present?exportMode=true`}
+            href={pdf ?? `/talks/${slug}/present?printMode=true`}
             target="_blank"
             rel="noopener noreferrer"
             className="border-2 border-white bg-white px-6 py-3 font-mono font-bold uppercase text-black shadow-hard-md transition-all hover:shadow-hard-lg active:translate-x-1 active:translate-y-1 active:shadow-none"

--- a/pages/talks/[slug]/present.tsx
+++ b/pages/talks/[slug]/present.tsx
@@ -6,7 +6,7 @@ import type { ReactElement } from 'react';
 import { useEffect } from 'react';
 import type { TalkFrontMatter } from 'types/TalkFrontMatter';
 import type { TalkSlide } from '@/lib/talks';
-import { getTalkBySlug, getTalkSlugs } from '@/lib/talks';
+import { getTalkBySlug, getTalkStaticPaths } from '@/lib/talks';
 
 // Spectacle touches the DOM/window on mount, so render it client-side only.
 const SpectacleDeck = dynamic(
@@ -16,12 +16,7 @@ const SpectacleDeck = dynamic(
   },
 );
 
-export async function getStaticPaths() {
-  return {
-    paths: getTalkSlugs().map((slug) => ({ params: { slug } })),
-    fallback: false,
-  };
-}
+export const getStaticPaths = getTalkStaticPaths;
 
 export const getStaticProps: GetStaticProps<{
   frontMatter: TalkFrontMatter;
@@ -39,26 +34,43 @@ export default function Present({
   slides,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const router = useRouter();
-  const exporting =
-    router.query.exportMode === 'true' || router.query.printMode === 'true';
+  // Only `printMode` (Spectacle's print-optimized, one-slide-per-page layout)
+  // auto-opens the print dialog. `exportMode` is the scrollable overview and
+  // must not trigger printing, or the PDF captures the wrong layout.
+  const printing = router.query.printMode === 'true';
 
-  // In export/print mode, open the print dialog once everything (incl. fonts
-  // and client-rendered diagrams) has settled.
+  // Open the print dialog once fonts AND client-rendered mermaid diagrams have
+  // finished painting — a fixed timer would race async diagram rendering and
+  // print blank diagram slides. Falls back to an 8s deadline.
   useEffect(() => {
-    if (!exporting) return;
+    if (!printing) return;
     let cancelled = false;
-    const ready = document.fonts?.ready ?? Promise.resolve();
-    let timer: ReturnType<typeof setTimeout>;
-    ready.then(() => {
-      timer = setTimeout(() => {
-        if (!cancelled) window.print();
-      }, 1200);
+    const deadline = Date.now() + 8000;
+
+    const diagramsReady = () =>
+      Array.from(document.querySelectorAll('.mermaid-diagram')).every((el) =>
+        el.querySelector('svg'),
+      );
+
+    const fontsReady = document.fonts?.ready ?? Promise.resolve();
+    fontsReady.then(() => {
+      const tick = () => {
+        if (cancelled) return;
+        if (diagramsReady() || Date.now() > deadline) {
+          requestAnimationFrame(() => {
+            if (!cancelled) window.print();
+          });
+          return;
+        }
+        setTimeout(tick, 150);
+      };
+      tick();
     });
+
     return () => {
       cancelled = true;
-      clearTimeout(timer);
     };
-  }, [exporting]);
+  }, [printing]);
 
   return (
     <>

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { globby } from 'globby';
+import matter from 'gray-matter';
 import prettier from 'prettier';
 
 const require = createRequire(import.meta.url);
@@ -33,10 +34,19 @@ const siteUrl = siteMetadata.siteUrl.replace(/\/$/, '');
     { cwd: root },
   );
 
+  // Draft content (blog posts / talks marked `draft: true`) is excluded from
+  // the production build's routes, so it must not appear in the sitemap either.
+  const isDraft = (page) => {
+    if (!/^data\/.*\.(mdx|md)$/.test(page)) return false;
+    const source = fs.readFileSync(path.join(root, page), 'utf8');
+    return matter(source).data.draft === true;
+  };
+  const publishedPages = pages.filter((page) => !isDraft(page));
+
   const sitemap = `
         <?xml version="1.0" encoding="UTF-8"?>
         <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-            ${pages
+            ${publishedPages
               .map((page) => {
                 const pagePath = page
                   .replace('pages/', '/')

--- a/types/TalkFrontMatter.ts
+++ b/types/TalkFrontMatter.ts
@@ -1,6 +1,7 @@
 export type TalkFrontMatter = {
   title: string;
-  date: string;
+  /** ISO date string, or null when the talk omits a date. */
+  date: string | null;
   event: string;
   location?: string;
   audience?: string;


### PR DESCRIPTION
Ports the verified talks code-review findings onto current `main` (#18 shipped talks but only fixed the draft-leak).

**Correctness:** fence-aware slide split (no split on `---` inside code); Download-PDF uses `printMode`/pre-rendered `pdf` not `exportMode`, and only `printMode` auto-prints after diagrams render (not a fixed 1.2s timer); `lib/mdx.ts` keeps unmapped Prism token classes instead of `[undefined]` (fixes blog + slides highlighting); speaker notes compiled through MDX for the presenter view; sitemap skips draft data files.

**Types/reuse:** `TalkFrontMatter.date` is `string | null`; landing page counts slides without compiling (`getTalkMeta`); shared `getTalkStaticPaths`; `getTalkSlugs` derives from `getAllTalksFrontMatter`.

Logic-only (no nav/visual change), so `e2e-visual` snapshots are unaffected. Local: lint, typecheck, unit (47), build all green; draft talk verified excluded from routes + sitemap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)