### PR TITLE
docs(talks): domain model + ADRs for audience participation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,121 @@
+# Live Talk Platform
+
+The audience-participation layer for live talks: a presenter runs a deck, and
+the audience joins from their own devices to react, ask questions, answer polls,
+and take part in activities — all in real time via Convex.
+
+## Language
+
+### Core scoping
+
+**Talk**:
+The authored, reusable deck content — the slides and notes. Lives in
+`data/talks/<slug>.mdx` and is identified by its `slug`. A Talk is *material*,
+not a live event; it has no database row of its own.
+_Avoid_: using "talk" for a live run (that's a Session).
+
+**Session**:
+One live *run* of a Talk — it starts, streams to an audience, and ends. Stored
+as a row in the `talks` table (a legacy name; the row is a Session, not a Talk).
+The user-facing noun in the admin panel for "one run."
+_Avoid_: Run, Show, Broadcast, Instance.
+
+**Room**:
+The identifier every live feature scopes to. A Room *is* a Session's `_id` —
+there is no separate room-code concept; joining "the live Session" is how the
+audience attaches to presence, reactions, questions, polls, and activities.
+_Avoid_: channel, room code.
+
+### Participants
+
+**Attendee**:
+A member of the audience. Pseudo-anonymous — identified only by a `machineId`,
+never by login. Presence, dedup, and rate-limiting all key on this.
+_Avoid_: user (a "user" is the authenticated GitHub identity), viewer.
+
+**machineId**:
+A random UUID a browser persists in localStorage. The Attendee's pseudo-identity:
+it de-duplicates a browser's tabs/reloads and scopes best-effort abuse controls.
+It is *not* a security identity — it is resettable. See [ADR-0001](docs/adr/0001-audience-participation-identity-and-abuse-controls.md).
+_Avoid_: userId, deviceId, sessionId.
+
+**Presenter**:
+The person running the Session. The only authenticated role — a GitHub login on
+the `ADMIN_GITHUB_LOGINS` allowlist. The real trust boundary: all moderation and
+Session-control mutations require it (`requireAdmin`).
+_Avoid_: admin (that's the allowlist mechanism), host, speaker.
+
+### Moderation
+
+Two independent mechanisms, not to be conflated:
+
+**Mask**:
+The *automatic* mechanism. On ingest, profanity is replaced with asterisks
+(`f**k`). The audience sees the masked text; the original is retained
+presenter-only and the entry is marked `flagged` so the console can highlight it
+(see [ADR-0002](docs/adr/0002-profanity-mask-retains-original.md)).
+_Avoid_: censor, filter, block (blocking is the manual mechanism).
+
+**Hide**:
+The *manual* mechanism. The Presenter removes an entry from the audience-visible
+surface (`hidden: true`). The row is kept — the console still sees it — but the
+audience gets only a count, never the content.
+_Avoid_: reject, delete, remove, ban.
+
+**Blocked (count)**:
+A **console-only** tally of Hidden entries the Presenter sees; the audience is
+shown neither the count nor the content (the Presenter raises it verbally if it
+matters). Always refers to the same rows as Hide.
+_Avoid_: using "blocked" for masked entries (masked entries are shown, not hidden).
+
+**Answered**:
+A question the Presenter has marked as addressed. Distinct from Hide — an
+Answered question stays visible in the queue.
+
+### Deck surfaces & reveal
+
+A single `SpectacleDeck` renders in one of three **modes** (from `?mode=`),
+carried to embedded components via `DeckMode`:
+
+**Presenter (mode)**:
+The clean, projected deck the room sees. Drives the reveal beat via the keyboard.
+_Avoid_: projector, stage.
+
+**Attendee (mode)**:
+The audience's own view (`/live` or a watch-along deck). Reveal-gated and the only
+mode that shows input forms. The default when `?mode=` is absent.
+_Avoid_: viewer, follower, guest.
+
+**Console (mode)**:
+The Presenter's second-screen cockpit — moderation controls, notes, preview. It
+**always** shows answers and moderation output regardless of Reveal state; it is
+never reveal-gated.
+_Avoid_: dashboard, admin view.
+
+**Reveal**:
+Flipping an Activity's canonical answer into view for everyone. A one-way,
+Session-wide flag (`revealed`) driven by any of: a scheduled timer at `revealAt`,
+the Presenter's `revealNow` control, or the **reveal beat**. Console always sees
+the answer; Presenter and Attendee are gated on it.
+_Avoid_: show, unlock, publish.
+
+**Reveal beat**:
+The presenting keyboard interaction: while an Activity is open and unrevealed, the
+next advance-key press *reveals* instead of advancing (a Spectacle-stepper-style
+beat); the following press advances. Tied to *presenting the deck*, not to
+follow-mode.
+_Avoid_: step, click.
+
+### Data lifecycle
+
+**Clear-down**:
+The Presenter manually purging one Session's generated data now. The Session
+record (the `talks` row) is kept, so the log persists showing zeroes. See
+[ADR-0003](docs/adr/0003-session-data-retention.md).
+_Avoid_: reset, wipe, delete session (the record survives).
+
+**Ephemeral / Persistent**:
+*Ephemeral* data is cron-reaped on a short TTL (presence, floating reactions,
+presenter heartbeats). *Persistent* data survives until Clear-down or auto-expiry
+(questions, polls, activities, reaction totals, attendees). Only the Session
+record outlives auto-expiry.

--- a/docs/adr/0001-audience-participation-identity-and-abuse-controls.md
+++ b/docs/adr/0001-audience-participation-identity-and-abuse-controls.md
@@ -1,0 +1,44 @@
+# Audience participation is machineId-identified, config-gated, and rate-limited best-effort
+
+## Context
+
+Audience participation (Q&A, polls/word-cloud, ordered-actions, upvotes) is
+deliberately zero-friction: no login, no room code. Every participation write is
+a public, unauthenticated Convex mutation. For a physically-present workshop room
+(often teenagers) this is the right UX, but it leaves shared aggregates —
+question upvote counts, the word cloud — trivially skewable by a held button or a
+second tab, on top of the profanity concern already handled by the mask.
+
+## Decision
+
+Participation is controlled at three layers, keyed on the audience's `machineId`
+— the random localStorage UUID already used for presence. Each *feature* is
+enabled/disabled **per Session at start time** (extending `talkConfig`), but the
+numeric limits themselves are **baked constants**, not presenter-facing knobs —
+the presenter is mid-setup in front of a room and can't intuit "tokens per
+window." A limit graduates to a real config field only once a live run proves a
+default wrong.
+
+1. **Client-side debounce / grey-out** — always on. Collapses rapid taps and
+   disables an already-used control (e.g. an upvoted question). UX only.
+2. **Server-side dedup** — a hand-rolled ledger table keyed `(target, machineId)`
+   enforces idempotent actions (one upvote per machine per question; optionally
+   one word per poll per machine). `ask` and activity `submit` stay unbounded
+   (multiple entries from one person are legitimate; the presenter moderates).
+3. **Server-side rate limiting** — via the official **`@convex-dev/rate-limiter`**
+   component. This PR introduces the Convex *components* system to the repo
+   (`convex/convex.config.ts` + `app.use`); we accept a hand-rolled limiter would
+   duplicate, and subtly mis-handle, what the component already solves.
+
+The per-feature enable pattern is extended to the new features too: `qa`, `poll`,
+and `activities` become `talkConfig` toggles whose writes are dropped server-side
+when disabled, matching the existing `presence`/`reactions`/`follow` contract.
+
+## Consequences
+
+- Every participation mutation (`upvote`, `ask`, poll/activity `submit`) now
+  takes `machineId`; previously none did — only presence/attendees carried it.
+- **This is best-effort, not a security boundary.** `machineId` is a resettable
+  localStorage value; a determined user clears it or opens tabs. The real trust
+  boundary remains the presenter's allowlisted-admin moderation controls
+  (`hidden` / reject). Do not treat these limits as anti-fraud.

--- a/docs/adr/0002-profanity-mask-retains-original.md
+++ b/docs/adr/0002-profanity-mask-retains-original.md
@@ -1,0 +1,28 @@
+# The profanity mask retains the original text for presenter review
+
+## Context
+
+Every audience submission is run through the profanity Mask on ingest. The
+original implementation was destructive: only the masked text was stored, and the
+`flagged` boolean the mask returns was computed then discarded. The matcher
+(obscenity + aggressive transformers) intentionally over-matches to defeat
+obfuscation, so false positives (the "Scunthorpe problem") are expected — and
+under the destructive design they were both unrecoverable and invisible, even to
+the Presenter. `profanity.ts` already *documented* `flagged` as existing "so the
+moderation screen can highlight the whole entry," but no code honoured that.
+
+## Decision
+
+The audience only ever sees masked text — that is unchanged. But we now:
+
+- **Persist `flagged`** on the row so the console can highlight masked entries.
+- **Retain the pre-mask original** in a presenter-only field, so a false-positive
+  mask is visible and judgeable by the Presenter (an allowlisted admin), never by
+  the audience.
+
+## Consequences
+
+- We deliberately store **unmasked, user-generated text** server-side. Access is
+  presenter-only (`requireAdmin`) and it is purged by the Session clear-down like
+  all other participation data. This is an accepted, scoped data-retention choice,
+  not an oversight.

--- a/docs/adr/0003-session-data-retention.md
+++ b/docs/adr/0003-session-data-retention.md
@@ -1,0 +1,31 @@
+# Session participation data is bounded by auto-expiry, not just manual clear-down
+
+## Context
+
+Participation data (questions, polls + words, activities + submissions,
+reaction totals, attendees) persists after a Session ends. Originally the only
+way to remove it was the Presenter's manual **clear-down**. Combined with
+[ADR-0002](0002-profanity-mask-retains-original.md) — which retains the *unmasked*
+original of everything the audience typed — "keep it until I remember to delete
+it" is a weak default: raw user text accumulates indefinitely across every run.
+
+## Decision
+
+Two removal paths:
+
+- **Clear-down** (manual) — the Presenter zeroes a single Session's data now. The
+  Session record (the `talks` row) is kept so the log persists, showing zeroes.
+- **Auto-expiry** (scheduled) — a cron reaper purges participation data for
+  *ended* Sessions past a generous retention window (~30 days). The Session
+  record is kept.
+
+Both purge paths must cover **all** per-Session tables, including the dedup
+ledger and rate-limit rows introduced by ADR-0001 — a cleared/expired Session is
+truly zeroed, leaving only the log entry.
+
+## Consequences
+
+- Bounded retention of unmasked user text (see ADR-0002) without the Presenter
+  having to remember. Post-talk review still has a month-long window.
+- Every *new* per-Session table added in future must be registered in both the
+  clear-down and auto-expiry purge lists, or it silently leaks past retention.


### PR DESCRIPTION
Stacked on #22. Docs-only — the domain model and decisions from a design review ("grill-with-docs") of the audience-participation feature. **No code changes**; the ADRs describe changes to be implemented in a follow-up PR.

## What's here
- **`CONTEXT.md`** — the project glossary / ubiquitous language:
  - **Talk / Session / Room** — resolves the biggest overload. A *Talk* is the authored MDX; a *Session* is one live run (the `talks` table row — legacy name); a *Room* is a Session's `_id`, the key every live feature scopes to.
  - **Attendee / machineId / Presenter** — the audience is pseudo-anonymous (`machineId`); the Presenter (GitHub allowlist) is the only real trust boundary.
  - **Mask / Hide / Blocked-count / Answered** — two distinct moderation mechanisms (automatic profanity mask vs. manual presenter hide), previously blurred.
  - **Presenter / Attendee / Console** deck modes; **Reveal** + **Reveal beat**.
  - **Clear-down**; **Ephemeral vs Persistent** data.
- **`docs/adr/`** — three decisions from the review:
  - **0001** — participation is `machineId`-identified, per-feature config-gated, deduped (ledger) and rate-limited (adopts `@convex-dev/rate-limiter`, the repo's first Convex component); best-effort, *not* a security boundary.
  - **0002** — the profanity mask keeps the pre-mask original (presenter-only) + persists `flagged`, so false-positive masks are reviewable instead of silently lost.
  - **0003** — Session participation data is bounded by a scheduled auto-expiry (~30d), not only manual clear-down; both purge paths must cover every per-Session table.

## Follow-up
A subsequent PR (new branch off #22) will implement the ADRs: `talkConfig` feature toggles, `machineId` threading + dedup + rate-limiter, mask-original retention, dropping the audience-facing blocked count, decoupling the reveal beat from follow-mode, and the auto-expiry cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)