### PR TITLE
feat(talks): per-slide pacing indicator + whole-talk clock on /admin

### DIFF
--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -6,6 +6,7 @@ import AudienceControls from '@/components/admin/AudienceControls';
 import SessionManager from '@/components/admin/SessionManager';
 import TalkControls from '@/components/admin/TalkControls';
 import TalkStatsChart from '@/components/TalkStatsChart';
+import TalkTimer from '@/components/talks/TalkTimer';
 import { api } from '@/convex/_generated/api';
 
 const DEFAULT_SLUG = 'so-you-want-to-build-software';
@@ -68,7 +69,11 @@ function ConfigBadges({
   );
 }
 
-function Dashboard() {
+function Dashboard({
+  talkDurations,
+}: {
+  talkDurations?: Record<string, number>;
+}) {
   const current = useQuery(api.talks.current);
   const viewer = useQuery(api.talks.viewer);
   const { signOut } = useAuthActions();
@@ -108,6 +113,13 @@ function Dashboard() {
               {current.title}
             </p>
             <ConfigBadges config={current.config} />
+            {/* Whole-talk clock — same pacing timer as the presenter console,
+                keyed on startedAt so a new talk resets it. */}
+            <TalkTimer
+              key={current.startedAt}
+              startedAt={current.startedAt}
+              durationMins={talkDurations?.[current.slug]}
+            />
           </div>
         ) : (
           <p className="font-mono text-zinc-400">
@@ -226,10 +238,15 @@ function Dashboard() {
  * the page shell prerender cleanly and never crash at build time on a missing
  * ConvexProvider.
  */
-export default function AdminDashboard() {
+export default function AdminDashboard({
+  talkDurations,
+}: {
+  /** slug → frontmatter durationMins, baked in by pages/admin getStaticProps. */
+  talkDurations?: Record<string, number>;
+}) {
   return (
     <AdminGate>
-      <Dashboard />
+      <Dashboard talkDurations={talkDurations} />
     </AdminGate>
   );
 }

--- a/components/talks/DeckSidebars.tsx
+++ b/components/talks/DeckSidebars.tsx
@@ -3,10 +3,16 @@ import PresenceBadge from '@/components/PresenceBadge';
 import Reactions from '@/components/Reactions';
 import TalkStatsChart from '@/components/TalkStatsChart';
 import { api } from '@/convex/_generated/api';
+import type { SlideWindow } from '@/lib/slideTiming';
 import SlideBody from './SlideBody';
 import TalkTimer from './TalkTimer';
 
-type Slide = { code: string; notes: string | null };
+type Slide = {
+  code: string;
+  notes: string | null;
+  /** `[⏱ a–b …]` window from the notes — drives the pacing indicator. */
+  window?: SlideWindow | null;
+};
 
 // Right-hand deck sidebar. The floating reaction bubbles (from <Reactions>) rise
 // in the viewport's right 20vw, i.e. within/near this panel.
@@ -101,12 +107,15 @@ export function ConsoleSidebar({
         Console
       </p>
 
-      {/* Pacing timer (keyed on startedAt so a new talk resets it) */}
+      {/* Pacing timer (keyed on startedAt so a new talk resets it) — with the
+          current slide's ⏱ window (when its notes declare one) for the
+          on-track / ahead / behind indicator. */}
       {startedAt != null && (
         <TalkTimer
           key={startedAt}
           startedAt={startedAt}
           durationMins={durationMins}
+          slideWindow={slides[idx]?.window ?? null}
         />
       )}
 

--- a/components/talks/SpectacleDeck.tsx
+++ b/components/talks/SpectacleDeck.tsx
@@ -12,6 +12,7 @@ import {
 } from 'spectacle';
 import { api } from '@/convex/_generated/api';
 import { isConvexConfigured } from '@/lib/convexClient';
+import type { SlideWindow } from '@/lib/slideTiming';
 import { DeckDriver, Follower } from './DeckLive';
 import { DeckModeProvider } from './DeckModeContext';
 import { AttendeeSidebar, ConsoleSidebar } from './DeckSidebars';
@@ -22,6 +23,8 @@ export interface DeckSlide {
   code: string;
   notes: string | null;
   notesCode: string | null;
+  /** Per-slide `[⏱ a–b …]` timing window (minutes from talk start), if any. */
+  window?: SlideWindow | null;
 }
 
 interface SpectacleDeckProps {

--- a/components/talks/TalkTimer.tsx
+++ b/components/talks/TalkTimer.tsx
@@ -1,9 +1,40 @@
 import { useStopwatch } from 'react-timer-hook';
+import { pacingStatus, type SlideWindow } from '@/lib/slideTiming';
 
 function fmt(totalSeconds: number): string {
   const s = Math.abs(Math.floor(totalSeconds));
   const m = Math.floor(s / 60);
   return `${m}:${String(s % 60).padStart(2, '0')}`;
+}
+
+/** "on track / ~N min ahead / ~N min behind" vs the current slide's window. */
+function SlidePace({
+  elapsedSeconds,
+  window,
+}: {
+  elapsedSeconds: number;
+  window: SlideWindow;
+}) {
+  const pace = pacingStatus(elapsedSeconds, window);
+  const color =
+    pace.kind === 'behind'
+      ? '#f472b6'
+      : pace.kind === 'ahead'
+        ? '#facc15'
+        : '#22d3ee';
+  const label =
+    pace.kind === 'on-track' ? 'on track' : `~${pace.minutes} min ${pace.kind}`;
+
+  return (
+    <div className="mt-2 flex items-baseline justify-between gap-2 border-t-2 border-zinc-700 pt-2 text-xs uppercase">
+      <span className="text-zinc-400">
+        slide {window.startMin}–{window.endMin}m
+      </span>
+      <span className="font-bold" style={{ color }}>
+        {label}
+      </span>
+    </div>
+  );
 }
 
 /**
@@ -12,13 +43,19 @@ function fmt(totalSeconds: number): string {
  * talk has a target duration, shows time remaining + a progress bar that turns
  * amber near the end and pink when overtime. Seeded via react-timer-hook's
  * useStopwatch offset; re-mount (keyed on startedAt) resets it for a new talk.
+ *
+ * When the current slide has a `[⏱ a–b …]` window in its presenter notes,
+ * pass it as `slideWindow` to also show a per-slide "on track / ahead /
+ * behind" line; slides without a window show nothing extra.
  */
 export default function TalkTimer({
   startedAt,
   durationMins,
+  slideWindow,
 }: {
   startedAt: number;
   durationMins?: number;
+  slideWindow?: SlideWindow | null;
 }) {
   // Seed the stopwatch with however long the talk has already been running.
   const elapsedNow = Math.max(0, Math.floor((Date.now() - startedAt) / 1000));
@@ -57,6 +94,9 @@ export default function TalkTimer({
             style={{ width: `${pct}%`, background: color }}
           />
         </div>
+      )}
+      {slideWindow && (
+        <SlidePace elapsedSeconds={totalSeconds} window={slideWindow} />
       )}
     </div>
   );

--- a/lib/slideTiming.ts
+++ b/lib/slideTiming.ts
@@ -1,0 +1,76 @@
+/**
+ * Per-slide timing windows, parsed from the `[⏱ start–end · LABEL]` tags that
+ * talk decks embed in their presenter notes (minutes from talk start), e.g.
+ *
+ *   [⏱ 66–69 · THE ROLE OF AI]
+ *   [⏱ 28–46 · TOAST ACTIVITY 🍞 · ~18 min · device-free]
+ *   [⏱ 99–100+ · Q&A]
+ *
+ * Pure module (no fs / React) so it's usable from the build-time deck loader
+ * (lib/talks.ts), client components, and unit tests alike.
+ *
+ * Deliberately tolerant: notes whose tag isn't a range from talk start (e.g.
+ * `[⏱ ~1 min · ICEBREAKER · overlaps the intro window]`) parse as null —
+ * "no window" — and the console simply shows nothing extra for that slide.
+ */
+
+export type SlideWindow = {
+  /** Window opens N minutes after talk start. */
+  startMin: number;
+  /** Window closes N minutes after talk start. */
+  endMin: number;
+};
+
+// `[⏱ 12–34 …]` — en dash, em dash or hyphen between the minute marks; an
+// optional trailing `+` on the end mark (`99–100+`); then either the label
+// separator `·` or the closing bracket. Anchoring on `⏱ <digits>` is what
+// rejects the `~N min` overlap variants.
+const WINDOW_RE =
+  /\[\s*⏱\s*(\d+(?:\.\d+)?)\s*[–—-]\s*(\d+(?:\.\d+)?)\s*\+?\s*[·\]]/u;
+
+/**
+ * Extract the timing window from a slide's raw presenter notes. Returns null
+ * for missing notes, notes without a `⏱` tag, and unparseable/nonsensical
+ * variants (non-range tags, reversed ranges) — treat null as "no window".
+ */
+export function parseSlideWindow(
+  notes: string | null | undefined,
+): SlideWindow | null {
+  if (!notes) return null;
+
+  const match = notes.match(WINDOW_RE);
+  if (!match) return null;
+
+  const startMin = Number(match[1]);
+  const endMin = Number(match[2]);
+  if (!Number.isFinite(startMin) || !Number.isFinite(endMin)) return null;
+  if (startMin < 0 || endMin <= startMin) return null;
+
+  return { startMin, endMin };
+}
+
+export type Pacing =
+  | { kind: 'on-track' }
+  | { kind: 'ahead' | 'behind'; minutes: number };
+
+/**
+ * Where the talk clock sits relative to the current slide's window: inside it
+ * (or within rounding distance of it) is on track; reaching the slide before
+ * its window opens is ahead; still on it after the window closes is behind.
+ */
+export function pacingStatus(
+  elapsedSeconds: number,
+  window: SlideWindow,
+): Pacing {
+  const elapsedMin = elapsedSeconds / 60;
+
+  if (elapsedMin < window.startMin) {
+    const minutes = Math.round(window.startMin - elapsedMin);
+    return minutes > 0 ? { kind: 'ahead', minutes } : { kind: 'on-track' };
+  }
+  if (elapsedMin > window.endMin) {
+    const minutes = Math.round(elapsedMin - window.endMin);
+    return minutes > 0 ? { kind: 'behind', minutes } : { kind: 'on-track' };
+  }
+  return { kind: 'on-track' };
+}

--- a/lib/talks.ts
+++ b/lib/talks.ts
@@ -8,6 +8,7 @@ import {
   getRemarkPlugins,
   setEsbuildBinaryPath,
 } from './mdx';
+import { parseSlideWindow, type SlideWindow } from './slideTiming';
 import { show_drafts } from './utils/showDrafts';
 
 const root = process.cwd();
@@ -209,6 +210,11 @@ export type TalkSlide = {
   notes: string | null;
   /** Compiled notes MDX — rendered (formatted) in Spectacle's presenter view. */
   notesCode: string | null;
+  /**
+   * Timing window (minutes from talk start) parsed from the notes' `[⏱ a–b …]`
+   * tag — drives the console's per-slide pacing indicator. Null = no window.
+   */
+  window: SlideWindow | null;
 };
 
 export async function getTalkBySlug(
@@ -235,7 +241,12 @@ export async function getTalkBySlug(
         compileSlide(body.trim()),
         notes ? compileSlide(notes) : Promise.resolve(null),
       ]);
-      return { code, notes: notes || null, notesCode };
+      return {
+        code,
+        notes: notes || null,
+        notesCode,
+        window: parseSlideWindow(notes),
+      };
     }),
   );
 

--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -1,6 +1,8 @@
+import type { GetStaticProps, InferGetStaticPropsType } from 'next';
 import dynamic from 'next/dynamic';
 import { PageSEO } from '@/components/SEO';
 import siteMetadata from '@/data/siteMetadata';
+import { getAllTalksFrontMatter } from '@/lib/talks';
 
 // The cockpit is entirely Convex/auth-driven, so render it client-only. The
 // page shell (heading) still prerenders; the dashboard never touches SSR.
@@ -12,7 +14,22 @@ const AdminDashboard = dynamic(
   },
 );
 
-export default function AdminPage() {
+// Talk targets come from deck frontmatter (build-time fs), which the
+// client-only dashboard can't read — so bake a slug → durationMins map into
+// the page props for the live-talk clock. Drafts included: admins run those.
+export const getStaticProps: GetStaticProps<{
+  talkDurations: Record<string, number>;
+}> = async () => {
+  const talkDurations: Record<string, number> = {};
+  for (const talk of getAllTalksFrontMatter(true)) {
+    if (talk.durationMins != null) talkDurations[talk.slug] = talk.durationMins;
+  }
+  return { props: { talkDurations } };
+};
+
+export default function AdminPage({
+  talkDurations,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <>
       <PageSEO title={`Admin - ${siteMetadata.author}`} description="" />
@@ -20,7 +37,7 @@ export default function AdminPage() {
         <h1 className="mb-6 font-display text-3xl font-bold uppercase text-white">
           [ Admin ]
         </h1>
-        <AdminDashboard />
+        <AdminDashboard talkDurations={talkDurations} />
       </article>
     </>
   );

--- a/tests/slide-timing.test.ts
+++ b/tests/slide-timing.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { pacingStatus, parseSlideWindow } from '../lib/slideTiming';
+
+describe('parseSlideWindow', () => {
+  it('parses a plain en-dash window tag', () => {
+    expect(
+      parseSlideWindow('[⏱ 66–69 · THE ROLE OF AI] They will be curious.'),
+    ).toEqual({ startMin: 66, endMin: 69 });
+  });
+
+  it('parses when extra segments follow the label', () => {
+    expect(
+      parseSlideWindow('[⏱ 28–46 · TOAST ACTIVITY 🍞 · ~18 min · device-free]'),
+    ).toEqual({ startMin: 28, endMin: 46 });
+  });
+
+  it('is not confused by a ~N min segment inside the same tag', () => {
+    expect(parseSlideWindow('[⏱ 73–82 · EMOJI ACTIVITY 😀 · ~9 min · FLEX]')) //
+      .toEqual({ startMin: 73, endMin: 82 });
+  });
+
+  it('parses a trailing "+" on the end mark (99–100+)', () => {
+    expect(parseSlideWindow('[⏱ 99–100+ · Q&A] Leave real time.')).toEqual({
+      startMin: 99,
+      endMin: 100,
+    });
+  });
+
+  it('parses a window starting at 0', () => {
+    expect(parseSlideWindow('[⏱ 0–5 · INTRO] Welcome — keep it warm.')).toEqual(
+      { startMin: 0, endMin: 5 },
+    );
+  });
+
+  it.each([
+    ['hyphen', '[⏱ 46-52 · BREAK]'],
+    ['em dash', '[⏱ 46—52 · BREAK]'],
+    ['spaced dash', '[⏱ 46 – 52 · BREAK]'],
+  ])('tolerates %s ranges', (_variant, notes) => {
+    expect(parseSlideWindow(notes)).toEqual({ startMin: 46, endMin: 52 });
+  });
+
+  it('parses a tag with no label (closing bracket right after the range)', () => {
+    expect(parseSlideWindow('[⏱ 5–9] Make it human.')).toEqual({
+      startMin: 5,
+      endMin: 9,
+    });
+  });
+
+  it('finds the tag even when it is not at the start of the notes', () => {
+    expect(
+      parseSlideWindow('Remember to breathe.\n\n[⏱ 19–24 · PARENTS] Beat.'),
+    ).toEqual({ startMin: 19, endMin: 24 });
+  });
+
+  it('treats the ~N min overlap variant as no window', () => {
+    expect(
+      parseSlideWindow('[⏱ ~1 min · ICEBREAKER 🗳️ · overlaps the intro window]'),
+    ).toBeNull();
+  });
+
+  it.each([
+    ['null notes', null],
+    ['undefined notes', undefined],
+    ['empty notes', ''],
+    ['notes without a tag', 'Just remember the punchline.'],
+    ['a bare dash range outside a ⏱ tag', 'Show 4–5 milestones, fast.'],
+    ['a single minute mark', '[⏱ 45 · CHECKPOINT]'],
+    ['a reversed range', '[⏱ 52–46 · BREAK]'],
+    ['a zero-length range', '[⏱ 46–46 · BREAK]'],
+    ['a negative-looking start', '[⏱ –5–9 · WAT]'],
+  ])('returns null for %s', (_label, notes) => {
+    expect(parseSlideWindow(notes)).toBeNull();
+  });
+});
+
+describe('pacingStatus', () => {
+  const win = { startMin: 46, endMin: 52 };
+
+  it('is on track inside the window', () => {
+    expect(pacingStatus(48 * 60, win)).toEqual({ kind: 'on-track' });
+  });
+
+  it('is on track at the window edges', () => {
+    expect(pacingStatus(46 * 60, win)).toEqual({ kind: 'on-track' });
+    expect(pacingStatus(52 * 60, win)).toEqual({ kind: 'on-track' });
+  });
+
+  it('rounds a sliver outside the window to on track', () => {
+    expect(pacingStatus(46 * 60 - 20, win)).toEqual({ kind: 'on-track' });
+    expect(pacingStatus(52 * 60 + 20, win)).toEqual({ kind: 'on-track' });
+  });
+
+  it('reports ~N min ahead when the slide is reached early', () => {
+    expect(pacingStatus(43 * 60, win)).toEqual({ kind: 'ahead', minutes: 3 });
+  });
+
+  it('reports ~N min behind when still on the slide past its window', () => {
+    expect(pacingStatus(56 * 60 + 30, win)) //
+      .toEqual({ kind: 'behind', minutes: 5 });
+  });
+
+  it('handles the 0-start window (never "ahead" at 0:00)', () => {
+    expect(pacingStatus(0, { startMin: 0, endMin: 5 })) //
+      .toEqual({ kind: 'on-track' });
+  });
+});


### PR DESCRIPTION
## What / why

QA finding **#26** from the **2026-07-02 careers-workshop debrief**: the presenter notes carry per-slide timing windows (`[⏱ 66–69 · THE ROLE OF AI]`) but they were pure prose — mid-talk the only pacing signal was the whole-talk timer, and `/admin` had no clock at all.

- **`lib/slideTiming.ts`** (new, pure — no fs/React): `parseSlideWindow()` extracts the `[⏱ a–b …]` window (minutes from talk start) from raw notes; `pacingStatus()` turns elapsed time + window into `on-track / ahead(N) / behind(N)`.
- **`lib/talks.ts`**: `TalkSlide` gains `window: SlideWindow | null`, parsed at deck build/load time.
- **`TalkTimer` / `ConsoleSidebar`**: when the current slide has a window, the console's timer card shows a per-slide line — `slide 46–52m · on track` (cyan) / `~N min ahead` (yellow) / `~N min behind` (pink). Slides without a window show nothing extra.
- **`/admin`**: the Status card now renders the whole-talk `TalkTimer` for the live session. `durationMins` comes from deck frontmatter via a slug→minutes map baked into the page props by a new `getStaticProps` (the dashboard is client-only and can't read frontmatter itself); without a match the timer still shows elapsed time.

## Parser notation coverage

Verified against every `⏱` tag in `data/talks/so-you-want-to-build-software.mdx` (22 windows parse, 2 overlap slides correctly yield none):

| Notation | Result |
| --- | --- |
| `[⏱ 0–5 · INTRO]` (en dash) | `{0, 5}` |
| `[⏱ 46-52 · BREAK]` / em dash / spaced dash | `{46, 52}` |
| `[⏱ 28–46 · TOAST ACTIVITY 🍞 · ~18 min · device-free]` | `{28, 46}` (inner `~18 min` ignored) |
| `[⏱ 99–100+ · Q&A]` | `{99, 100}` |
| `[⏱ ~1 min · ICEBREAKER 🗳️ · overlaps the intro window]` | no window |
| No tag / reversed / zero-length range / bare `4–5` outside a tag | no window |

## Testing

- `tests/slide-timing.test.ts` — 22 new vitest unit cases for parser + pacing maths (`pnpm exec vitest run --project unit`: 57/57 pass).
- `pnpm exec tsc --noEmit` clean; Biome clean.
- Parser exercised against the real deck's notes end-to-end (all 24 slides, table above).

### Manual test steps

1. `pnpm dev`, start the talk from `/admin` (Start / control a talk).
2. `/admin` → Status card now shows the ticking clock + remaining-of-100m bar.
3. Open `/talks/so-you-want-to-build-software/present?mode=console` — the timer card shows e.g. `slide 0–5m · on track`.
4. Navigate ahead a few slides immediately → indicator flips to `~N min ahead` (yellow); sit on slide 1 past 5 min → `~N min behind` (pink).
5. Slides 3 and 13 (the `~1 min` overlap beats) show no pacing line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)