### PR TITLE
feat(talks): enforce feature config, drop audience moderation counts, add retention

### DIFF
--- a/components/talks/LivePoll.tsx
+++ b/components/talks/LivePoll.tsx
@@ -147,9 +147,8 @@ function Poll({
         )}
       </div>
 
-      <div className="mt-4 flex justify-between font-mono text-xs text-zinc-500">
+      <div className="mt-4 font-mono text-xs text-zinc-500">
         <span>{poll.total} answers</span>
-        {poll.blocked > 0 && <span>🚫 {poll.blocked} blocked</span>}
       </div>
     </div>
   );

--- a/components/talks/OrderedActions.tsx
+++ b/components/talks/OrderedActions.tsx
@@ -133,9 +133,6 @@ function Activity({
     : (active?.options ?? []);
   const consoleSubs = isConsole ? (feedRes?.submissions ?? []) : [];
   const audienceWall = isConsole ? [] : (active?.wall ?? []);
-  const blocked = isConsole
-    ? consoleSubs.filter((s) => s.hidden).length
-    : (active?.blocked ?? 0);
   const submissionCount = isConsole ? consoleSubs.length : audienceWall.length;
   const showForm = !display && mode === 'attendee';
   // Whether this activity has a canonical answer at all. The console reads it
@@ -292,12 +289,6 @@ function Activity({
                 />
               ))}
         </div>
-        {/* Audience surfaces only ever see a count of what was blocked. */}
-        {!isConsole && blocked > 0 && (
-          <p className="pt-2 font-mono text-xs text-zinc-600">
-            🚫 {blocked} {blocked === 1 ? 'entry' : 'entries'} blocked
-          </p>
-        )}
       </div>
     </div>
   );
@@ -308,7 +299,7 @@ function Activity({
  * The presenter opens a prompt + hidden canonical options; the audience builds an
  * ordered step list and submits; the wall fills live and the canonical answer
  * reveals on a timer (or via the deck's next-key). Mode-aware:
- * - attendee → reveal-gated + submission form (blocked entries show as a count),
+ * - attendee → reveal-gated + submission form (rejected entries are omitted),
  * - presenter (projected) → reveal-gated, display-only,
  * - console (2nd screen) → answer + every submission incl. blocked shown always.
  */

--- a/components/talks/QuestionQueue.tsx
+++ b/components/talks/QuestionQueue.tsx
@@ -70,7 +70,6 @@ function Queue({
   };
 
   const questions = data?.questions ?? [];
-  const blocked = data?.blocked ?? 0;
 
   return (
     <div className="border-2 border-white bg-zinc-900 p-5">
@@ -167,11 +166,6 @@ function Queue({
             );
           })
         )}
-        {blocked > 0 && (
-          <p className="pt-1 font-mono text-xs text-zinc-600">
-            🚫 {blocked} {blocked === 1 ? 'entry' : 'entries'} blocked
-          </p>
-        )}
       </div>
     </div>
   );
@@ -179,9 +173,10 @@ function Queue({
 
 /**
  * Embedded live Q&A: anyone types a question, everyone upvotes to reorder the
- * queue, the presenter answers/rejects from the console. Rejected questions show
- * only as a "blocked" count. Resolves the live room automatically, or takes one.
- * `display` (projected deck) is read-only — no ask box, votes as static badges.
+ * queue, the presenter answers/rejects from the console. Rejected questions are
+ * omitted from the audience entirely (the presenter sees them on the console).
+ * Resolves the live room automatically, or takes one. `display` (projected deck)
+ * is read-only — no ask box, votes as static badges.
  */
 export default function QuestionQueue({
   room,

--- a/components/talks/SpectacleDeck.tsx
+++ b/components/talks/SpectacleDeck.tsx
@@ -148,6 +148,16 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
     (mode === 'presenter' || mode === 'console') && followOn && isAdmin;
   const followEnabled = followOn && !broadcasting;
 
+  // A deck the presenter is actively driving on THIS live talk (presenter screen
+  // or console), regardless of follow. Slide-broadcast still only takes effect
+  // when `follow` is on (setSlide is gated server-side), but this deck always
+  // renders the driver so it reports its slide index and wires Prev/Next — which
+  // the deck-native reveal beat below needs even in a non-follow session.
+  const drivingDeck =
+    (mode === 'presenter' || mode === 'console') &&
+    isAdmin &&
+    Boolean(liveHere);
+
   const showAttendeeSidebar = mode === 'attendee' && Boolean(reactionsOn);
   const showConsoleSidebar = mode === 'console' && isAdmin && Boolean(liveHere);
   const showPresenterHud = mode === 'presenter' && isAuthenticated && isAdmin;
@@ -172,14 +182,15 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
   // Deck-native reveal: while driving the deck with an open activity whose answer
   // is still hidden, the next "advance" press reveals the canonical answer to the
   // room instead of changing slide (a Spectacle-stepper-style beat). A second
-  // press then advances normally. Only the broadcasting deck arms this.
+  // press then advances normally. Armed on any deck the presenter is driving —
+  // independent of follow, so it works in a non-follow session too.
   const openActivity = useQuery(
     api.activities.active,
-    broadcasting && room ? { room } : 'skip',
+    drivingDeck && room ? { room } : 'skip',
   );
   const revealNow = useMutation(api.activities.revealNow);
   const pendingReveal =
-    broadcasting && openActivity && !openActivity.revealed
+    drivingDeck && openActivity && !openActivity.revealed
       ? openActivity._id
       : null;
 
@@ -222,7 +233,7 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
   }) => (
     <>
       <Chrome slideNumber={slideNumber} numberOfSlides={numberOfSlides} />
-      {broadcasting ? (
+      {drivingDeck ? (
         <DeckDriver
           room={room}
           initialSlide={current?.currentSlide ?? 0}

--- a/convex/activities.ts
+++ b/convex/activities.ts
@@ -3,7 +3,7 @@ import { internal } from './_generated/api';
 import { internalMutation, mutation, query } from './_generated/server';
 import { isAdminUser, requireAdmin } from './lib/admin';
 import { cleanSteps, cleanText } from './lib/profanity';
-import { liveTalkForRoom } from './talks';
+import { liveTalkForRoom, resolveConfig } from './talks';
 
 const MAX_STEPS = 12;
 const MAX_STEP_LEN = 140;
@@ -26,6 +26,11 @@ export const open = mutation({
   },
   handler: async (ctx, { room, prompt, options, revealDelayMs }) => {
     await requireAdmin(ctx);
+    // Only for a live talk with the activities feature enabled.
+    const talk = await liveTalkForRoom(ctx, room);
+    if (!talk || !resolveConfig(talk).activities) {
+      throw new Error('The activities feature is disabled for this session.');
+    }
 
     // Close any activity already open in this room — one at a time.
     const existing = await ctx.db
@@ -128,8 +133,6 @@ export const active = query({
       hasAnswer: activity.options.length > 0,
       options: activity.revealed ? activity.options : [],
       submissionCount: submissions.length,
-      // Presenter-rejected entries are never sent to the audience — only a count.
-      blocked: submissions.length - visible.length,
       wall: visible.map(({ _id, nickname, steps }) => ({
         _id,
         nickname,
@@ -188,6 +191,8 @@ export const submit = mutation({
     // Gate on the live talk owning this room (mirrors reactions/questions).
     const talk = await liveTalkForRoom(ctx, activity.room);
     if (!talk) throw new Error('No live talk.');
+    // Activities disabled for this session: drop the write silently.
+    if (!resolveConfig(talk).activities) return { ok: false as const };
 
     const trimmed = args.steps
       .map((step) => step.trim())

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -29,4 +29,13 @@ crons.interval(
   {},
 );
 
+// Auto-expire ended sessions past the retention window: purge the (possibly
+// unmasked) audience data they generated while keeping the session log. ADR-0003.
+crons.interval(
+  'reap ended sessions',
+  { hours: 24 },
+  internal.sessions.reapEndedSessions,
+  {},
+);
+
 export default crons;

--- a/convex/polls.ts
+++ b/convex/polls.ts
@@ -2,7 +2,7 @@ import { v } from 'convex/values';
 import { mutation, query } from './_generated/server';
 import { isAdminUser, requireAdmin } from './lib/admin';
 import { cleanText } from './lib/profanity';
-import { liveTalkForRoom } from './talks';
+import { liveTalkForRoom, resolveConfig } from './talks';
 
 const MAX_PROMPT_LEN = 160;
 const MAX_WORD_LEN = 32;
@@ -19,6 +19,11 @@ export const start = mutation({
   args: { room: v.string(), prompt: v.string() },
   handler: async (ctx, { room, prompt }) => {
     await requireAdmin(ctx);
+    // Only for a live talk with the poll feature enabled.
+    const talk = await liveTalkForRoom(ctx, room);
+    if (!talk || !resolveConfig(talk).poll) {
+      throw new Error('The poll feature is disabled for this session.');
+    }
     const existing = await ctx.db
       .query('polls')
       .withIndex('by_room_created', (q) => q.eq('room', room))
@@ -67,12 +72,12 @@ export const active = query({
 
     const visible = words.filter((w) => !w.hidden);
     const total = visible.reduce((sum, w) => sum + w.count, 0);
+    // Blocked words are withheld from the audience entirely — no count either
+    // (the presenter sees them on the console feed).
     return {
       _id: poll._id,
       prompt: poll.prompt,
       total,
-      // Blocked words are counted for the presenter's awareness but withheld.
-      blocked: words.length - visible.length,
       words: visible
         .map(({ word, count }) => ({ word, count }))
         .sort((a, b) => b.count - a.count),
@@ -118,6 +123,8 @@ export const submit = mutation({
     }
     const talk = await liveTalkForRoom(ctx, poll.room);
     if (!talk) throw new Error('No live talk.');
+    // Poll disabled for this session: drop the write silently.
+    if (!resolveConfig(talk).poll) return { ok: false as const };
 
     const normalized = normalizeWord(word);
     if (!normalized) throw new Error('Type a word before submitting.');

--- a/convex/questions.ts
+++ b/convex/questions.ts
@@ -2,7 +2,7 @@ import { v } from 'convex/values';
 import { mutation, query } from './_generated/server';
 import { isAdminUser, requireAdmin } from './lib/admin';
 import { cleanText } from './lib/profanity';
-import { liveTalkForRoom } from './talks';
+import { liveTalkForRoom, resolveConfig } from './talks';
 
 const MAX_TEXT_LEN = 280;
 const MAX_NICKNAME_LEN = 24;
@@ -15,7 +15,7 @@ function byPriority<T extends { votes: number; createdAt: number }>(
   return b.votes - a.votes || a.createdAt - b.createdAt;
 }
 
-/** Audience: ask a question. Gated on a live talk owning the room. */
+/** Audience: ask a question. Gated on a live talk with Q&A enabled. */
 export const ask = mutation({
   args: {
     room: v.string(),
@@ -25,6 +25,8 @@ export const ask = mutation({
   handler: async (ctx, { room, text, nickname }) => {
     const talk = await liveTalkForRoom(ctx, room);
     if (!talk) throw new Error('No live talk.');
+    // Q&A disabled for this session: drop the write silently (not merely hidden).
+    if (!resolveConfig(talk).qa) return { ok: false as const };
 
     const cleaned = cleanText(text.trim().slice(0, MAX_TEXT_LEN));
     if (!cleaned.text) throw new Error('Type a question before submitting.');
@@ -42,13 +44,14 @@ export const ask = mutation({
       hidden: cleaned.flagged || (cleanedNickname?.flagged ?? false),
       createdAt: Date.now(),
     });
-    return { ok: true };
+    return { ok: true as const };
   },
 });
 
 /**
- * Public: the audience-visible queue (non-rejected), ordered by priority, plus a
- * `blocked` count of presenter-rejected questions (content withheld, count only).
+ * Public: the audience-visible queue (non-rejected), ordered by priority.
+ * Rejected (hidden) questions are omitted entirely — the audience is shown
+ * neither their content nor a count (the presenter tracks those on the console).
  */
 export const list = query({
   args: { room: v.string() },
@@ -57,10 +60,9 @@ export const list = query({
       .query('questions')
       .withIndex('by_room_created', (q) => q.eq('room', room))
       .collect();
-    const visible = rows.filter((r) => !r.hidden);
     return {
-      blocked: rows.length - visible.length,
-      questions: visible
+      questions: rows
+        .filter((r) => !r.hidden)
         .sort(byPriority)
         .map(({ _id, text, nickname, votes, answered }) => ({
           _id,

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -1,7 +1,19 @@
 import { v } from 'convex/values';
 import type { Id } from './_generated/dataModel';
-import { type MutationCtx, mutation, query } from './_generated/server';
+import {
+  internalMutation,
+  type MutationCtx,
+  mutation,
+  query,
+} from './_generated/server';
 import { isAdminUser, requireAdmin } from './lib/admin';
+
+/**
+ * Ended sessions are auto-purged this long after they end (the `talks` row is
+ * kept, only its generated data goes). Manual clear-down is available sooner.
+ * See ADR-0003.
+ */
+const RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 /**
  * Session management for the admin hub. A "session" is one live run of a talk
@@ -112,9 +124,65 @@ async function purgeByRoom(
 }
 
 /**
- * Admin: clear down all data a session generated — reactions, head-count,
- * presence, questions, polls (+ their words) and activities (+ submissions).
- * The session record itself is kept, so the log persists (now showing zeroes).
+ * Delete every row every feature scoped to this room — reactions, head-count,
+ * presence, questions (+ their vote ledger), polls (+ their words and submitter
+ * ledger) and activities (+ submissions). The `talks` row itself is left intact,
+ * so the session log persists (now showing zeroes). Shared by the manual
+ * clear-down and the auto-expiry reaper. See ADR-0003.
+ */
+async function purgeSessionData(ctx: MutationCtx, room: string): Promise<void> {
+  await purgeByRoom(ctx, 'reactions', room);
+  await purgeByRoom(ctx, 'reactionTotals', room);
+  await purgeByRoom(ctx, 'attendees', room);
+  await purgeByRoom(ctx, 'presence', room);
+  await purgeByRoom(ctx, 'presenters', room);
+  await purgeByRoom(ctx, 'activitySubmissions', room);
+
+  // Questions own child vote rows (keyed by question, not room).
+  const questions = await ctx.db
+    .query('questions')
+    .withIndex('by_room_created', (q) => q.eq('room', room))
+    .collect();
+  for (const question of questions) {
+    const votes = await ctx.db
+      .query('questionVotes')
+      .withIndex('by_question_machine', (q) => q.eq('questionId', question._id))
+      .collect();
+    await Promise.all(votes.map((row) => ctx.db.delete(row._id)));
+    await ctx.db.delete(question._id);
+  }
+
+  // Polls own child word + submitter rows; activities are cleared by room index.
+  const polls = await ctx.db
+    .query('polls')
+    .withIndex('by_room_created', (q) => q.eq('room', room))
+    .collect();
+  for (const poll of polls) {
+    const words = await ctx.db
+      .query('pollWords')
+      .withIndex('by_poll', (q) => q.eq('pollId', poll._id))
+      .collect();
+    await Promise.all(words.map((w) => ctx.db.delete(w._id)));
+    const submitters = await ctx.db
+      .query('pollSubmitters')
+      .withIndex('by_poll_machine', (q) => q.eq('pollId', poll._id))
+      .collect();
+    await Promise.all(submitters.map((s) => ctx.db.delete(s._id)));
+    await ctx.db.delete(poll._id);
+  }
+
+  const activities = await ctx.db
+    .query('activities')
+    .withIndex('by_room_created', (q) => q.eq('room', room))
+    .collect();
+  await Promise.all(
+    activities.map((a) => ctx.db.delete(a._id as Id<'activities'>)),
+  );
+}
+
+/**
+ * Admin: clear down all data a session generated. The session record itself is
+ * kept, so the log persists (now showing zeroes).
  */
 export const clearDown = mutation({
   args: { room: v.string() },
@@ -129,56 +197,28 @@ export const clearDown = mutation({
       throw new Error('End the talk before clearing its data.');
     }
 
-    await purgeByRoom(ctx, 'reactions', room);
-    await purgeByRoom(ctx, 'reactionTotals', room);
-    await purgeByRoom(ctx, 'attendees', room);
-    await purgeByRoom(ctx, 'presence', room);
-    await purgeByRoom(ctx, 'presenters', room);
-    await purgeByRoom(ctx, 'activitySubmissions', room);
-
-    // Questions own child vote rows (keyed by question, not room).
-    const questions = await ctx.db
-      .query('questions')
-      .withIndex('by_room_created', (q) => q.eq('room', room))
-      .collect();
-    for (const question of questions) {
-      const votes = await ctx.db
-        .query('questionVotes')
-        .withIndex('by_question_machine', (q) =>
-          q.eq('questionId', question._id),
-        )
-        .collect();
-      await Promise.all(votes.map((row) => ctx.db.delete(row._id)));
-      await ctx.db.delete(question._id);
-    }
-
-    // Polls own child word + submitter rows; activities are cleared by room index.
-    const polls = await ctx.db
-      .query('polls')
-      .withIndex('by_room_created', (q) => q.eq('room', room))
-      .collect();
-    for (const poll of polls) {
-      const words = await ctx.db
-        .query('pollWords')
-        .withIndex('by_poll', (q) => q.eq('pollId', poll._id))
-        .collect();
-      await Promise.all(words.map((w) => ctx.db.delete(w._id)));
-      const submitters = await ctx.db
-        .query('pollSubmitters')
-        .withIndex('by_poll_machine', (q) => q.eq('pollId', poll._id))
-        .collect();
-      await Promise.all(submitters.map((s) => ctx.db.delete(s._id)));
-      await ctx.db.delete(poll._id);
-    }
-
-    const activities = await ctx.db
-      .query('activities')
-      .withIndex('by_room_created', (q) => q.eq('room', room))
-      .collect();
-    await Promise.all(
-      activities.map((a) => ctx.db.delete(a._id as Id<'activities'>)),
-    );
-
+    await purgeSessionData(ctx, room);
     return { ok: true };
+  },
+});
+
+/**
+ * Scheduled (crons.ts): auto-expire ended sessions past the retention window.
+ * Purges each old session's generated data while keeping its `talks` row, so the
+ * session log stays but the (possibly unmasked) audience content does not.
+ * See ADR-0003.
+ */
+export const reapEndedSessions = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const cutoff = Date.now() - RETENTION_MS;
+    const ended = await ctx.db
+      .query('talks')
+      .withIndex('by_status', (q) => q.eq('status', 'ended'))
+      .collect();
+    for (const talk of ended) {
+      if ((talk.endedAt ?? talk.startedAt) > cutoff) continue;
+      await purgeSessionData(ctx, talk._id as string);
+    }
   },
 });

--- a/convex/talkConfig.ts
+++ b/convex/talkConfig.ts
@@ -17,6 +17,16 @@ export const talkConfigValidator = v.object({
   chartThreshold: v.number(),
   /** Follow-the-presenter: audience decks mirror the presenter's slide. */
   follow: v.boolean(),
+  // The audience-participation features. Optional in the validator so talks
+  // started before these existed still validate; `resolveConfig` fills the
+  // gaps from DEFAULT_CONFIG. Enforced server-side — a disabled feature's
+  // writes are dropped, not merely hidden.
+  /** Live Q&A queue. */
+  qa: v.optional(v.boolean()),
+  /** Live poll / word cloud. */
+  poll: v.optional(v.boolean()),
+  /** Put-it-in-order activities. */
+  activities: v.optional(v.boolean()),
 });
 
 export type TalkConfig = {
@@ -25,15 +35,24 @@ export type TalkConfig = {
   closingChart: boolean;
   chartThreshold: number;
   follow: boolean;
+  qa: boolean;
+  poll: boolean;
+  activities: boolean;
 };
 
-/** Applied to any talk missing a config (e.g. started before configs existed). */
+/**
+ * Applied to any talk missing a config, and merged over a partial config so a
+ * talk stored before the newer toggles existed resolves to sensible defaults.
+ */
 export const DEFAULT_CONFIG: TalkConfig = {
   presence: true,
   reactions: true,
   closingChart: true,
   chartThreshold: 3,
   follow: true,
+  qa: true,
+  poll: true,
+  activities: true,
 };
 
 /**
@@ -51,6 +70,9 @@ export const TALK_PRESETS: { id: string; label: string; config: TalkConfig }[] =
         closingChart: true,
         chartThreshold: 3,
         follow: true,
+        qa: true,
+        poll: true,
+        activities: true,
       },
     },
     {
@@ -62,6 +84,9 @@ export const TALK_PRESETS: { id: string; label: string; config: TalkConfig }[] =
         closingChart: true,
         chartThreshold: 3,
         follow: true,
+        qa: true,
+        poll: true,
+        activities: true,
       },
     },
     {
@@ -73,6 +98,9 @@ export const TALK_PRESETS: { id: string; label: string; config: TalkConfig }[] =
         closingChart: false,
         chartThreshold: 3,
         follow: false,
+        qa: false,
+        poll: false,
+        activities: false,
       },
     },
   ];

--- a/convex/talks.ts
+++ b/convex/talks.ts
@@ -10,9 +10,15 @@ import {
   talkConfigValidator,
 } from './talkConfig';
 
-/** A talk's config, falling back to defaults for talks started before configs. */
-export function resolveConfig(talk: { config?: TalkConfig }): TalkConfig {
-  return talk.config ?? DEFAULT_CONFIG;
+/**
+ * A talk's config. Defaults fill in for talks started before configs existed,
+ * and are merged *over* a partial config so a talk stored before a newer toggle
+ * (qa/poll/activities) resolves that toggle to its default, not `undefined`.
+ */
+export function resolveConfig(talk: {
+  config?: Partial<TalkConfig>;
+}): TalkConfig {
+  return { ...DEFAULT_CONFIG, ...talk.config };
 }
 
 /**


### PR DESCRIPTION
Follow-up hardening for audience participation, layered on top of the #26 review fixes. Scoped to the gaps #26 didn't cover — its dedup ledgers (`questionVotes`/`pollSubmitters`), `machineId` extraction and profanity auto-hide are kept as-is.

## What this adds

### Per-session feature enforcement
- New `qa` / `poll` / `activities` toggles on `TalkConfig` (optional in the validator, merged over `DEFAULT_CONFIG` by `resolveConfig`, so talks stored before the toggles existed still resolve sensibly). Presets: **Interactive** / **Lab + follow** enable all; **Talk-only** disables all.
- Q&A `ask`, poll `start`/`submit` and activity `open`/`submit` now gate on a live talk with the feature enabled. A **disabled** feature drops audience writes silently (not merely hidden); acting on a target that just **closed** still errors as before.

### Moderation counts are presenter-only
- Stop sending the rejected/"blocked" count to the audience in `questions.list` and `polls.active`, and remove the blocked-count UI from the Q&A queue, poll and activity wall. Rejected content stays entirely on the console. (Matches the design decision from the grilling: moderation is the presenter's business.)

### Deck-native reveal beat works without follow
- The next-key answer reveal previously armed only on a *broadcasting* deck, which requires `follow` — so it was silently dead in a non-follow session. It now arms on any deck the presenter is **driving** (presenter or console, admin, live here). The driving deck always renders the driver (slide-broadcast stays a server-side no-op when `follow` is off), which also reports the slide index for #26's slide-scoped arming and wires console Prev/Next in non-follow sessions.

### Session data retention (ADR-0003)
- Extract clear-down's purge into a shared `purgeSessionData` helper (covering the `questionVotes`/`pollSubmitters` ledgers) and add a `reapEndedSessions` internal mutation + daily cron that purges ended sessions past a 30-day window, keeping the `talks` row so the session log persists.

## Not in this PR
Rate-limiting (ADR-0001) is deferred to its own follow-up: the Convex rate-limiter component needs online codegen, which isn't available in this environment.

## Verification
`tsc --noEmit`, `biome check`, and `pnpm test` (57/57) all pass against the current `main` (post-#30). Convex codegen was not re-run (no live deployment here); no new tables were added, so the generated types are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)