### PR TITLE
feat(admin): flip talk feature flags mid-talk without ending the session

### DIFF
--- a/components/admin/TalkControls.tsx
+++ b/components/admin/TalkControls.tsx
@@ -9,6 +9,9 @@ const FEATURE_TOGGLES: { key: keyof TalkConfig; label: string }[] = [
   { key: 'reactions', label: 'Emoji reactions' },
   { key: 'follow', label: 'Follow-the-presenter' },
   { key: 'closingChart', label: 'Closing stats chart' },
+  { key: 'qa', label: 'Q&A queue' },
+  { key: 'poll', label: 'Poll / word cloud' },
+  { key: 'activities', label: 'Ordering activities' },
 ];
 
 /**
@@ -19,6 +22,7 @@ export default function TalkControls() {
   const current = useQuery(api.talks.current);
   const start = useMutation(api.talks.start);
   const end = useMutation(api.talks.end);
+  const updateConfig = useMutation(api.talks.updateConfig);
 
   const [slug, setSlug] = useState('so-you-want-to-build-software');
   const [title, setTitle] = useState('So You Want To Build Software?');
@@ -38,14 +42,45 @@ export default function TalkControls() {
     return <p className="font-mono text-zinc-400">Connecting…</p>;
   }
 
-  // While a talk is live, hide the start form entirely — the only action is to
-  // stop it.
+  // While a talk is live, hide the start form — but keep the feature toggles
+  // available so flags (e.g. reactions) can be flipped mid-talk without ending
+  // the session. Toggles write through talks.updateConfig; every audience
+  // mutation re-checks the config server-side, so flips apply immediately.
   if (current) {
+    const liveConfig = current.config;
+    const setLiveFlag = (key: keyof TalkConfig, value: boolean) =>
+      run(() =>
+        updateConfig({
+          room: current.room,
+          config: { ...liveConfig, [key]: value },
+        }),
+      );
     return (
       <div className="space-y-3 font-mono">
         <p className="text-sm text-zinc-300">
           A talk is running. Starting a new one isn't available until this ends.
         </p>
+        <fieldset className="border-2 border-zinc-700 p-3">
+          <legend className="px-1 text-xs uppercase text-zinc-400">
+            Live features (apply instantly)
+          </legend>
+          <div className="space-y-2">
+            {FEATURE_TOGGLES.map(({ key, label }) => (
+              <label
+                key={key}
+                className="flex items-center gap-2 text-sm text-white"
+              >
+                <input
+                  type="checkbox"
+                  checked={liveConfig[key] as boolean}
+                  onChange={(e) => setLiveFlag(key, e.target.checked)}
+                  className="h-4 w-4 accent-brutalist-cyan"
+                />
+                {label}
+              </label>
+            ))}
+          </div>
+        </fieldset>
         <button
           type="button"
           onClick={() => run(() => end({}))}

--- a/convex/talks.ts
+++ b/convex/talks.ts
@@ -143,6 +143,22 @@ export const start = mutation({
   },
 });
 
+/**
+ * Presenter: replace the live talk's feature config mid-talk. Admin-only.
+ * Every audience mutation re-resolves the config on each call (e.g.
+ * reactions.send re-checks `resolveConfig(talk).reactions` before inserting),
+ * so a flipped flag takes effect immediately — no new room, nothing orphaned.
+ */
+export const updateConfig = mutation({
+  args: { room: v.string(), config: talkConfigValidator },
+  handler: async (ctx, { room, config }) => {
+    await requireAdmin(ctx);
+    const talk = await liveTalkForRoom(ctx, room);
+    if (!talk) return;
+    await ctx.db.patch(talk._id, { config });
+  },
+});
+
 /** Presenter: end the current talk. Admin-only. */
 export const end = mutation({
   args: {},


### PR DESCRIPTION
## What

Adds a server-enforced way to flip a live talk's feature flags mid-session, plus admin UI toggles for it. QA finding **#25** from the **2026-07-02 careers-workshop debrief**.

- **`convex/talks.ts`** — new `talks.updateConfig` mutation: `requireAdmin`-gated, resolves the room via `liveTalkForRoom` (no-ops unless the talk is live), args validated by `talkConfigValidator`, and patches the live talk row's `config` in place.
- **`components/admin/TalkControls.tsx`** — while a talk is live, the controls card now shows a "Live features (apply instantly)" fieldset with checkboxes for **all boolean flags** (head-count, reactions, follow, closing chart, Q&A, poll, activities) wired to `updateConfig`. The shared `FEATURE_TOGGLES` list also gains qa/poll/activities, so the pre-start form can set them individually too.

## Why

Talk config was written once by `talks.start`; once live, TalkControls hid the entire start form and offered only "End talk" — which mints a new room and orphans everything submitted. In a room of kids the presenter needed to switch emoji reactions off (and back on) mid-talk.

## Immediacy (verified in code)

Every audience mutation re-resolves `resolveConfig(talk)` on each call, so a patched config takes effect on the very next write:

- `reactions.send` re-checks `resolveConfig(talk).reactions` before inserting — reactions off means writes are dropped instantly.
- Same pattern in `presence.ping`, `polls`, `questions`, `activities`, and `talks.setSlide` (follow).
- Audience UIs read the reactive `talks.current` query, so panels hide/show immediately as well.

One soft edge: flipping **head-count** off stops new heartbeats instantly, but attendee rows already written decay via the existing TTL reaper rather than vanishing at once. No feature fails to honour the flip.

## Manual test steps

1. Sign in at `/admin` with an allowlisted GitHub account and start a talk with reactions on.
2. Open `/live` in a second (incognito) window; send a few emoji reactions — they animate.
3. In `/admin`, untick **Emoji reactions** in the new "Live features" fieldset.
4. `/live` hides the reaction bar immediately; any in-flight `reactions.send` calls are dropped server-side (reaction totals stop growing).
5. Re-tick the box — the bar returns and reactions land again. Same room throughout; presence/Q&A/poll data all intact.
6. Repeat for follow: untick and confirm broadcast slide changes stop moving followers.

Validation: `pnpm exec tsc --noEmit` clean, `vitest --project unit` 31/31 passing, biome clean, `npx convex codegen` produced no `_generated` diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)