### PR TITLE
fix(activities): presenter owns the reveal — auto-reveal timer is opt-in

### DIFF
--- a/components/admin/AudienceControls.tsx
+++ b/components/admin/AudienceControls.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from 'convex/react';
 import { useState } from 'react';
+import { useCountdown } from '@/components/talks/OrderedActions';
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 import { useRunAction } from './useRunAction';
@@ -10,7 +11,10 @@ function ErrorLine({ error }: { error: string | null }) {
   return <p className="font-mono text-xs text-brutalist-pink">{error}</p>;
 }
 
-const REVEAL_PRESETS = [
+// The presenter owns the reveal by default ("manual" arms no timer); the timed
+// presets are an opt-in fallback that can still be cancelled while pending.
+const REVEAL_PRESETS: { label: string; ms: number | null }[] = [
+  { label: 'Manual', ms: null },
   { label: '30s', ms: 30_000 },
   { label: '1 min', ms: 60_000 },
   { label: '2 min', ms: 120_000 },
@@ -136,14 +140,19 @@ function ActivityControls({ room }: { room: string }) {
   const open = useMutation(api.activities.open);
   const close = useMutation(api.activities.close);
   const revealNow = useMutation(api.activities.revealNow);
+  const cancelReveal = useMutation(api.activities.cancelReveal);
   const setHidden = useMutation(api.activities.setHidden);
   const { run, error } = useRunAction();
 
   const [prompt, setPrompt] = useState('');
   const [options, setOptions] = useState('');
-  const [delayMs, setDelayMs] = useState(120_000);
+  // null = manual (the default): no auto-reveal timer is armed on open.
+  const [delayMs, setDelayMs] = useState<number | null>(null);
 
   const activity = feed?.authorized ? feed.activity : null;
+  const countdown = useCountdown(
+    activity && !activity.revealed ? activity.revealAt : null,
+  );
 
   return (
     <Section title="Put-it-in-order activity" accent="text-brutalist-yellow">
@@ -152,7 +161,13 @@ function ActivityControls({ room }: { room: string }) {
           <p className="font-mono text-sm text-white">
             Open: <b>{activity.prompt}</b>{' '}
             <span className="text-zinc-500">
-              ({activity.revealed ? 'answer revealed' : 'answer hidden'})
+              (
+              {activity.revealed
+                ? 'answer revealed'
+                : countdown != null
+                  ? `auto-reveals in ${countdown}s`
+                  : 'answer hidden — reveal when you are ready'}
+              )
             </span>
           </p>
           <div className="max-h-56 space-y-2 overflow-y-auto">
@@ -191,7 +206,7 @@ function ActivityControls({ room }: { room: string }) {
                 </div>
               ))}
           </div>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             {!activity.revealed && (
               <button
                 type="button"
@@ -201,6 +216,19 @@ function ActivityControls({ room }: { room: string }) {
                 }
               >
                 Reveal answer now
+              </button>
+            )}
+            {!activity.revealed && countdown != null && (
+              <button
+                type="button"
+                className={`${btnCls} bg-black text-white`}
+                onClick={() =>
+                  run(() =>
+                    cancelReveal({ id: activity._id as Id<'activities'> }),
+                  )
+                }
+              >
+                Cancel auto-reveal
               </button>
             )}
             <button
@@ -230,7 +258,9 @@ function ActivityControls({ room }: { room: string }) {
                 room,
                 prompt: prompt.trim(),
                 options: opts,
-                revealDelayMs: delayMs,
+                // Manual (null) sends no delay at all — the backend only arms
+                // an auto-reveal timer when one is explicitly requested.
+                revealDelayMs: delayMs ?? undefined,
               }),
             );
             setPrompt('');
@@ -247,15 +277,15 @@ function ActivityControls({ room }: { room: string }) {
             className={`${inputCls} h-24 resize-none`}
             value={options}
             onChange={(e) => setOptions(e.target.value)}
-            placeholder={'Answer steps (one per line) — revealed on the timer'}
+            placeholder={'Answer steps (one per line) — revealed when you say'}
           />
           <div className="flex flex-wrap items-center gap-2">
             <span className="font-mono text-xs uppercase text-zinc-500">
-              Reveal after
+              Reveal
             </span>
             {REVEAL_PRESETS.map((p) => (
               <button
-                key={p.ms}
+                key={p.label}
                 type="button"
                 onClick={() => setDelayMs(p.ms)}
                 className={`border-2 px-2 py-1 font-mono text-xs ${

--- a/components/talks/OrderedActions.tsx
+++ b/components/talks/OrderedActions.tsx
@@ -5,7 +5,9 @@ import { useDeckMode } from './DeckModeContext';
 import { ResolvedRoom } from './ResolvedRoom';
 
 /** Live-updating seconds remaining until `revealAt` (null once elapsed/absent). */
-function useCountdown(revealAt: number | null | undefined): number | null {
+export function useCountdown(
+  revealAt: number | null | undefined,
+): number | null {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     if (!revealAt) return;
@@ -83,6 +85,8 @@ function Activity({
   const feedRes = useQuery(api.activities.feed, isConsole ? { room } : 'skip');
   const submit = useMutation(api.activities.submit);
   const openActivity = useMutation(api.activities.open);
+  const revealNow = useMutation(api.activities.revealNow);
+  const cancelReveal = useMutation(api.activities.cancelReveal);
   const isAdmin = useQuery(api.talks.isAdmin) === true;
 
   const [steps, setSteps] = useState<string[]>(['']);
@@ -257,6 +261,31 @@ function Activity({
               </li>
             ))}
           </ol>
+          {/* The reveal moment belongs to the presenter: reveal-now is always at
+              hand on the console, and an opt-in auto-reveal timer can be
+              cancelled here while it's still pending. */}
+          {isConsole && !activity.revealed && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => revealNow({ id: activity._id }).catch(() => {})}
+                className="border-2 border-white bg-brutalist-cyan px-4 py-2 font-mono text-xs font-bold uppercase text-black shadow-hard-md"
+              >
+                Reveal to room now
+              </button>
+              {countdown != null && (
+                <button
+                  type="button"
+                  onClick={() =>
+                    cancelReveal({ id: activity._id }).catch(() => {})
+                  }
+                  className="border-2 border-white bg-black px-4 py-2 font-mono text-xs font-bold uppercase text-white"
+                >
+                  ✕ Cancel timer
+                </button>
+              )}
+            </div>
+          )}
         </div>
       )}
       {!isConsole && hasAnswer && !activity.revealed && countdown != null && (
@@ -298,7 +327,9 @@ function Activity({
  * Embedded "put the actions in order" activity (the toast exercise generalized).
  * The presenter opens a prompt + hidden canonical options; the audience builds an
  * ordered step list and submits; the wall fills live and the canonical answer
- * reveals on a timer (or via the deck's next-key). Mode-aware:
+ * reveals when the presenter decides (the deck's next-key beat, the console's
+ * reveal-now, or /admin) — an auto-reveal timer only runs if the slide opts in
+ * via `revealAfterMs`. Mode-aware:
  * - attendee → reveal-gated + submission form (rejected entries are omitted),
  * - presenter (projected) → reveal-gated, display-only,
  * - console (2nd screen) → answer + every submission incl. blocked shown always.
@@ -319,6 +350,11 @@ export default function OrderedActions({
   /** Slide-declared defaults — an admin can open the activity in one click. */
   prompt?: string;
   options?: string[];
+  /**
+   * Opt-in auto-reveal fallback. Omit (the default) and the answer stays hidden
+   * until the presenter reveals it; set it only when a slide genuinely wants a
+   * self-firing timer.
+   */
   revealAfterMs?: number;
 }) {
   return (

--- a/convex/activities.ts
+++ b/convex/activities.ts
@@ -14,8 +14,10 @@ const MAX_PROMPT_LEN = 200;
 /**
  * The generalized "put the actions in order" activity (toast is one instance).
  * The presenter opens an activity with a prompt and a hidden set of canonical
- * options; the audience submits their own ordered steps; after `revealDelayMs`
- * a scheduled function flips `revealed` so everyone sees the canonical options.
+ * options; the audience submits their own ordered steps; the presenter decides
+ * when `revealed` flips (reveal-now / the deck's reveal beat). An auto-reveal
+ * timer is an opt-in fallback: only when `revealDelayMs` is explicitly passed
+ * does a scheduled function flip `revealed` — and it can be cancelled.
  */
 export const open = mutation({
   args: {
@@ -50,19 +52,25 @@ export const open = mutation({
       .slice(0, MAX_OPTIONS)
       .map((o) => cleanText(o.slice(0, MAX_STEP_LEN)).text);
 
-    const delay = Math.max(0, Math.floor(revealDelayMs ?? 60_000));
+    // Auto-reveal is strictly opt-in: omitting `revealDelayMs` keeps the answer
+    // hidden until the presenter reveals it (reveal-now / the deck's reveal
+    // beat). Passing 0 reveals immediately; passing >0 arms a fallback timer.
+    const delay =
+      revealDelayMs === undefined
+        ? null
+        : Math.max(0, Math.floor(revealDelayMs));
     const now = Date.now();
     const id = await ctx.db.insert('activities', {
       room,
       prompt: cleanPrompt,
       options: cleanOptions,
-      revealAt: delay > 0 ? now + delay : now,
+      revealAt: delay === null ? null : now + delay,
       revealed: delay === 0,
       status: 'open',
       createdAt: now,
     });
 
-    if (delay > 0) {
+    if (delay !== null && delay > 0) {
       await ctx.scheduler.runAfter(delay, internal.activities.reveal, { id });
     }
     return { ok: true };
@@ -74,8 +82,22 @@ export const reveal = internalMutation({
   args: { id: v.id('activities') },
   handler: async (ctx, { id }) => {
     const doc = await ctx.db.get(id);
-    if (!doc || doc.revealed) return;
+    // `revealAt: null` means the presenter cancelled the timer after this run
+    // was scheduled — the stale invocation must not reveal anything.
+    if (!doc || doc.revealed || doc.revealAt === null) return;
     await ctx.db.patch(id, { revealed: true });
+  },
+});
+
+/**
+ * Presenter: cancel a pending auto-reveal timer. The answer stays hidden until
+ * an explicit reveal (reveal-now / the deck's reveal beat).
+ */
+export const cancelReveal = mutation({
+  args: { id: v.id('activities') },
+  handler: async (ctx, { id }) => {
+    await requireAdmin(ctx);
+    await ctx.db.patch(id, { revealAt: null });
   },
 });
 

--- a/data/talks/so-you-want-to-build-software.mdx
+++ b/data/talks/so-you-want-to-build-software.mdx
@@ -174,7 +174,6 @@ the sat-nav, the hospital screens — all software."
     'Wait for it to pop up',
     'Spread butter on it',
   ]}
-  revealAfterMs={120000}
 />
 
 ???
@@ -182,7 +181,9 @@ the sat-nav, the hospital screens — all software."
 [⏱ 28–46 · TOAST ACTIVITY 🍞 · ~18 min · device-free]
 - If the room has devices: open the "make toast" activity from /admin (Audience
   participation → Put-it-in-order). Groups submit their steps; the wall fills
-  live and the answer reveals on the timer. Otherwise run it on paper as below.
+  live and YOU reveal the answer when the room is ready — hit next on this
+  slide, or "Reveal answer now" on the console or /admin. No timer runs unless you
+  arm one. Otherwise run it on paper as below.
 Based on discovere.org/engineering-activities/making-toast.
 1. (2m) Split into groups of 3–4. Each group writes numbered steps to make toast.
 2. (8m) Groups write. Circulate, encourage precision.


### PR DESCRIPTION
## What

Makes the ordered-actions activity reveal presenter-controlled by default. Opening an activity no longer arms an auto-reveal timer unless one is explicitly requested, and a pending timer is now visible and cancellable.

- **convex/activities.ts** — `open` no longer defaults `revealDelayMs` to 60s: omitted means no timer, no scheduled reveal (`revealAt: null`); `0` still reveals immediately; `>0` arms an opt-in fallback timer. New admin mutation `activities.cancelReveal` clears a pending timer, and the scheduled `reveal` treats a cancelled timer (`revealAt: null`) as a no-op so the stale invocation can't reveal anyway.
- **components/admin/AudienceControls.tsx** — the open form's reveal presets gain a **Manual** option, which is now the default (previously 2 min was pre-selected). While an activity is open, the status line shows a live `auto-reveals in Ns` countdown when a timer is pending, alongside a **Cancel auto-reveal** button next to **Reveal answer now**.
- **components/talks/OrderedActions.tsx** — the console's answer block gains **Reveal to room now** and (when a timer is pending) **Cancel timer** buttons, next to the existing `room sees it in Ns` status. `useCountdown` is exported for reuse by the admin panel.
- **data/talks/so-you-want-to-build-software.mdx** — the toast slide drops `revealAfterMs={120000}`; the reveal now happens via the deck's next-key beat / reveal-now, per the speaker notes.

## Why

QA finding #21 from the 2026-07-02 careers-workshop debrief: the toast slide's `revealAfterMs={120000}` armed a fixed timer on open that fired regardless of where the room was — in a real session the timer effectively owned the reveal, even though reveal-now and the reveal-on-advance beat existed. The presenter should decide the reveal moment; a timer should be an opt-in fallback, not an override.

## How to test manually

1. Presenter drives the deck (`?mode=presenter` + console) with a live session on the room; audience joins via `/live`.
2. Open the toast activity from the slide's **Open activity** button (or `/admin` → Put-it-in-order with **Manual** selected). Wait well past 2 minutes: the answer must **not** reveal on its own; audience sees no countdown.
3. Reveal via any of: next-key on the activity slide (reveal beat), **Reveal to room now** on the console answer block, or **Reveal answer now** in `/admin`. Audience sees the canonical order only then.
4. Open another activity from `/admin` with a timed preset (e.g. 30s): `/admin` shows `auto-reveals in Ns` and the console shows `room sees it in Ns`. Click **Cancel auto-reveal** (or the console's **Cancel timer**) before it fires: the countdown disappears and the answer stays hidden past the deadline; reveal-now still works afterwards.
5. Timed preset left alone still auto-reveals when the countdown hits zero (opt-in fallback preserved).

Validated with `pnpm exec tsc --noEmit`, `pnpm lint`, and `pnpm test:unit` (57/57).

🤖 Generated with [Claude Code](https://claude.com/claude-code)