### PR TITLE
fix(talks): converge concurrent presenters — last-write-wins on the shared slide

### DIFF
--- a/components/talks/DeckLive.tsx
+++ b/components/talks/DeckLive.tsx
@@ -13,10 +13,19 @@ type NavRef = { current: { next: () => void; prev: () => void } | null };
  * room — the deck itself is the source of truth, so it never "detaches". On mount
  * it aligns to the room's current slide (so opening a driver mid-talk doesn't
  * reset everyone to the first slide), and only broadcasts once aligned.
+ *
+ * Multiple drivers (presenter screen + console, or two presenters) co-exist via
+ * last-write-wins on the room's single `currentSlide`: a driver broadcasts its
+ * OWN navigation, and *follows* a remote change made by another driver (skipTo
+ * without re-detaching). Distinguishing the two — local index moved vs. room
+ * slide moved — is what prevents the echo/stale-write clash: without it a second
+ * driver sits diverged after the first one navigates, and its next keypress
+ * yanks the whole room back to its stale position.
  */
 export function DeckDriver({
   room,
   initialSlide,
+  currentSlide,
   setSlide,
   onIndex,
   navRef,
@@ -25,6 +34,8 @@ export function DeckDriver({
 }: {
   room?: string;
   initialSlide: number;
+  /** The room's live slide — remote co-driver moves are followed via skipTo. */
+  currentSlide?: number;
   setSlide: SetSlide;
   onIndex?: (index: number) => void;
   navRef?: NavRef;
@@ -34,40 +45,85 @@ export function DeckDriver({
   const { activeView, skipTo, advanceSlide, regressSlide } =
     useContext(DeckContext);
   const index = activeView.slideIndex;
-  // The room's slide at the moment this driver opened — captured once (this
-  // component only mounts after the talk has loaded), then we align to it.
+  // Fallback alignment target (the room's slide when this driver opened) for
+  // the moment before the live query delivers `currentSlide`.
   const targetRef = useRef(initialSlide);
   const [aligned, setAligned] = useState(false);
 
   // Expose deck navigation to out-of-deck controls (the console Prev/Next).
   if (navRef) navRef.current = { next: advanceSlide, prev: regressSlide };
 
-  // Align to the room's slide, retrying until it lands — Spectacle can drop an
-  // early skipTo before its navigation is ready. Once aligned we start driving;
-  // we never broadcast the pre-alignment position (which would reset the room).
+  // Align to the room's LIVE slide, retrying until it lands — Spectacle can drop
+  // an early skipTo before its navigation is ready. Tracking the live value (not
+  // just the mount-time snapshot) means a driver opened while another presenter
+  // is navigating aligns to where the room actually is, instead of broadcasting
+  // a stale position back at it. Once aligned we start driving; we never
+  // broadcast the pre-alignment position (which would reset the room).
   useEffect(() => {
     if (aligned) return;
-    if (index === targetRef.current) {
+    const target = currentSlide ?? targetRef.current;
+    if (index === target) {
       setAligned(true);
       return;
     }
-    skipTo({ slideIndex: targetRef.current, stepIndex: 0 });
-  }, [aligned, index, skipTo]);
+    skipTo({ slideIndex: target, stepIndex: 0 });
+  }, [aligned, index, currentSlide, skipTo]);
 
   // Report position for the console's notes/preview (always).
   useEffect(() => {
     onIndex?.(index);
   }, [index, onIndex]);
 
-  // Broadcast position to the room (only after alignment).
+  // Drive / converge (only after alignment). Local navigation broadcasts
+  // (last write wins on the shared slide); a remote change from another driver
+  // is followed. A remote echo of our own broadcast (room caught up to us) is
+  // a no-op, so drivers can't ping-pong.
+  const prevIndexRef = useRef<number | null>(null);
+  const prevRemoteRef = useRef(currentSlide);
+  const followTargetRef = useRef<number | null>(null);
   useEffect(() => {
-    if (!aligned || !room) return;
-    setSlide({ room, index })
-      .then(() => onPublished?.(index))
-      .catch((e) =>
-        onError?.(e instanceof Error ? e.message : 'broadcast failed'),
-      );
-  }, [aligned, index, room, setSlide, onPublished, onError]);
+    if (!aligned || !room) {
+      // Pre-alignment: consume remote updates so alignment-time state doesn't
+      // read as a "remote move" once we start driving.
+      prevRemoteRef.current = currentSlide;
+      return;
+    }
+    const localMoved =
+      prevIndexRef.current === null || index !== prevIndexRef.current;
+    const remoteMoved = currentSlide !== prevRemoteRef.current;
+    prevIndexRef.current = index;
+    prevRemoteRef.current = currentSlide;
+
+    if (localMoved) {
+      if (index === followTargetRef.current) {
+        // Our own follow-skipTo landing — the room is already on this slide,
+        // so re-broadcasting would only race a newer remote move.
+        followTargetRef.current = null;
+        onPublished?.(index);
+        return;
+      }
+      // This driver navigated (or just finished aligning) — publish it.
+      followTargetRef.current = null;
+      setSlide({ room, index })
+        .then(() => onPublished?.(index))
+        .catch((e) =>
+          onError?.(e instanceof Error ? e.message : 'broadcast failed'),
+        );
+    } else if (remoteMoved && currentSlide != null && currentSlide !== index) {
+      // Another driver moved the room — converge on their slide.
+      followTargetRef.current = currentSlide;
+      skipTo({ slideIndex: currentSlide, stepIndex: 0 });
+    }
+  }, [
+    aligned,
+    index,
+    currentSlide,
+    room,
+    setSlide,
+    skipTo,
+    onPublished,
+    onError,
+  ]);
 
   return null;
 }

--- a/components/talks/DeckSidebars.tsx
+++ b/components/talks/DeckSidebars.tsx
@@ -176,7 +176,7 @@ export function ConsoleSidebar({
           {presenters === undefined
             ? 'presenter link: …'
             : clash
-              ? `⚠ ${presenters} presenters connected — clash`
+              ? `⚠ ${presenters} presenters connected — last change wins`
               : noPresenter
                 ? 'no presenter broadcasting'
                 : 'presenter connected'}

--- a/components/talks/SpectacleDeck.tsx
+++ b/components/talks/SpectacleDeck.tsx
@@ -143,7 +143,10 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
 
   // Both presenter and console DRIVE the deck (their navigation broadcasts);
   // attendees follow. Same admin identity, so both heartbeat a presenter session
-  // and two connected at once surfaces a clash.
+  // and two connected at once surfaces a multi-presenter notice. Concurrent
+  // drivers resolve last-write-wins on the room's single slide: each driver
+  // follows the other's moves (see DeckDriver), so surfaces converge instead
+  // of diverging and stale-writing over each other.
   const broadcasting =
     (mode === 'presenter' || mode === 'console') && followOn && isAdmin;
   const followEnabled = followOn && !broadcasting;
@@ -237,6 +240,7 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
         <DeckDriver
           room={room}
           initialSlide={current?.currentSlide ?? 0}
+          currentSlide={current?.currentSlide}
           setSlide={setSlide}
           onIndex={setDeckIndex}
           navRef={navRef}
@@ -363,7 +367,7 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
                 padding: '0.3rem 0.6rem',
               }}
             >
-              ⚠ {presenterCount} presenters connected — you may clash
+              ⚠ {presenterCount} presenters connected — last change wins
             </span>
           )}
           {revealArmed && (


### PR DESCRIPTION
## What / why

QA finding **#24** from the 2026-07-02 careers-workshop debrief: running with more than one presenter works until two presenters change slide at (nearly) the same time — the changes clash instead of resolving, leaving presenter surfaces diverged/stuck.

This PR makes simultaneous navigation resolve predictably as **last-write-wins on the room's single shared slide** (`talks.currentSlide`), with every presenter surface converging on the winning slide immediately.

## Root cause

`DeckDriver` (the presenter/console driving surface in `components/talks/DeckLive.tsx`) was **broadcast-only**: it aligned to the room's slide once on mount, then only published its own local navigation and never read the room's slide again. With two driving surfaces open (presenter screen + console, or two presenters):

1. Presenter A navigates → room moves, but B's deck **stays put** — B is a driver, and drivers had no follow path. B's surface is now silently diverged (the "stuck" state).
2. B's next keypress advances *from B's stale position* and broadcasts it — yanking the whole room backwards over A's changes. That's the clash the HUD indicator (`presenterCount > 1`) was warning about without being able to resolve.

The server was never the problem: `setSlide` writes one shared field and Convex serializes mutations, so the backend already had last-write-wins semantics. The clients just never reconciled to it.

## Fix

- `DeckDriver` now receives the room's live `currentSlide` and distinguishes **local move** (this driver navigated → broadcast; last write wins) from **remote move** (another driver navigated → follow it via `skipTo`, converging immediately without detaching).
- Follow landings are tracked (`followTargetRef`) so a follow's own index change neither re-broadcasts nor races a newer remote move — no echo/ping-pong loop.
- Mount alignment now targets the *live* slide instead of the mount-time snapshot, so opening a second driver while the first is mid-navigation can't broadcast a stale position back at the room.
- The multi-presenter indicator (HUD + console sidebar) is kept, reworded from "you may clash" to "last change wins" to state the now-true semantics. Nothing is hidden.

No Convex function changes (so no codegen needed).

## Manual test steps

1. Start a talk from `/admin` with **follow** enabled.
2. Open two presenter windows on the deck: `?mode=presenter` and `?mode=console` (or two `?mode=presenter` tabs), plus one attendee tab.
3. Navigate in window A → window B and the attendee should land on the same slide immediately (previously B stayed behind).
4. Navigate in window B → everyone follows B. Alternate rapidly / press arrows in both windows at nearly the same time → all surfaces settle on the last committed change, same slide everywhere, no stuck or diverged deck, no snapping backwards.
5. Both presenter surfaces show the "N presenters connected — last change wins" notice while both are open.
6. Open a third presenter window while another is navigating → it joins on the room's current slide instead of dragging the room back.

## Validation

- `pnpm exec tsc --noEmit` clean
- `biome check` clean on touched files
- `pnpm test` — 57/57 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)