### PR TITLE
feat(talks): add 1979 IBM accountability quote slide

### DIFF
--- a/data/talks/so-you-want-to-build-software.mdx
+++ b/data/talks/so-you-want-to-build-software.mdx
@@ -284,6 +284,26 @@ AI is the biggest change in my job right now — but it's a **power tool, not a 
 
 ---
 
+# THEY SAW THIS COMING
+
+> ### "A computer can never be held accountable, therefore a computer must never make a management decision."
+>
+> — IBM training manual, **1979**
+
+Written when computers filled rooms — nearly **50 years** before AI could write code. Still true today: the computer does the work, but a **person** owns the decision.
+
+???
+
+[⏱ ~1 min · IBM QUOTE · inside the AI window] One beat, let the quote breathe.
+- Read it aloud, then land the date: **1979** — before their parents were born,
+  decades before ChatGPT.
+- Tie straight back to the previous slide: AI can draft the code, but *I* check it
+  and *I* answer for it. Accountability doesn't transfer to the tool.
+- That's why the fundamentals matter — you can't be accountable for something you
+  can't understand.
+
+---
+
 # WHERE I'VE WORKED
 
 Same skills — wildly different worlds:


### PR DESCRIPTION
## Summary
- Adds a new slide, **"They Saw This Coming"**, to the *So You Want To Build Software?* deck, quoting the 1979 IBM training manual: *"A computer can never be held accountable, therefore a computer must never make a management decision."*
- Placed directly after **The Role of AI** so it lands as the closing beat of the AI section (~1 min, inside the existing 66–69 timing window).
- Presenter notes tie it back to the previous slide: AI drafts, a person checks and answers for it — which is why fundamentals still matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)