### PR TITLE
fix(talks): align mid-talk joiners to the presenter's slide

### DIFF
--- a/components/talks/DeckLive.tsx
+++ b/components/talks/DeckLive.tsx
@@ -78,6 +78,9 @@ export function DeckDriver({
  * own they detach to free-roam (a "resume" button re-attaches). We distinguish
  * a presenter move (currentSlide changed → follow it) from a manual move
  * (activeView changed on its own → detach) by tracking the previous values.
+ * On join it aligns to the room's slide, retrying until it lands — the same
+ * dropped-early-skipTo race DeckDriver works around; without the retry a
+ * mid-talk joiner sits on slide 1 until the presenter next moves.
  */
 export function Follower({
   enabled,
@@ -89,11 +92,35 @@ export function Follower({
   const { activeView, skipTo } = useContext(DeckContext);
   const active = activeView.slideIndex;
   const [detached, setDetached] = useState(false);
+  const [aligned, setAligned] = useState(false);
   const prevCurrent = useRef(currentSlide);
   const prevActive = useRef(active);
 
+  // Join alignment: drive to the room's slide until Spectacle actually lands
+  // there (an early skipTo can be silently dropped before nav is ready).
+  useEffect(() => {
+    if (aligned || !enabled || currentSlide == null || detached) return;
+    if (active === currentSlide) {
+      setAligned(true);
+      return;
+    }
+    skipTo({ slideIndex: currentSlide, stepIndex: 0 });
+    const retry = setInterval(
+      () => skipTo({ slideIndex: currentSlide, stepIndex: 0 }),
+      250,
+    );
+    return () => clearInterval(retry);
+  }, [aligned, enabled, currentSlide, active, detached, skipTo]);
+
   useEffect(() => {
     if (!enabled || currentSlide == null) {
+      prevCurrent.current = currentSlide;
+      prevActive.current = active;
+      return;
+    }
+    if (!aligned) {
+      // Pre-alignment navigation belongs to the join effect above — don't let
+      // its skipTos read as manual moves and detach the viewer.
       prevCurrent.current = currentSlide;
       prevActive.current = active;
       return;
@@ -117,7 +144,7 @@ export function Follower({
 
     prevCurrent.current = currentSlide;
     prevActive.current = active;
-  }, [enabled, currentSlide, active, detached, skipTo]);
+  }, [enabled, currentSlide, active, detached, aligned, skipTo]);
 
   if (!enabled) return null;
 


### PR DESCRIPTION
## Bug

An attendee opening the deck **while a talk is already live** stayed on slide 1 until the presenter next changed slide (found during the pre-talk live drill — see `docs/verify-deployed-talk.md` in #34). `Follower`'s initial reconcile `skipTo` fires once, Spectacle drops it because its navigation isn't ready yet, and nothing re-fires it. `DeckDriver` already works around this exact race with a retry; `Follower` didn't.

## Fix

- New join-alignment effect in `Follower`: retry `skipTo` on a 250ms interval until `activeView.slideIndex` actually equals the room's slide, then mark aligned.
- Detach heuristics (manual-move detection) are held until that first alignment, so the retry navigations aren't misread as the viewer roaming — pre-alignment, prev-refs are just kept current.
- Guards: skips when follow is disabled, the room has no slide yet, or the viewer already detached.

## Verification (live A/B on the dev deployment)

Ran two frontends against the same live dev-Convex talk, presenter parked at slide 9:

| build | fresh anonymous client joins mid-talk |
| --- | --- |
| unfixed (`blog-audience` worktree, :3002) | stuck at **1 / 23** |
| this branch (:3005) | lands on **9 / 23** without the presenter moving |

Post-alignment regression checks on the fixed build: presenter 9→10 still mirrored (~2s); manual ArrowLeft detaches (stays at 9 while presenter at 10) and the "● Live — resume" pill becomes visible. Talk ended + test session cleared down afterwards.

`tsc`, Biome, 57/57 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)