### PR TITLE
docs(adr): preview-environment + OAuth tradeoff (ADR-0004)

### DIFF
--- a/docs/adr/0004-preview-environments-and-auth.md
+++ b/docs/adr/0004-preview-environments-and-auth.md
@@ -1,0 +1,76 @@
+# Preview environments: Convex data branches cleanly, first-party OAuth does not
+
+## Context
+
+Verifying the live-talk / audience-participation features end-to-end (see
+[ADR-0001](0001-audience-participation-identity-and-abuse-controls.md)) means
+driving a real deployment with a browser. The obvious target is a **Vercel
+preview** per PR, but a preview needs *two* things, and only one of them is easy:
+
+1. **A backend running the branch's current code.** Convex solves this with
+   [preview deployments](https://docs.convex.dev/production/hosting/preview-deployments):
+   set the Vercel build command to `npx convex deploy --cmd 'pnpm build'` with a
+   *Preview* deploy key, and every branch gets a fresh, isolated backend with
+   `NEXT_PUBLIC_CONVEX_URL` injected automatically. This is the direct analog of
+   database branching and is a solved, standard pattern.
+
+2. **A working auth callback.** This is the rough edge. Admin/presenter actions
+   are gated behind GitHub OAuth via Convex Auth, whose callback lives on the
+   Convex deployment's `*.convex.site` domain. A GitHub **OAuth App allows a
+   single callback URL and no wildcards**, so a *per-branch* Convex deployment
+   (a new `*.convex.site` each time) can never have its callback pre-registered.
+   This is not a Convex quirk — it's the well-known Vercel-preview OAuth problem
+   that NextAuth, Auth0, and Better Auth all have long threads about; hosted auth
+   providers (Clerk, Auth0) largely exist to paper over it.
+
+The two halves are independent: audience-facing mutations (ask, upvote, poll
+submit — the behaviours the review fixes hardened) are **public** and testable on
+any current backend. Only the presenter setup (start a talk, open a poll,
+moderate) needs the admin session — and that is exactly what OAuth-on-previews
+makes hard.
+
+## Decision
+
+**Test admin-driven flows locally for now.** Local dev runs against a dev Convex
+deployment (`dev:keen-shark-231`) whose `.convex.site` callback and
+`localhost:3000` are stable and registered once — GitHub OAuth "just works". The
+`agent-browser` CLI attaches over CDP to the signed-in dev Chrome and drives
+`localhost`, so no OAuth dance per run. This is the supported path for the
+end-to-end harness today.
+
+**Do not adopt per-branch Convex preview deployments while admin auth uses raw
+GitHub OAuth** — the data half would work but the auth half would silently break
+(sign-in fails on the ephemeral `*.convex.site`).
+
+When preview-environment testing becomes worth the setup, the going-forward
+options, in preference order for this repo, are:
+
+- **Preview auth bypass** — a dev-only sign-in path gated on
+  `VERCEL_ENV !== 'production'`. Lowest friction for a solo, admin-only app;
+  pairs cleanly with Convex per-branch preview deployments so previews become
+  fully automatic. **Recommended** if/when we automate previews.
+- **Stable staging deployment** — one long-lived preview backend with its own
+  GitHub OAuth App and a fixed callback. Keeps real sign-in, loses per-branch
+  data isolation, and needs a deploy trigger (CI on PR, or a manual command) to
+  stay current.
+- **Hosted auth provider (Clerk/Auth0)** — first-class preview/wildcard support;
+  the only option that gives true per-branch preview *login*, at the cost of
+  replacing the auth layer.
+
+Today's Vercel Preview `NEXT_PUBLIC_CONVEX_URL` points at the shared dev
+deployment, which CI does **not** deploy to (only production, via
+`convex-deploy.yml`). So a preview is only as current as the last manual
+`convex dev`/`deploy` to that deployment — treat previews as best-effort until
+one of the options above is adopted.
+
+## Consequences
+
+- The e2e harness is a **local** tool (attaches to a signed-in CDP browser); it
+  is not CI-ready until a non-interactive auth path (the bypass above) lands.
+  See `docs/live-e2e-harness.md`.
+- Choosing an approach later is a real fork: automatic-but-bypass-auth vs
+  real-auth-but-manual-staging vs swap-the-auth-provider. The blocker to weigh is
+  always the **OAuth callback**, not the Convex deploy.
+- If per-branch previews are wired up before an auth story exists, admin flows
+  will appear broken on previews even though the backend is healthy — document
+  the bypass in the same change to avoid that trap.

--- a/docs/live-e2e-harness.md
+++ b/docs/live-e2e-harness.md
@@ -66,3 +66,11 @@ the agent-browser CLI after deploy: prod is a separate Convex deployment
 end-to-end signal. Drive the same surfaces (`/admin` cockpit, `/live`,
 `/talks/<slug>/present`) and confirm the same behaviours, then clear the session
 down.
+
+Vercel **preview** environments are deliberately *not* the target for admin-driven
+runs: per-branch previews can't pre-register a GitHub OAuth callback on their
+ephemeral `*.convex.site`, so admin sign-in breaks even when the backend is
+healthy. Local (stable `localhost` callback) and production (stable domain) are
+the supported targets. See
+[ADR-0004](adr/0004-preview-environments-and-auth.md) for the tradeoff and the
+going-forward options.


### PR DESCRIPTION
Records why we test the live-talk admin flows **locally** rather than on Vercel previews, as part of the audience-participation testing work.

## The tradeoff
A Vercel preview needs two things; only one is easy:
- **Current backend** — Convex preview deployments solve this cleanly (per-branch, auto-injected URL).
- **Working auth callback** — Convex Auth's GitHub OAuth callback lives on the deployment's `*.convex.site`; a GitHub OAuth App allows a single callback URL with no wildcards, so ephemeral per-branch deployments can't pre-register it. This is the well-known Vercel-preview OAuth problem, not a Convex quirk.

## Decision
Test admin-driven flows locally for now (stable `localhost` + dev Convex callback). Don't adopt per-branch previews while admin auth is raw GitHub OAuth. Captures the going-forward options — **preview auth bypass** (recommended), stable staging, or a hosted auth provider — so the OAuth-callback blocker is weighed, not the Convex deploy.

## Files
- `docs/adr/0004-preview-environments-and-auth.md` (new)
- `docs/live-e2e-harness.md` — reciprocal cross-link

🤖 Generated with [Claude Code](https://claude.com/claude-code)