### PR TITLE
chore: gitignore local todo.md scratch file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ storybook-static
 .worktrees/
 .claude/worktrees/
 tsconfig.tsbuildinfo
+
+# local scratch TODO (code-review findings, not for commit)
+todo.md


### PR DESCRIPTION
Keeps the code-review TODO scratch file (`todo.md`) out of version control.

`todo.md` is a local scratchpad holding the PR #22 code-review findings — useful to have at the repo root while working, but not something to commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)