### PR TITLE
fix(talks): keep presenter deck and console surfaces in sync

### DIFF
--- a/components/talks/DeckLive.tsx
+++ b/components/talks/DeckLive.tsx
@@ -13,10 +13,19 @@ type NavRef = { current: { next: () => void; prev: () => void } | null };
  * room — the deck itself is the source of truth, so it never "detaches". On mount
  * it aligns to the room's current slide (so opening a driver mid-talk doesn't
  * reset everyone to the first slide), and only broadcasts once aligned.
+ *
+ * The presenter can run TWO driving surfaces at once (projected deck +
+ * console). Each also follows `currentSlide`, so a move on either surface
+ * pulls the other along — like attendee follow, but without detach: both
+ * surfaces stay live drivers. Two guards prevent echo loops: room changes
+ * are ignored while our own broadcast is in flight (that change is our own
+ * echo), and a position we moved to *because* the room changed is never
+ * re-broadcast.
  */
 export function DeckDriver({
   room,
   initialSlide,
+  currentSlide,
   setSlide,
   onIndex,
   navRef,
@@ -25,6 +34,8 @@ export function DeckDriver({
 }: {
   room?: string;
   initialSlide: number;
+  /** Live room slide — lets co-presenter surfaces (deck + console) follow each other. */
+  currentSlide?: number;
   setSlide: SetSlide;
   onIndex?: (index: number) => void;
   navRef?: NavRef;
@@ -38,6 +49,13 @@ export function DeckDriver({
   // component only mounts after the talk has loaded), then we align to it.
   const targetRef = useRef(initialSlide);
   const [aligned, setAligned] = useState(false);
+  // Broadcasts from THIS surface still in flight — while any are pending, a
+  // room-slide change is our own write echoing back, not another surface.
+  const pendingRef = useRef(0);
+  // Slide we jumped to because the room moved (other surface drove there) —
+  // consumed by the broadcast effect so we don't re-publish what we received.
+  const followedRef = useRef<number | null>(null);
+  const prevRemoteRef = useRef(currentSlide);
 
   // Expose deck navigation to out-of-deck controls (the console Prev/Next).
   if (navRef) navRef.current = { next: advanceSlide, prev: regressSlide };
@@ -59,14 +77,37 @@ export function DeckDriver({
     onIndex?.(index);
   }, [index, onIndex]);
 
+  // Co-presenter follow: the room's slide changed and it isn't an echo of our
+  // own broadcast — the presenter's OTHER surface moved, so follow it.
+  useEffect(() => {
+    const prev = prevRemoteRef.current;
+    prevRemoteRef.current = currentSlide;
+    if (!aligned || currentSlide == null || currentSlide === prev) return;
+    if (pendingRef.current > 0) return; // our own write echoing back
+    if (currentSlide === index) return;
+    followedRef.current = currentSlide;
+    skipTo({ slideIndex: currentSlide, stepIndex: 0 });
+  }, [aligned, currentSlide, index, skipTo]);
+
   // Broadcast position to the room (only after alignment).
   useEffect(() => {
     if (!aligned || !room) return;
+    if (followedRef.current === index) {
+      // We're on this slide because the other surface drove here — don't
+      // publish it back (that echo could drag a fast-moving driver backwards).
+      followedRef.current = null;
+      return;
+    }
+    followedRef.current = null;
+    pendingRef.current += 1;
     setSlide({ room, index })
       .then(() => onPublished?.(index))
       .catch((e) =>
         onError?.(e instanceof Error ? e.message : 'broadcast failed'),
-      );
+      )
+      .finally(() => {
+        pendingRef.current -= 1;
+      });
   }, [aligned, index, room, setSlide, onPublished, onError]);
 
   return null;

--- a/components/talks/SpectacleDeck.tsx
+++ b/components/talks/SpectacleDeck.tsx
@@ -141,9 +141,11 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
   const reactionsOn = liveHere && current?.config.reactions === true;
   const room = current?.room;
 
-  // Both presenter and console DRIVE the deck (their navigation broadcasts);
-  // attendees follow. Same admin identity, so both heartbeat a presenter session
-  // and two connected at once surfaces a clash.
+  // Both presenter and console DRIVE the deck (their navigation broadcasts),
+  // and via DeckDriver's co-presenter follow they also track each other, so
+  // advancing either surface moves the other. Attendees follow. Same admin
+  // identity, so both heartbeat a presenter session and two connected at once
+  // surfaces a clash.
   const broadcasting =
     (mode === 'presenter' || mode === 'console') && followOn && isAdmin;
   const followEnabled = followOn && !broadcasting;
@@ -237,6 +239,7 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
         <DeckDriver
           room={room}
           initialSlide={current?.currentSlide ?? 0}
+          currentSlide={current?.currentSlide}
           setSlide={setSlide}
           onIndex={setDeckIndex}
           navRef={navRef}


### PR DESCRIPTION
## What

When dual-presenting — projected deck (`?mode=presenter`) on one screen and console (`?mode=console`) on a second — changing the slide on one surface did not move the other; the presenter had to advance both by hand every slide.

`DeckDriver` (rendered by both presenter surfaces) aligned to the room's slide once on mount and then only ever *broadcast* — it never listened for later room changes. Attendee decks already converge on the broadcast slide via `Follower`; the presenter's own surfaces had no equivalent.

## How

`DeckDriver` now also follows the room's `currentSlide` (passed down from `SpectacleDeck`): a room change that isn't an echo of this surface's own broadcast means the presenter's *other* surface moved, so the driver `skipTo`s it. Unlike attendee follow there is no detach — both surfaces remain full drivers, and both still broadcast their own navigation.

Two guards prevent echo loops / fighting local navigation:

- room-slide changes are ignored while this surface's own `setSlide` is still in flight (that change is our own write echoing back);
- a position reached *by following* the room is consumed and never re-broadcast, so a fast-moving driver can't be dragged backwards by its peer's echo.

## Manual test (two browser windows, admin GitHub session)

1. Start a live, follow-enabled talk from `/admin`.
2. Window A: open the deck with `?mode=presenter`. Window B: same deck with `?mode=console`.
3. Advance slides in A (arrow keys) — B's deck, notes and preview follow within a beat.
4. Advance/regress in B (console Prev/Next or arrows) — A follows.
5. Navigate quickly back and forth on one surface — no bouncing/oscillation, and an attendee tab (default mode) still tracks the presenter slide.
6. Open a third surface mid-talk — it aligns to the current slide, as before.

## Validation

- `pnpm exec tsc --noEmit` clean
- `pnpm lint` (biome) clean
- `pnpm test` 57/57 unit tests pass

QA finding 23 from the 2026-07-02 careers-workshop debrief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)