### PR TITLE
feat(activities): presenter evaluation surface for ordered-actions submissions

### DIFF
--- a/components/admin/ActivityEvalGrid.tsx
+++ b/components/admin/ActivityEvalGrid.tsx
@@ -1,0 +1,96 @@
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import type { Doc } from '@/convex/_generated/dataModel';
+import { useRunAction } from './useRunAction';
+
+/**
+ * Presenter evaluation surface for an open ordered-actions activity. Renders
+ * every submission (including hidden ones, straight from `activities.feed`) as
+ * compact numbered-steps cards in a responsive grid so answers can be scanned
+ * and compared side by side, with in-context controls on each card:
+ * - mark/unmark — highlight the submission being worked through with the room
+ *   (presenter-only; the audience wall never sees it),
+ * - hide/restore — pull it from / return it to the audience wall.
+ */
+export default function ActivityEvalGrid({
+  submissions,
+}: {
+  submissions: Doc<'activitySubmissions'>[];
+}) {
+  const setHidden = useMutation(api.activities.setHidden);
+  const setMarked = useMutation(api.activities.setMarked);
+  const { run, error } = useRunAction();
+
+  if (submissions.length === 0) {
+    return (
+      <p className="font-mono text-xs text-zinc-500">No submissions yet.</p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="grid gap-2 [grid-template-columns:repeat(auto-fill,minmax(13rem,1fr))]">
+        {submissions.map((s) => (
+          <div
+            key={s._id}
+            className={`flex flex-col border-2 bg-black p-2 ${
+              s.marked
+                ? 'border-brutalist-yellow shadow-hard-yellow'
+                : s.hidden
+                  ? 'border-zinc-800 opacity-60'
+                  : 'border-zinc-700'
+            }`}
+          >
+            <div className="mb-1 flex items-center justify-between gap-2">
+              <span className="truncate font-mono text-xs text-brutalist-pink">
+                {s.nickname ?? 'anon'}
+              </span>
+              {s.marked ? (
+                <span className="shrink-0 font-mono text-[10px] uppercase text-brutalist-yellow">
+                  ★ marked
+                </span>
+              ) : s.hidden ? (
+                <span className="shrink-0 font-mono text-[10px] uppercase text-zinc-500">
+                  hidden
+                </span>
+              ) : null}
+            </div>
+            <ol
+              className={`mb-2 space-y-0.5 ${s.hidden ? 'line-through' : ''}`}
+            >
+              {/* Steps are positional (order is the point), so index keys are fine. */}
+              {s.steps.map((step, i) => (
+                <li key={i} className="font-mono text-xs text-zinc-200">
+                  <span className="text-zinc-500">{i + 1}.</span> {step}
+                </li>
+              ))}
+            </ol>
+            <div className="mt-auto flex gap-3 font-mono text-[10px] uppercase">
+              <button
+                type="button"
+                className="text-brutalist-yellow underline"
+                onClick={() =>
+                  run(() => setMarked({ id: s._id, marked: !s.marked }))
+                }
+              >
+                {s.marked ? 'unmark' : 'mark'}
+              </button>
+              <button
+                type="button"
+                className="text-brutalist-pink underline"
+                onClick={() =>
+                  run(() => setHidden({ id: s._id, hidden: !s.hidden }))
+                }
+              >
+                {s.hidden ? 'restore' : 'hide'}
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      {error && (
+        <p className="font-mono text-xs text-brutalist-pink">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/components/admin/AudienceControls.tsx
+++ b/components/admin/AudienceControls.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery } from 'convex/react';
 import { useState } from 'react';
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
+import ActivityEvalGrid from './ActivityEvalGrid';
 import { useRunAction } from './useRunAction';
 
 /** Shared error line for the admin panels. */
@@ -136,7 +137,6 @@ function ActivityControls({ room }: { room: string }) {
   const open = useMutation(api.activities.open);
   const close = useMutation(api.activities.close);
   const revealNow = useMutation(api.activities.revealNow);
-  const setHidden = useMutation(api.activities.setHidden);
   const { run, error } = useRunAction();
 
   const [prompt, setPrompt] = useState('');
@@ -155,42 +155,11 @@ function ActivityControls({ room }: { room: string }) {
               ({activity.revealed ? 'answer revealed' : 'answer hidden'})
             </span>
           </p>
-          <div className="max-h-56 space-y-2 overflow-y-auto">
-            {feed?.authorized &&
-              feed.submissions.map((s) => (
-                <div
-                  key={s._id}
-                  className={`border-2 p-2 font-mono text-xs ${
-                    s.hidden
-                      ? 'border-zinc-800 text-zinc-600'
-                      : 'border-zinc-700 text-zinc-200'
-                  }`}
-                >
-                  <div className="mb-1 flex items-center justify-between">
-                    <span className="text-brutalist-pink">
-                      {s.nickname ?? 'anon'}
-                    </span>
-                    <button
-                      type="button"
-                      className="text-xs uppercase text-brutalist-pink underline"
-                      onClick={() =>
-                        run(() =>
-                          setHidden({
-                            id: s._id as Id<'activitySubmissions'>,
-                            hidden: !s.hidden,
-                          }),
-                        )
-                      }
-                    >
-                      {s.hidden ? 'restore' : 'reject'}
-                    </button>
-                  </div>
-                  <span className={s.hidden ? 'line-through' : ''}>
-                    {s.steps.join(' → ')}
-                  </span>
-                </div>
-              ))}
-          </div>
+          {feed?.authorized && (
+            <div className="max-h-96 overflow-y-auto pr-1">
+              <ActivityEvalGrid submissions={feed.submissions} />
+            </div>
+          )}
           <div className="flex gap-2">
             {!activity.revealed && (
               <button

--- a/components/talks/DeckSidebars.tsx
+++ b/components/talks/DeckSidebars.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQuery } from 'convex/react';
+import ActivityEvalGrid from '@/components/admin/ActivityEvalGrid';
 import PresenceBadge from '@/components/PresenceBadge';
 import Reactions from '@/components/Reactions';
 import TalkStatsChart from '@/components/TalkStatsChart';
@@ -82,6 +83,9 @@ export function ConsoleSidebar({
   durationMins?: number;
 }) {
   const presenters = useQuery(api.talks.presenterCount, { room });
+  // Presenter-only feed of the open ordered-actions activity (null when none),
+  // so submissions can be evaluated from the console without leaving the deck.
+  const activityFeed = useQuery(api.activities.feed, { room });
   const end = useMutation(api.talks.end);
 
   const last = slides.length - 1;
@@ -158,6 +162,25 @@ export function ConsoleSidebar({
             Next up
           </p>
           <Thumb code={next.code} />
+        </div>
+      )}
+
+      {/* Open ordered-actions activity: evaluate submissions in-context
+          (mark the one being discussed, hide/restore) without leaving the deck. */}
+      {activityFeed?.authorized && activityFeed.activity && (
+        <div>
+          <p className="mb-1 font-mono text-xs uppercase tracking-wider text-brutalist-yellow">
+            Activity · {activityFeed.submissions.length}{' '}
+            {activityFeed.submissions.length === 1
+              ? 'submission'
+              : 'submissions'}
+          </p>
+          <p className="mb-2 font-mono text-xs text-zinc-400">
+            {activityFeed.activity.prompt}
+          </p>
+          <div className="max-h-80 overflow-y-auto pr-1">
+            <ActivityEvalGrid submissions={activityFeed.submissions} />
+          </div>
         </div>
       )}
 

--- a/convex/activities.ts
+++ b/convex/activities.ts
@@ -236,3 +236,16 @@ export const setHidden = mutation({
     await ctx.db.patch(id, { hidden });
   },
 });
+
+/**
+ * Presenter: mark/unmark a submission while working through the responses with
+ * the room. Only surfaced on presenter views (the audience `active` query never
+ * returns it), so marking carries no audience-facing side effects.
+ */
+export const setMarked = mutation({
+  args: { id: v.id('activitySubmissions'), marked: v.boolean() },
+  handler: async (ctx, { id, marked }) => {
+    await requireAdmin(ctx);
+    await ctx.db.patch(id, { marked });
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -181,6 +181,12 @@ export default defineSchema({
     steps: v.array(v.string()),
     /** Presenter has removed this from the wall. */
     hidden: v.boolean(),
+    /**
+     * Presenter has marked this while evaluating submissions with the room
+     * (e.g. "discussing this one" / "already covered"). Presenter-only signal —
+     * never exposed on the audience wall.
+     */
+    marked: v.optional(v.boolean()),
     createdAt: v.number(),
   })
     .index('by_activity_created', ['activityId', 'createdAt'])


### PR DESCRIPTION
## What

Makes the presenter view of an open ordered-actions ("put it in order") activity a proper evaluation surface — **QA finding #22 from the 2026-07-02 careers-workshop debrief**.

- **New `components/admin/ActivityEvalGrid.tsx`** — every submission (including hidden ones, via the admin-gated `activities.feed`) rendered as compact numbered-steps cards in a responsive grid, easy to scan and compare side by side. Each card has in-context controls:
  - **mark / unmark** — highlight (yellow border + hard shadow + ★ tag) the submission being worked through with the room; presenter-only, never exposed on the audience wall
  - **hide / restore** — pull a submission from / return it to the audience wall (existing `hidden` flag, now surfaced properly)
- **`/admin` ActivityControls** — the cramped `steps.join(' → ')` one-line list is replaced with the grid.
- **Console deck sidebar (`ConsoleSidebar`)** — when an activity is open, a new "Activity · N submissions" section shows the prompt + the same evaluation grid, so the presenter can evaluate from the second screen without leaving the deck.
- **Backend** — optional `marked: v.optional(v.boolean())` on `activitySubmissions` + admin-gated `activities.setMarked` mutation. `feed` already returns full docs so the flag flows through; the audience-facing `active` query never returns it.

## Why

During the toast activity, incoming group answers were presented as an unscannable list with no in-context moderation, and no way to track which answer was under discussion — the presenter ended up walking the room reading students' devices.

## Manual test steps

1. Start a live talk (activities enabled) on `/admin`, open a put-it-in-order activity.
2. Submit 3–4 answers from `/live` as an attendee (include one with profanity to get an auto-hidden row).
3. On `/admin` → "Put-it-in-order activity": submissions appear as numbered-steps cards in a grid; the auto-hidden one is greyed with a `hidden` tag.
4. Click **mark** on a card — it gets a yellow border + ★ marked tag; **unmark** reverts. The audience wall is unaffected.
5. Click **hide** — the card greys out and disappears from the audience wall on `/live`; **restore** brings it back.
6. Open the deck in console mode (`?mode=console`): the sidebar shows "Activity · N submissions" with the same cards and controls; changes sync live with `/admin`.

## Validation

- `pnpm typecheck` clean
- `biome check` clean on changed files
- `vitest run tests/toast-profanity.test.ts tests/talk-metadata.test.ts` — 15/15 pass
- `npx convex codegen` — no generated-file drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)