### PR TITLE
feat(talks): surface the live Q&A queue on both presenter surfaces

### DIFF
--- a/components/admin/AudienceControls.tsx
+++ b/components/admin/AudienceControls.tsx
@@ -291,8 +291,15 @@ function QAControls({ room }: { room: string }) {
 
   if (!feed?.authorized) return null;
 
+  // Live count in the card title so new arrivals are noticeable at a glance
+  // (the feed is reactive — the number ticks up as questions come in).
+  const count = feed.questions.length;
+
   return (
-    <Section title="Q&A moderation" accent="text-brutalist-cyan">
+    <Section
+      title={`Q&A moderation — ${count} question${count === 1 ? '' : 's'}`}
+      accent="text-brutalist-cyan"
+    >
       {feed.questions.length === 0 ? (
         <p className="font-mono text-sm text-zinc-500">No questions yet.</p>
       ) : (

--- a/components/talks/DeckSidebars.tsx
+++ b/components/talks/DeckSidebars.tsx
@@ -1,8 +1,10 @@
 import { useMutation, useQuery } from 'convex/react';
+import { useEffect, useRef, useState } from 'react';
 import PresenceBadge from '@/components/PresenceBadge';
 import Reactions from '@/components/Reactions';
 import TalkStatsChart from '@/components/TalkStatsChart';
 import { api } from '@/convex/_generated/api';
+import QuestionQueue from './QuestionQueue';
 import SlideBody from './SlideBody';
 import TalkTimer from './TalkTimer';
 
@@ -24,6 +26,80 @@ export function AttendeeSidebar({ room }: { room: string }) {
       <p className="mt-auto font-mono text-[10px] uppercase leading-relaxed text-zinc-600">
         Tap to react — everyone's reactions float up here.
       </p>
+    </aside>
+  );
+}
+
+/**
+ * Console Q&A panel: always-visible live queue (audience-visible questions,
+ * votes-first via `questions.list`) with a toast-style "+N new" ping when a
+ * question arrives. Last-seen is tracked client-side per mount, seeded with
+ * whatever is already in the queue so opening the console doesn't ping.
+ */
+function ConsoleQuestionsPanel({ room }: { room: string }) {
+  const data = useQuery(api.questions.list, { room });
+  const questions = data?.questions;
+
+  const seenRef = useRef<Set<string> | null>(null);
+  const [fresh, setFresh] = useState(0);
+
+  useEffect(() => {
+    if (!questions) return;
+    if (seenRef.current === null) {
+      seenRef.current = new Set(questions.map((q) => q._id));
+      return;
+    }
+    const seen = seenRef.current;
+    const arrived = questions.filter((q) => !seen.has(q._id));
+    if (arrived.length === 0) return;
+    for (const q of arrived) seen.add(q._id);
+    setFresh((n) => n + arrived.length);
+  }, [questions]);
+
+  // The ping is a transient flash, not a persistent unread count — the queue
+  // itself is always on screen, so clear the badge after a few seconds.
+  useEffect(() => {
+    if (fresh === 0) return;
+    const t = setTimeout(() => setFresh(0), 6000);
+    return () => clearTimeout(t);
+  }, [fresh]);
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <p className="font-mono text-xs uppercase text-zinc-400">
+          Questions{' '}
+          <span className="text-white">
+            {questions ? questions.length : '…'}
+          </span>
+        </p>
+        {fresh > 0 && (
+          <span className="animate-pulse border-2 border-brutalist-yellow bg-brutalist-yellow px-2 py-0.5 font-mono text-xs font-bold uppercase text-black">
+            +{fresh} new
+          </span>
+        )}
+      </div>
+      <div className="max-h-72 overflow-y-auto">
+        <QuestionQueue room={room} display title="Live queue" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Projected-deck Q&A sidebar: the presenter toggles this on to show the room
+ * the question queue. Display-only and audience-safe — it renders the same
+ * non-hidden, votes-ordered list the audience sees on /live.
+ */
+export function PresenterQuestionsSidebar({ room }: { room: string }) {
+  return (
+    <aside className={PANEL}>
+      <QuestionQueue
+        room={room}
+        display
+        title="Questions from the room"
+        info="Ask + upvote from the live link — top-voted first."
+      />
     </aside>
   );
 }
@@ -62,7 +138,8 @@ function Thumb({ code }: { code: string }) {
 /**
  * Presenter console (admin second screen): drive the deck (Prev/Next → setSlide,
  * same identity as the presenter), read speaker notes for the current slide,
- * preview what's next, and monitor connection status / reactions / numbers.
+ * preview what's next, and monitor the Q&A queue (with a new-question ping),
+ * connection status, reactions and live numbers.
  */
 export function ConsoleSidebar({
   room,
@@ -160,6 +237,9 @@ export function ConsoleSidebar({
           <Thumb code={next.code} />
         </div>
       )}
+
+      {/* Q&A queue (always visible — new arrivals ping) */}
+      <ConsoleQuestionsPanel room={room} />
 
       {/* Connection status */}
       <div className="space-y-1 border-2 border-zinc-700 p-3 font-mono text-xs">

--- a/components/talks/SpectacleDeck.tsx
+++ b/components/talks/SpectacleDeck.tsx
@@ -14,7 +14,11 @@ import { api } from '@/convex/_generated/api';
 import { isConvexConfigured } from '@/lib/convexClient';
 import { DeckDriver, Follower } from './DeckLive';
 import { DeckModeProvider } from './DeckModeContext';
-import { AttendeeSidebar, ConsoleSidebar } from './DeckSidebars';
+import {
+  AttendeeSidebar,
+  ConsoleSidebar,
+  PresenterQuestionsSidebar,
+} from './DeckSidebars';
 import SlideBody from './SlideBody';
 import { brutalistTheme } from './theme';
 
@@ -103,7 +107,8 @@ function resolveMode(raw: unknown): Mode {
  *
  * - `presenter` (admin) → BROADCAST: this deck drives the room (identity-gated
  *   setSlide) and heartbeats a presenter session so clashes are detectable.
- *   Full-screen, clean (projector view).
+ *   Full-screen, clean (projector view), with a toggleable question sidebar
+ *   ("Q" or the HUD button) to show the room the audience-visible queue.
  * - `attendee` (default) → WATCH ALONG: follows the presenter's slide and shows
  *   a reactions sidebar (react + everyone's synced reactions).
  * - `console` (admin) → follows + a presenter console sidebar (connection status,
@@ -161,6 +166,35 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
   const showAttendeeSidebar = mode === 'attendee' && Boolean(reactionsOn);
   const showConsoleSidebar = mode === 'console' && isAdmin && Boolean(liveHere);
   const showPresenterHud = mode === 'presenter' && isAuthenticated && isAdmin;
+
+  // Projected-deck question sidebar: presenter-toggled ("Q" or the HUD button)
+  // so the room can be shown the audience-visible queue on demand.
+  const [qaOpen, setQaOpen] = useState(false);
+  const showPresenterQuestions =
+    showPresenterHud && qaOpen && Boolean(liveHere);
+
+  // "Q" is deliberately outside Spectacle's advance keys (space/arrows/PageDown)
+  // and its mod+shift chords — plain bubble-phase listener, so it also can't
+  // interfere with the capture-phase reveal interceptor below.
+  useEffect(() => {
+    if (!showPresenterHud) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'q' && e.key !== 'Q') return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const t = e.target as HTMLElement | null;
+      if (
+        t &&
+        (t.tagName === 'INPUT' ||
+          t.tagName === 'TEXTAREA' ||
+          t.isContentEditable)
+      ) {
+        return;
+      }
+      setQaOpen((open) => !open);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [showPresenterHud]);
 
   useEffect(() => {
     if (!broadcasting || !room) return;
@@ -273,16 +307,102 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
         startedAt={current?.startedAt}
         durationMins={durationMins}
       />
+    ) : showPresenterQuestions && room ? (
+      <PresenterQuestionsSidebar room={room} />
     ) : null;
   // The console is a working cockpit (controls + notes + preview), so give it
-  // more room than the slim attendee reactions rail.
-  const sidebarWidth = showConsoleSidebar ? '34vw' : '20vw';
+  // more room than the slim attendee reactions rail; the projected question
+  // queue sits in between (readable from the room without dwarfing the deck).
+  const sidebarWidth = showConsoleSidebar
+    ? '34vw'
+    : showPresenterQuestions
+      ? '26vw'
+      : '20vw';
 
   // With a sidebar, the deck occupies the left ~4/5 (Spectacle scales into its
   // container) and the sidebar fills the right 1/5. Use dvh (dynamic viewport)
   // + overflow-hidden so the layout fits the *visible* height — otherwise
   // browser UI that shrinks the viewport (mobile chrome bars, or Chrome's
   // "controlled by automated test software" infobar) pushes content off-screen.
+  // Presenter HUD — rendered fixed over the plain deck, or absolute inside the
+  // deck pane when the question sidebar is open (so it doesn't cover the queue).
+  const hud = showPresenterHud && (
+    <div
+      style={{
+        position: sidebar ? 'absolute' : 'fixed',
+        top: '1rem',
+        right: '1rem',
+        zIndex: 40,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-end',
+        gap: '0.4rem',
+        fontFamily: MONO,
+        fontSize: '0.75rem',
+        textTransform: 'uppercase',
+        fontWeight: 700,
+      }}
+    >
+      <span
+        style={{
+          border: '2px solid #fff',
+          background: '#000',
+          padding: '0.3rem 0.6rem',
+          color: pubError ? '#f472b6' : broadcasting ? '#22d3ee' : '#facc15',
+        }}
+      >
+        {!followOn
+          ? 'no live follow talk'
+          : pubError
+            ? `broadcast error: ${pubError}`
+            : `● presenting${pubSlide != null ? ` · slide ${pubSlide + 1}` : ''}`}
+      </span>
+      {liveHere && (
+        <button
+          type="button"
+          onClick={() => setQaOpen((open) => !open)}
+          style={{
+            border: '2px solid #fff',
+            background: qaOpen ? '#22d3ee' : '#000',
+            color: qaOpen ? '#000' : '#fff',
+            padding: '0.3rem 0.6rem',
+            fontFamily: MONO,
+            fontSize: '0.75rem',
+            textTransform: 'uppercase',
+            fontWeight: 700,
+            cursor: 'pointer',
+          }}
+        >
+          {qaOpen ? 'hide questions · q' : 'show questions · q'}
+        </button>
+      )}
+      {clash && (
+        <span
+          style={{
+            border: '2px solid #f472b6',
+            background: '#f472b6',
+            color: '#000',
+            padding: '0.3rem 0.6rem',
+          }}
+        >
+          ⚠ {presenterCount} presenters connected — you may clash
+        </span>
+      )}
+      {revealArmed && (
+        <span
+          style={{
+            border: '2px solid #facc15',
+            background: '#facc15',
+            color: '#000',
+            padding: '0.3rem 0.6rem',
+          }}
+        >
+          ▶ next reveals the answer
+        </span>
+      )}
+    </div>
+  );
+
   if (sidebar) {
     return (
       <div
@@ -302,6 +422,7 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
           }}
         >
           {deckEl}
+          {hud}
         </div>
         <div
           style={{
@@ -319,67 +440,7 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
   return (
     <>
       {deckEl}
-      {showPresenterHud && (
-        <div
-          style={{
-            position: 'fixed',
-            top: '1rem',
-            right: '1rem',
-            zIndex: 40,
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'flex-end',
-            gap: '0.4rem',
-            fontFamily: MONO,
-            fontSize: '0.75rem',
-            textTransform: 'uppercase',
-            fontWeight: 700,
-          }}
-        >
-          <span
-            style={{
-              border: '2px solid #fff',
-              background: '#000',
-              padding: '0.3rem 0.6rem',
-              color: pubError
-                ? '#f472b6'
-                : broadcasting
-                  ? '#22d3ee'
-                  : '#facc15',
-            }}
-          >
-            {!followOn
-              ? 'no live follow talk'
-              : pubError
-                ? `broadcast error: ${pubError}`
-                : `● presenting${pubSlide != null ? ` · slide ${pubSlide + 1}` : ''}`}
-          </span>
-          {clash && (
-            <span
-              style={{
-                border: '2px solid #f472b6',
-                background: '#f472b6',
-                color: '#000',
-                padding: '0.3rem 0.6rem',
-              }}
-            >
-              ⚠ {presenterCount} presenters connected — you may clash
-            </span>
-          )}
-          {revealArmed && (
-            <span
-              style={{
-                border: '2px solid #facc15',
-                background: '#facc15',
-                color: '#000',
-                padding: '0.3rem 0.6rem',
-              }}
-            >
-              ▶ next reveals the answer
-            </span>
-          )}
-        </div>
-      )}
+      {hud}
     </>
   );
 }


### PR DESCRIPTION
## What / why

QA finding **#28** from the 2026-07-02 careers-workshop debrief: attendees asked questions from /live all session, but there was **no presenter-facing signal anywhere** — the queue lived only in the /admin moderation list and the read-only embed on the closing "QUESTIONS?" slide, so the presenter only discovered it at the end.

This surfaces the queue on both presenter surfaces (plus a count on /admin):

- **Console deck (`?mode=console`)** — always-visible **Questions** panel in the sidebar: the live votes-ordered queue (audience-safe `questions.list`, reusing the `QuestionQueue` display rendering) with a question count and a transient toast-style **"+N new"** ping when a question arrives. Last-seen is tracked client-side and seeded on mount, so opening the console mid-talk doesn't false-ping.
- **Projected presenter deck (`?mode=presenter`)** — **toggleable question sidebar** via the **Q** key or a HUD button, so the room can be shown the queue on demand. Display-only and audience-safe: non-hidden questions, same list the audience sees on /live. The `Q` binding avoids Spectacle's advance keys (space/arrows/PageDown) and its mod+shift chords, and is a plain bubble-phase listener so it can't interfere with the capture-phase reveal interceptor; it's also ignored while typing in an input/textarea. The presenter HUD now renders in both layout branches (absolute inside the deck pane when the sidebar is open, fixed otherwise).
- **/admin Q&A moderation card** — live question count in the card title (`Q&A moderation — N questions`), so new arrivals are noticeable there too.

**No Convex changes** — reuses the existing `questions.list` (audience-safe) and `questions.feed` (admin-gated) queries.

## Manual test steps

1. Start a live talk from /admin with Q&A enabled; open the deck with `?mode=console` (admin-authed).
2. From /live in another browser, ask a question → the console's Questions panel count ticks up and a yellow "+1 new" badge flashes for ~6s; upvotes reorder the queue live.
3. Open the deck with `?mode=presenter` (admin-authed). Press **Q** (or click "show questions · q" in the HUD) → a right-hand question sidebar appears; press **Q** again to hide. Verify space/arrows still advance slides, and the armed-reveal beat (open activity, unrevealed answer) still consumes the advance key as before.
4. From /admin, reject a question → it disappears from both deck surfaces (audience-safe list) while the moderation card count is unchanged.
5. Check the /admin Q&A card title shows the live count.

Validated: `pnpm exec tsc --noEmit`, `pnpm lint`, `pnpm test` (57/57).

🤖 Generated with [Claude Code](https://claude.com/claude-code)