### PR TITLE
fix(deck): attendee UX — inline poll answer + hide admin badge on projected deck

### DIFF
--- a/components/AdminIndicator.tsx
+++ b/components/AdminIndicator.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { useIsAdmin } from '@/lib/useIsAdmin';
 
 /**
@@ -9,7 +10,16 @@ import { useIsAdmin } from '@/lib/useIsAdmin';
  */
 export default function AdminIndicator() {
   const isAdmin = useIsAdmin();
-  if (!isAdmin) return null;
+  const router = useRouter();
+
+  // Never overlay the badge on a projected deck — attendee/presenter views are
+  // shown to the room, so the audience would see it. The presenter console
+  // (mode=console) is a private 2nd screen, so the badge stays there. The deck
+  // defaults to attendee when no mode is set, so treat "not console" as hidden.
+  const onDeck = router.pathname === '/talks/[slug]/present';
+  const hiddenOnProjectedDeck = onDeck && router.query.mode !== 'console';
+
+  if (!isAdmin || hiddenOnProjectedDeck) return null;
   return (
     <Link
       href="/admin"

--- a/data/talks/so-you-want-to-build-software.mdx
+++ b/data/talks/so-you-want-to-build-software.mdx
@@ -52,9 +52,8 @@ intimidating."
 **One word:** how does the idea of writing code make you feel?
 
 <LivePoll
-  display
   prompt="One word: how does the idea of coding make you feel?"
-  info="Head to the live page and send one word — no wrong answers."
+  info="One word — no wrong answers."
 />
 
 ???


### PR DESCRIPTION
Two small deck-presentation fixes (verified locally with agent-browser).

## 1. Attendees answer the poll on the talk itself
`<LivePoll>` on the QUICK POLL slide dropped its `display` prop, so it's now
**mode-aware** like `OrderedActions`:
- **attendee** deck → shows the "One word…" input + Send (answer inline on the talk)
- **presenter/console** (projected) deck → cloud-only, no dead input on the big screen

Previously `display` forced cloud-only everywhere, so attendees could only answer
via `/live`.

## 2. Admin badge hidden on the projected deck
`AdminIndicator` ("● Admin", bottom-left) no longer shows on a projected deck
(`?mode=attendee` / `?mode=presenter`) — the audience shouldn't see it. It stays
on the **private console** (`?mode=console`) and everywhere else in the site.

## Verified (agent-browser, localhost:3002)
- Badge: **attendee hidden · presenter hidden · console visible**
- Poll slide: attendee deck `hasInput+Send` ✓, presenter deck no input ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)