### PR TITLE
feat(live): per-attendee poll answer caps + rate-limited audience writes

### DIFF
--- a/components/Reactions.tsx
+++ b/components/Reactions.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
+import RateLimitNotice from '@/components/talks/RateLimitNotice';
 import { isConvexConfigured } from '@/lib/convexClient';
+import { useRateLimitNotice } from '@/lib/useRateLimitNotice';
 import { useReactions } from '@/lib/useReactions';
 
 // Mirrors the server allow-list (convex/reactions.ts). Kept here so the client
@@ -15,7 +17,8 @@ interface Bubble {
 }
 
 function LiveReactions({ room }: { room: string }) {
-  const { recent, react } = useReactions(room);
+  const { secondsLeft, notify } = useRateLimitNotice();
+  const { recent, react } = useReactions(room, notify);
   const seen = useRef<Set<string>>(new Set());
   const primed = useRef(false);
   const [bubbles, setBubbles] = useState<Bubble[]>([]);
@@ -65,6 +68,12 @@ function LiveReactions({ room }: { room: string }) {
           </button>
         ))}
       </div>
+
+      {secondsLeft !== null && (
+        <div className="mt-2">
+          <RateLimitNotice secondsLeft={secondsLeft} />
+        </div>
+      )}
 
       {/* Floating reactions — bottom-right 20% of the viewport. */}
       <div className="reaction-stream pointer-events-none fixed right-0 bottom-0 z-40 h-[45vh] w-[20vw] overflow-hidden">

--- a/components/admin/AudienceControls.tsx
+++ b/components/admin/AudienceControls.tsx
@@ -52,13 +52,19 @@ function PollControls({ room }: { room: string }) {
   const hideWord = useMutation(api.polls.hideWord);
   const { run, error } = useRunAction();
   const [prompt, setPrompt] = useState('');
+  // Answers each attendee may submit (server-clamped 1–5; default 1).
+  const [maxAnswers, setMaxAnswers] = useState(1);
 
   return (
     <Section title="Live poll / word cloud" accent="text-brutalist-pink">
       {poll ? (
         <div className="space-y-3">
           <p className="font-mono text-sm text-white">
-            Open: <b>{poll.prompt}</b>
+            Open: <b>{poll.prompt}</b>{' '}
+            <span className="text-zinc-500">
+              ({poll.maxAnswers} answer{poll.maxAnswers === 1 ? '' : 's'} per
+              person)
+            </span>
           </p>
           <div className="max-h-48 space-y-1 overflow-y-auto">
             {feed?.authorized &&
@@ -102,12 +108,19 @@ function PollControls({ room }: { room: string }) {
         </div>
       ) : (
         <form
-          className="flex flex-col gap-2 sm:flex-row"
+          className="space-y-2"
           onSubmit={(e) => {
             e.preventDefault();
             if (!prompt.trim()) return;
-            run(() => start({ room, prompt: prompt.trim() }));
+            run(() =>
+              start({
+                room,
+                prompt: prompt.trim(),
+                maxAnswersPerAttendee: maxAnswers,
+              }),
+            );
             setPrompt('');
+            setMaxAnswers(1);
           }}
         >
           <input
@@ -116,13 +129,32 @@ function PollControls({ room }: { room: string }) {
             onChange={(e) => setPrompt(e.target.value)}
             placeholder="Poll prompt, e.g. One word: how do you feel about coding?"
           />
-          <button
-            type="submit"
-            disabled={!prompt.trim()}
-            className={`${btnCls} bg-brutalist-pink text-black`}
-          >
-            Start
-          </button>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-xs uppercase text-zinc-500">
+              Answers per person
+            </span>
+            {[1, 2, 3, 4, 5].map((n) => (
+              <button
+                key={n}
+                type="button"
+                onClick={() => setMaxAnswers(n)}
+                className={`border-2 px-2 py-1 font-mono text-xs ${
+                  maxAnswers === n
+                    ? 'border-brutalist-pink bg-brutalist-pink text-black'
+                    : 'border-white text-white'
+                }`}
+              >
+                {n}
+              </button>
+            ))}
+            <button
+              type="submit"
+              disabled={!prompt.trim()}
+              className={`${btnCls} ml-auto bg-brutalist-pink text-black`}
+            >
+              Start
+            </button>
+          </div>
           <ErrorLine error={error} />
         </form>
       )}

--- a/components/talks/LivePoll.tsx
+++ b/components/talks/LivePoll.tsx
@@ -2,7 +2,9 @@ import { useMutation, useQuery } from 'convex/react';
 import { useState } from 'react';
 import { api } from '@/convex/_generated/api';
 import { getMachineId } from '@/lib/machineId';
+import { useRateLimitNotice } from '@/lib/useRateLimitNotice';
 import { useDeckMode } from './DeckModeContext';
+import RateLimitNotice from './RateLimitNotice';
 import { ResolvedRoom } from './ResolvedRoom';
 
 const CLOUD_COLORS = [
@@ -39,6 +41,10 @@ function Poll({
   const [word, setWord] = useState('');
   const [sending, setSending] = useState(false);
   const [done, setDone] = useState(false);
+  // Answers this browser has left on a multi-answer poll (null until the first
+  // submit confirms; the server is the source of truth via `remaining`).
+  const [answersLeft, setAnswersLeft] = useState<number | null>(null);
+  const { secondsLeft, notify } = useRateLimitNotice();
 
   // No open poll yet. An admin on a slide that declares a prompt can start it in
   // one click (the poll question lives with the slide).
@@ -72,16 +78,26 @@ function Poll({
     if (!trimmed || sending) return;
     setSending(true);
     try {
-      await submit({
+      const res = await submit({
         pollId: poll._id,
         word: trimmed,
         machineId: getMachineId(),
       });
-      setWord('');
-      setDone(true);
+      // `=== true` so the union narrows under this repo's `strict: false`.
+      if (res.ok === true) {
+        setWord('');
+        setAnswersLeft(res.remaining);
+        if (res.remaining <= 0) setDone(true);
+      } else if (res.reason === 'rate_limited') {
+        // Refused, not dropped: keep the typed word and show when to retry.
+        notify(res.retryAfterMs);
+      } else {
+        // limit_reached / disabled: stop offering the form.
+        setDone(true);
+      }
     } catch {
-      // One answer per person: an "already answered" (or transient) failure
-      // still lands us in the submitted state so we stop offering the form.
+      // A transient/closed-poll failure still lands us in the submitted state
+      // so we stop offering the form.
       setDone(true);
     } finally {
       setSending(false);
@@ -100,30 +116,45 @@ function Poll({
       {!info && <div className="mb-3" />}
 
       {/* On the projected deck (display) we show the cloud only — no dead input
-          box on a big screen. Students still submit from /live. One answer per
-          person, so once submitted we confirm instead of re-offering the form. */}
+          box on a big screen. Students still submit from /live. Answers per
+          person are capped server-side (default 1, presenter-set up to 5);
+          once they're used up we confirm instead of re-offering the form. */}
       {showForm &&
         (done ? (
           <p className="border-2 border-brutalist-pink bg-black p-3 font-mono text-sm text-brutalist-pink">
-            ✓ Your answer's in — watch the cloud below.
+            {poll.maxAnswers > 1
+              ? '✓ Your answers are in — watch the cloud below.'
+              : "✓ Your answer's in — watch the cloud below."}
           </p>
         ) : (
-          <form onSubmit={send} className="flex flex-col gap-3 sm:flex-row">
-            <input
-              value={word}
-              onChange={(e) => setWord(e.target.value)}
-              maxLength={32}
-              placeholder="One word…"
-              className="min-w-0 flex-1 border-2 border-white bg-black px-3 py-3 font-mono text-base text-white placeholder:text-zinc-600 focus:border-brutalist-pink focus:outline-none"
-            />
-            <button
-              type="submit"
-              disabled={sending || !word.trim()}
-              className="border-2 border-white bg-brutalist-pink px-5 py-3 font-mono font-bold uppercase text-black shadow-hard-md disabled:opacity-40"
-            >
-              Send
-            </button>
-          </form>
+          <div className="space-y-2">
+            <form onSubmit={send} className="flex flex-col gap-3 sm:flex-row">
+              <input
+                value={word}
+                onChange={(e) => setWord(e.target.value)}
+                maxLength={32}
+                placeholder="One word…"
+                className="min-w-0 flex-1 border-2 border-white bg-black px-3 py-3 font-mono text-base text-white placeholder:text-zinc-600 focus:border-brutalist-pink focus:outline-none"
+              />
+              <button
+                type="submit"
+                disabled={sending || !word.trim()}
+                className="border-2 border-white bg-brutalist-pink px-5 py-3 font-mono font-bold uppercase text-black shadow-hard-md disabled:opacity-40"
+              >
+                Send
+              </button>
+            </form>
+            {poll.maxAnswers > 1 && (
+              <p className="font-mono text-xs text-zinc-500">
+                {answersLeft === null
+                  ? `Up to ${poll.maxAnswers} answers per person.`
+                  : `✓ Sent — ${answersLeft} answer${
+                      answersLeft === 1 ? '' : 's'
+                    } left.`}
+              </p>
+            )}
+            <RateLimitNotice secondsLeft={secondsLeft} />
+          </div>
         ))}
 
       <div className="mt-5 flex min-h-[4rem] flex-wrap items-center gap-x-4 gap-y-1">

--- a/components/talks/OrderedActions.tsx
+++ b/components/talks/OrderedActions.tsx
@@ -1,7 +1,10 @@
 import { useMutation, useQuery } from 'convex/react';
 import { useEffect, useState } from 'react';
 import { api } from '@/convex/_generated/api';
+import { getMachineId } from '@/lib/machineId';
+import { useRateLimitNotice } from '@/lib/useRateLimitNotice';
 import { useDeckMode } from './DeckModeContext';
+import RateLimitNotice from './RateLimitNotice';
 import { ResolvedRoom } from './ResolvedRoom';
 
 /** Live-updating seconds remaining until `revealAt` (null once elapsed/absent). */
@@ -88,6 +91,7 @@ function Activity({
   const [steps, setSteps] = useState<string[]>(['']);
   const [sending, setSending] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const { secondsLeft, notify } = useRateLimitNotice();
 
   const consoleActivity = feedRes?.authorized ? feedRes.activity : null;
   const activity = isConsole ? consoleActivity : (active ?? null);
@@ -159,9 +163,19 @@ function Activity({
     if (filled.length === 0 || sending) return;
     setSending(true);
     try {
-      await submit({ activityId: activity._id, steps: filled });
-      setSteps(['']);
-      setSubmitted(true);
+      const res = await submit({
+        activityId: activity._id,
+        steps: filled,
+        machineId: getMachineId(),
+      });
+      // `=== false` so the union narrows under this repo's `strict: false`.
+      if (res.ok === false && res.reason === 'rate_limited') {
+        // Refused, not dropped: keep the typed steps and show when to retry.
+        notify(res.retryAfterMs);
+      } else {
+        setSteps(['']);
+        setSubmitted(true);
+      }
     } finally {
       setSending(false);
     }
@@ -217,6 +231,7 @@ function Activity({
                 )}
               </div>
             ))}
+            <RateLimitNotice secondsLeft={secondsLeft} />
             <div className="flex flex-col gap-2 pt-1 sm:flex-row">
               <button
                 type="button"

--- a/components/talks/QuestionQueue.tsx
+++ b/components/talks/QuestionQueue.tsx
@@ -3,7 +3,9 @@ import { useCallback, useState } from 'react';
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 import { getMachineId } from '@/lib/machineId';
+import { useRateLimitNotice } from '@/lib/useRateLimitNotice';
 import { useDeckMode } from './DeckModeContext';
+import RateLimitNotice from './RateLimitNotice';
 import { ResolvedRoom } from './ResolvedRoom';
 
 const VOTED_KEY = 'talk-qa-voted';
@@ -51,6 +53,7 @@ function Queue({
 
   const [text, setText] = useState('');
   const [sending, setSending] = useState(false);
+  const { secondsLeft, notify } = useRateLimitNotice();
 
   // Projected/console decks (and any `display` embed) are read-only: no ask box,
   // votes shown as static badges. Students ask + upvote from /live.
@@ -62,8 +65,14 @@ function Queue({
     if (!trimmed || sending) return;
     setSending(true);
     try {
-      await ask({ room, text: trimmed });
-      setText('');
+      const res = await ask({ room, text: trimmed, machineId: getMachineId() });
+      // `=== false` so the union narrows under this repo's `strict: false`.
+      if (res.ok === false && res.reason === 'rate_limited') {
+        // Refused, not dropped: keep the typed question and show when to retry.
+        notify(res.retryAfterMs);
+      } else {
+        setText('');
+      }
     } finally {
       setSending(false);
     }
@@ -96,6 +105,12 @@ function Queue({
             Ask
           </button>
         </form>
+      )}
+
+      {!readOnly && (
+        <div className="mt-3 empty:hidden">
+          <RateLimitNotice secondsLeft={secondsLeft} />
+        </div>
       )}
 
       <div className={`${readOnly ? '' : 'mt-5'} space-y-2`}>
@@ -133,8 +148,10 @@ function Queue({
                         id: q._id as Id<'questions'>,
                         machineId: getMachineId(),
                       })
-                        .then((ok) => {
-                          if (ok) mark(q._id);
+                        .then((res) => {
+                          if (res.ok === true) mark(q._id);
+                          else if (res.reason === 'rate_limited')
+                            notify(res.retryAfterMs);
                         })
                         .catch(() => {});
                     }}

--- a/components/talks/RateLimitNotice.tsx
+++ b/components/talks/RateLimitNotice.tsx
@@ -1,0 +1,17 @@
+/**
+ * Inline notice shown when an audience write was refused with
+ * `{ ok: false, reason: 'rate_limited', retryAfterMs }`. Renders nothing while
+ * not limited; pairs with `useRateLimitNotice` for the countdown.
+ */
+export default function RateLimitNotice({
+  secondsLeft,
+}: {
+  secondsLeft: number | null;
+}) {
+  if (secondsLeft === null) return null;
+  return (
+    <p className="border-2 border-brutalist-yellow bg-black p-3 font-mono text-sm text-brutalist-yellow">
+      ⚠ Easy there — you've hit the send limit. Try again in {secondsLeft}s.
+    </p>
+  );
+}

--- a/components/talks/index.ts
+++ b/components/talks/index.ts
@@ -8,5 +8,6 @@ export { default as EmojiTop5 } from './EmojiTop5';
 export { default as LivePoll } from './LivePoll';
 export { default as OrderedActions } from './OrderedActions';
 export { default as QuestionQueue } from './QuestionQueue';
+export { default as RateLimitNotice } from './RateLimitNotice';
 export { default as TalkCard } from './TalkCard';
 export { default as TalkTimer } from './TalkTimer';

--- a/convex/AGENTS.md
+++ b/convex/AGENTS.md
@@ -34,7 +34,8 @@ content; a **talk session** is one live run of it. They share only the `slug`.
 | `questionVotes`       | One row per (question, machineId) — dedups upvotes                  |
 | `polls`               | Word-cloud poll prompts (`open`/`closed`)                           |
 | `pollWords`           | Per-(poll, word) tally; `hidden` blocks a word                      |
-| `pollSubmitters`      | One row per (poll, machineId) — dedups answers                      |
+| `pollSubmitters`      | One row per (poll, machineId) with answer `count` — caps answers per attendee |
+| `rateLimits`          | Per-(machineId, kind) fixed-window counters for audience writes    |
 | `activities`          | "Put the actions in order" activity (`options`, `revealAt`, `revealed`) |
 | `activitySubmissions` | Audience ordered-step submissions (`hidden` when flagged)          |
 | `...authTables`       | Convex Auth tables; `users` overridden to carry `githubLogin`       |
@@ -56,6 +57,7 @@ content; a **talk session** is one live run of it. They share only the `slug`.
 | `crons.ts`        | Scheduled TTL reapers (presence, reactions, presenters), every 1 min |
 | `lib/admin.ts`    | `isAdminUser` / `requireAdmin` — GitHub-login allowlist gate      |
 | `lib/profanity.ts`| `cleanText` / `cleanSteps` — mask + flag profanity (`obscenity`) |
+| `lib/rateLimit.ts`| Per-machine fixed-window rate limits for audience writes; structured `rate_limited` refusals |
 | `_generated/`     | Convex codegen (derived from schema + functions — do not hand-edit) |
 
 ## WHERE TO LOOK

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type * as hello from "../hello.js";
 import type * as http from "../http.js";
 import type * as lib_admin from "../lib/admin.js";
 import type * as lib_profanity from "../lib/profanity.js";
+import type * as lib_rateLimit from "../lib/rateLimit.js";
 import type * as polls from "../polls.js";
 import type * as presence from "../presence.js";
 import type * as questions from "../questions.js";
@@ -37,6 +38,7 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   "lib/admin": typeof lib_admin;
   "lib/profanity": typeof lib_profanity;
+  "lib/rateLimit": typeof lib_rateLimit;
   polls: typeof polls;
   presence: typeof presence;
   questions: typeof questions;

--- a/convex/activities.ts
+++ b/convex/activities.ts
@@ -3,6 +3,7 @@ import { internal } from './_generated/api';
 import { internalMutation, mutation, query } from './_generated/server';
 import { isAdminUser, requireAdmin } from './lib/admin';
 import { cleanSteps, cleanText } from './lib/profanity';
+import { enforceRateLimit } from './lib/rateLimit';
 import { liveTalkForRoom, resolveConfig } from './talks';
 
 const MAX_STEPS = 12;
@@ -176,12 +177,16 @@ export const feed = query({
   },
 });
 
-/** Audience: submit an ordered list of actions for the open activity. */
+/**
+ * Audience: submit an ordered list of actions for the open activity.
+ * Rate-limited per machine (structured refusal, so the UI can say when to retry).
+ */
 export const submit = mutation({
   args: {
     activityId: v.id('activities'),
     nickname: v.optional(v.string()),
     steps: v.array(v.string()),
+    machineId: v.string(),
   },
   handler: async (ctx, args) => {
     const activity = await ctx.db.get(args.activityId);
@@ -191,8 +196,10 @@ export const submit = mutation({
     // Gate on the live talk owning this room (mirrors reactions/questions).
     const talk = await liveTalkForRoom(ctx, activity.room);
     if (!talk) throw new Error('No live talk.');
-    // Activities disabled for this session: drop the write silently.
-    if (!resolveConfig(talk).activities) return { ok: false as const };
+    // Activities disabled for this session: drop the write (visibly).
+    if (!resolveConfig(talk).activities) {
+      return { ok: false as const, reason: 'disabled' as const };
+    }
 
     const trimmed = args.steps
       .map((step) => step.trim())
@@ -202,6 +209,14 @@ export const submit = mutation({
     if (trimmed.length === 0) {
       throw new Error('Add at least one step before submitting.');
     }
+
+    const limited = await enforceRateLimit(
+      ctx,
+      args.machineId,
+      'activity:submit',
+    );
+    if (limited) return limited;
+
     const { steps, flagged: stepsFlagged } = cleanSteps(trimmed);
 
     let nickname: string | undefined;
@@ -224,7 +239,7 @@ export const submit = mutation({
       hidden: stepsFlagged || nicknameFlagged,
       createdAt: Date.now(),
     });
-    return { ok: true };
+    return { ok: true as const };
   },
 });
 

--- a/convex/lib/rateLimit.ts
+++ b/convex/lib/rateLimit.ts
@@ -1,0 +1,122 @@
+import type { MutationCtx } from '../_generated/server';
+
+/**
+ * Per-machine rate limiting for the audience-write endpoints (poll submit,
+ * question ask/upvote, activity submit, reaction send), so a rowdy room — or a
+ * scripted client — can't flood a session. A fixed-window counter kept in the
+ * `rateLimits` table: one row per (machineId, kind), reused across windows
+ * (patched, never deleted), so the table stays bounded without a reaper.
+ *
+ * Best-effort by design: `machineId` is the same pseudo-anonymous localStorage
+ * id presence/dedup use, so it stops accidental floods and casual abuse, not a
+ * determined attacker minting fresh ids.
+ *
+ * When a call is refused the mutation returns a structured refusal —
+ * `{ ok: false, reason: 'rate_limited', retryAfterMs }` — never a silent drop,
+ * so the /live UI can tell the attendee when they can retry.
+ */
+
+export interface RateLimitConfig {
+  /** Max writes allowed per window. */
+  limit: number;
+  /** Window length in ms. */
+  windowMs: number;
+}
+
+/** Per-endpoint limits (per machine, per window). */
+export const RATE_LIMITS = {
+  'poll:submit': { limit: 10, windowMs: 60_000 },
+  'question:ask': { limit: 5, windowMs: 60_000 },
+  'question:upvote': { limit: 30, windowMs: 60_000 },
+  'activity:submit': { limit: 5, windowMs: 60_000 },
+  // Reactions arrive as client-debounced batches (count ≤ 20 per row), so this
+  // caps batches per window, not individual taps.
+  'reaction:send': { limit: 30, windowMs: 60_000 },
+} as const satisfies Record<string, RateLimitConfig>;
+
+export type RateLimitKind = keyof typeof RATE_LIMITS;
+
+/** The persisted counter state for one (machineId, kind) window. */
+export interface WindowState {
+  windowStart: number;
+  count: number;
+}
+
+export type TokenDecision =
+  | { allowed: true; next: WindowState }
+  | { allowed: false; retryAfterMs: number };
+
+/**
+ * Pure fixed-window token take: given the stored window state (or null for a
+ * first-ever call), decide whether one more write is allowed at `now` and what
+ * the next state should be. Kept pure so the window logic is unit-testable.
+ */
+export function takeToken(
+  state: WindowState | null,
+  config: RateLimitConfig,
+  now: number,
+): TokenDecision {
+  if (!state || now - state.windowStart >= config.windowMs) {
+    // Fresh machine or the previous window has elapsed: start a new window.
+    return { allowed: true, next: { windowStart: now, count: 1 } };
+  }
+  if (state.count < config.limit) {
+    return {
+      allowed: true,
+      next: { windowStart: state.windowStart, count: state.count + 1 },
+    };
+  }
+  return {
+    allowed: false,
+    retryAfterMs: state.windowStart + config.windowMs - now,
+  };
+}
+
+/** The structured refusal every rate-limited audience mutation returns. */
+export type RateLimitedRefusal = {
+  ok: false;
+  reason: 'rate_limited';
+  retryAfterMs: number;
+};
+
+/**
+ * Consume one rate-limit token for (machineId, kind), persisting the window
+ * counter. Returns `null` when the write may proceed, or the structured
+ * refusal to return to the client. Call it after the cheap read-only gates and
+ * immediately before the mutation's writes, so refused calls write nothing and
+ * the limit counts *landed* writes per window.
+ */
+export async function enforceRateLimit(
+  ctx: MutationCtx,
+  machineId: string,
+  kind: RateLimitKind,
+  now = Date.now(),
+): Promise<RateLimitedRefusal | null> {
+  const row = await ctx.db
+    .query('rateLimits')
+    .withIndex('by_machine_kind', (q) =>
+      q.eq('machineId', machineId).eq('kind', kind),
+    )
+    .unique();
+
+  const decision = takeToken(
+    row ? { windowStart: row.windowStart, count: row.count } : null,
+    RATE_LIMITS[kind],
+    now,
+  );
+  // `=== false` (not `!`): this repo compiles with `strict: false`, where
+  // truthiness checks don't narrow discriminated unions but comparisons do.
+  if (decision.allowed === false) {
+    return {
+      ok: false,
+      reason: 'rate_limited',
+      retryAfterMs: decision.retryAfterMs,
+    };
+  }
+  if (row) {
+    await ctx.db.patch(row._id, decision.next);
+  } else {
+    await ctx.db.insert('rateLimits', { machineId, kind, ...decision.next });
+  }
+  return null;
+}

--- a/convex/polls.ts
+++ b/convex/polls.ts
@@ -2,10 +2,19 @@ import { v } from 'convex/values';
 import { mutation, query } from './_generated/server';
 import { isAdminUser, requireAdmin } from './lib/admin';
 import { cleanText } from './lib/profanity';
+import { enforceRateLimit } from './lib/rateLimit';
 import { liveTalkForRoom, resolveConfig } from './talks';
 
 const MAX_PROMPT_LEN = 160;
 const MAX_WORD_LEN = 32;
+/** Hard ceiling on the presenter-set answers-per-attendee cap. */
+const MAX_ANSWERS_PER_ATTENDEE = 5;
+
+/** Clamp the presenter-set per-attendee answer cap to an integer in 1–5. */
+function clampAnswerCap(cap: number | undefined): number {
+  if (cap === undefined || !Number.isFinite(cap)) return 1;
+  return Math.min(MAX_ANSWERS_PER_ATTENDEE, Math.max(1, Math.floor(cap)));
+}
 
 /** Normalize a free-text answer into a single lowercase word for tallying. */
 function normalizeWord(raw: string): string {
@@ -16,8 +25,13 @@ function normalizeWord(raw: string): string {
 
 /** Presenter: open a poll prompt (closes any other open poll in the room). */
 export const start = mutation({
-  args: { room: v.string(), prompt: v.string() },
-  handler: async (ctx, { room, prompt }) => {
+  args: {
+    room: v.string(),
+    prompt: v.string(),
+    /** Answers each attendee may submit (default 1, server-clamped 1–5). */
+    maxAnswersPerAttendee: v.optional(v.number()),
+  },
+  handler: async (ctx, { room, prompt, maxAnswersPerAttendee }) => {
     await requireAdmin(ctx);
     // Only for a live talk with the poll feature enabled.
     const talk = await liveTalkForRoom(ctx, room);
@@ -39,6 +53,7 @@ export const start = mutation({
       prompt: cleanText(prompt.trim().slice(0, MAX_PROMPT_LEN)).text,
       status: 'open',
       createdAt: Date.now(),
+      maxAnswersPerAttendee: clampAnswerCap(maxAnswersPerAttendee),
     });
     return { ok: true };
   },
@@ -77,6 +92,7 @@ export const active = query({
     return {
       _id: poll._id,
       prompt: poll.prompt,
+      maxAnswers: clampAnswerCap(poll.maxAnswersPerAttendee),
       total,
       words: visible
         .map(({ word, count }) => ({ word, count }))
@@ -111,8 +127,11 @@ export const hideWord = mutation({
 });
 
 /**
- * Audience: submit a one-word answer; upserts the running tally. One answer per
- * machine per poll, so a single browser can't inflate the cloud by resubmitting.
+ * Audience: submit a one-word answer; upserts the running tally. Enforced
+ * server-side per machine: each attendee gets `maxAnswersPerAttendee` answers
+ * (default 1, presenter-set up to 5), so a single browser can't inflate the
+ * cloud by resubmitting. Rate-limited per machine on top; refusals are
+ * structured (never silent) so the UI can tell the attendee what happened.
  */
 export const submit = mutation({
   args: { pollId: v.id('polls'), word: v.string(), machineId: v.string() },
@@ -123,20 +142,34 @@ export const submit = mutation({
     }
     const talk = await liveTalkForRoom(ctx, poll.room);
     if (!talk) throw new Error('No live talk.');
-    // Poll disabled for this session: drop the write silently.
-    if (!resolveConfig(talk).poll) return { ok: false as const };
+    // Poll disabled for this session: drop the write (visibly to the client).
+    if (!resolveConfig(talk).poll) {
+      return { ok: false as const, reason: 'disabled' as const };
+    }
 
     const normalized = normalizeWord(word);
     if (!normalized) throw new Error('Type a word before submitting.');
 
-    const already = await ctx.db
+    const cap = clampAnswerCap(poll.maxAnswersPerAttendee);
+    const submitter = await ctx.db
       .query('pollSubmitters')
       .withIndex('by_poll_machine', (row) =>
         row.eq('pollId', pollId).eq('machineId', machineId),
       )
       .unique();
-    if (already) throw new Error('You have already answered this poll.');
-    await ctx.db.insert('pollSubmitters', { pollId, machineId });
+    const used = submitter ? (submitter.count ?? 1) : 0;
+    if (used >= cap) {
+      return { ok: false as const, reason: 'limit_reached' as const };
+    }
+
+    const limited = await enforceRateLimit(ctx, machineId, 'poll:submit');
+    if (limited) return limited;
+
+    if (submitter) {
+      await ctx.db.patch(submitter._id, { count: used + 1 });
+    } else {
+      await ctx.db.insert('pollSubmitters', { pollId, machineId, count: 1 });
+    }
 
     const existing = await ctx.db
       .query('pollWords')
@@ -149,6 +182,6 @@ export const submit = mutation({
     } else {
       await ctx.db.insert('pollWords', { pollId, word: normalized, count: 1 });
     }
-    return { ok: true };
+    return { ok: true as const, remaining: cap - used - 1 };
   },
 });

--- a/convex/questions.ts
+++ b/convex/questions.ts
@@ -2,6 +2,7 @@ import { v } from 'convex/values';
 import { mutation, query } from './_generated/server';
 import { isAdminUser, requireAdmin } from './lib/admin';
 import { cleanText } from './lib/profanity';
+import { enforceRateLimit } from './lib/rateLimit';
 import { liveTalkForRoom, resolveConfig } from './talks';
 
 const MAX_TEXT_LEN = 280;
@@ -15,21 +16,30 @@ function byPriority<T extends { votes: number; createdAt: number }>(
   return b.votes - a.votes || a.createdAt - b.createdAt;
 }
 
-/** Audience: ask a question. Gated on a live talk with Q&A enabled. */
+/**
+ * Audience: ask a question. Gated on a live talk with Q&A enabled and
+ * rate-limited per machine (structured refusal, so the UI can say when to retry).
+ */
 export const ask = mutation({
   args: {
     room: v.string(),
     text: v.string(),
     nickname: v.optional(v.string()),
+    machineId: v.string(),
   },
-  handler: async (ctx, { room, text, nickname }) => {
+  handler: async (ctx, { room, text, nickname, machineId }) => {
     const talk = await liveTalkForRoom(ctx, room);
     if (!talk) throw new Error('No live talk.');
-    // Q&A disabled for this session: drop the write silently (not merely hidden).
-    if (!resolveConfig(talk).qa) return { ok: false as const };
+    // Q&A disabled for this session: drop the write (not merely hidden).
+    if (!resolveConfig(talk).qa) {
+      return { ok: false as const, reason: 'disabled' as const };
+    }
 
     const cleaned = cleanText(text.trim().slice(0, MAX_TEXT_LEN));
     if (!cleaned.text) throw new Error('Type a question before submitting.');
+
+    const limited = await enforceRateLimit(ctx, machineId, 'question:ask');
+    if (limited) return limited;
 
     const rawNickname = nickname?.trim().slice(0, MAX_NICKNAME_LEN);
     const cleanedNickname = rawNickname ? cleanText(rawNickname) : undefined;
@@ -81,14 +91,18 @@ export const list = query({
  * single browser can upvote a given question at most once. Returns whether the
  * vote actually counted so the client only disables the button on a real success
  * (a no-op — hidden question, no live talk, or already voted — leaves it live).
+ * Rate-limited per machine with a structured refusal so the UI can say when to
+ * retry.
  */
 export const upvote = mutation({
   args: { id: v.id('questions'), machineId: v.string() },
   handler: async (ctx, { id, machineId }) => {
     const q = await ctx.db.get(id);
-    if (!q || q.hidden) return false;
+    if (!q || q.hidden) {
+      return { ok: false as const, reason: 'not_counted' as const };
+    }
     const talk = await liveTalkForRoom(ctx, q.room);
-    if (!talk) return false;
+    if (!talk) return { ok: false as const, reason: 'not_counted' as const };
 
     const already = await ctx.db
       .query('questionVotes')
@@ -96,11 +110,14 @@ export const upvote = mutation({
         row.eq('questionId', id).eq('machineId', machineId),
       )
       .unique();
-    if (already) return false;
+    if (already) return { ok: false as const, reason: 'not_counted' as const };
+
+    const limited = await enforceRateLimit(ctx, machineId, 'question:upvote');
+    if (limited) return limited;
 
     await ctx.db.insert('questionVotes', { questionId: id, machineId });
     await ctx.db.patch(id, { votes: q.votes + 1 });
-    return true;
+    return { ok: true as const };
   },
 });
 

--- a/convex/reactions.ts
+++ b/convex/reactions.ts
@@ -1,5 +1,6 @@
 import { v } from 'convex/values';
 import { internalMutation, mutation, query } from './_generated/server';
+import { enforceRateLimit } from './lib/rateLimit';
 import { liveTalkForRoom, resolveConfig } from './talks';
 
 // Reactions only need to live long enough to animate on screen.
@@ -11,14 +12,33 @@ const ALLOWED = new Set(['👍', '❤️', '😂', '🎉', '👏', '🔥']);
 
 export const ALLOWED_EMOJIS = ['👍', '❤️', '😂', '🎉', '👏', '🔥'];
 
-/** Send a batch of one emoji (count = debounced taps). Validated against the allow-list. */
+/**
+ * Send a batch of one emoji (count = debounced taps, clamped 1–20 — that's
+ * input clamping; the real flood control is the per-machine rate limit on
+ * batches, refused with a structured `rate_limited` result the UI surfaces).
+ * Validated against the allow-list.
+ */
 export const send = mutation({
-  args: { room: v.string(), emoji: v.string(), count: v.number() },
-  handler: async (ctx, { room, emoji, count }) => {
-    if (!ALLOWED.has(emoji)) return; // silently drop anything off the allow-list
+  args: {
+    room: v.string(),
+    emoji: v.string(),
+    count: v.number(),
+    machineId: v.string(),
+  },
+  handler: async (ctx, { room, emoji, count, machineId }) => {
+    // Drop anything off the allow-list (structured, but nothing to retry).
+    if (!ALLOWED.has(emoji)) {
+      return { ok: false as const, reason: 'dropped' as const };
+    }
     // Server-side gate: reactions only land for a live talk with reactions on.
     const talk = await liveTalkForRoom(ctx, room);
-    if (!talk || !resolveConfig(talk).reactions) return;
+    if (!talk || !resolveConfig(talk).reactions) {
+      return { ok: false as const, reason: 'dropped' as const };
+    }
+
+    const limited = await enforceRateLimit(ctx, machineId, 'reaction:send');
+    if (limited) return limited;
+
     const n = Math.min(Math.max(Math.floor(count), 1), 20);
     await ctx.db.insert('reactions', { room, emoji, count: n, at: Date.now() });
 
@@ -32,6 +52,7 @@ export const send = mutation({
     } else {
       await ctx.db.insert('reactionTotals', { room, emoji, total: n });
     }
+    return { ok: true as const };
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -137,6 +137,11 @@ export default defineSchema({
     prompt: v.string(),
     status: v.union(v.literal('open'), v.literal('closed')),
     createdAt: v.number(),
+    /**
+     * Answers each attendee may submit (server-clamped 1–5). Absent on polls
+     * opened before the field existed — treated as the default of 1.
+     */
+    maxAnswersPerAttendee: v.optional(v.number()),
   }).index('by_room_created', ['room', 'createdAt']),
 
   pollWords: defineTable({
@@ -149,12 +154,28 @@ export default defineSchema({
     .index('by_poll', ['pollId'])
     .index('by_poll_word', ['pollId', 'word']),
 
-  // One row per (poll, machine): the audience answers a poll once, so a single
-  // browser can't inflate the word cloud by resubmitting.
+  // One row per (poll, machine) with a per-machine answer count, enforced
+  // server-side against the poll's `maxAnswersPerAttendee` (default 1) so a
+  // single browser can't inflate the word cloud by resubmitting.
   pollSubmitters: defineTable({
     pollId: v.id('polls'),
     machineId: v.string(),
+    /** Answers this machine has submitted (absent on legacy rows = 1). */
+    count: v.optional(v.number()),
   }).index('by_poll_machine', ['pollId', 'machineId']),
+
+  // Per-(machine, kind) fixed-window counters rate-limiting the audience-write
+  // endpoints (poll submit, question ask/upvote, activity submit, reaction
+  // send). One row per machine+kind, reused across windows (patched, never
+  // deleted), so the table stays bounded without a reaper. Machine-scoped, not
+  // room-scoped — deliberately outside the per-session clear-down. See
+  // convex/lib/rateLimit.ts.
+  rateLimits: defineTable({
+    machineId: v.string(),
+    kind: v.string(),
+    windowStart: v.number(),
+    count: v.number(),
+  }).index('by_machine_kind', ['machineId', 'kind']),
 
   // Generic "put the actions in order" activity (the toast exercise generalized).
   // The presenter opens an activity with a prompt and a set of pre-defined option

--- a/lib/useRateLimitNotice.ts
+++ b/lib/useRateLimitNotice.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export interface RateLimitNoticeState {
+  /** Seconds until the next attempt is allowed; null when not limited. */
+  secondsLeft: number | null;
+  /** Arm the notice from a mutation's `{ retryAfterMs }` refusal. */
+  notify: (retryAfterMs: number) => void;
+}
+
+/**
+ * Countdown state for the audience-write rate limits. When a mutation returns
+ * `{ ok: false, reason: 'rate_limited', retryAfterMs }`, call `notify` with the
+ * refusal's `retryAfterMs`; `secondsLeft` then ticks down to null, so the UI
+ * can show the attendee they've hit the limit and when they can retry.
+ */
+export function useRateLimitNotice(): RateLimitNoticeState {
+  const [until, setUntil] = useState<number | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (until === null) return;
+    const id = setInterval(() => setNow(Date.now()), 500);
+    return () => clearInterval(id);
+  }, [until]);
+
+  useEffect(() => {
+    if (until !== null && now >= until) setUntil(null);
+  }, [now, until]);
+
+  const notify = useCallback((retryAfterMs: number) => {
+    const at = Date.now();
+    setNow(at);
+    setUntil(at + Math.max(0, retryAfterMs));
+  }, []);
+
+  const secondsLeft =
+    until === null ? null : Math.max(1, Math.ceil((until - now) / 1000));
+  return { secondsLeft, notify };
+}

--- a/lib/useReactions.ts
+++ b/lib/useReactions.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from 'convex/react';
 import { useCallback, useEffect, useRef } from 'react';
 import { api } from '@/convex/_generated/api';
+import { getMachineId } from '@/lib/machineId';
 
 // Batch this user's rapid taps: accumulate per-emoji counts and flush one
 // mutation per emoji after a short idle gap. Keeps spam off the wire while
@@ -12,15 +13,31 @@ export interface ReactionsState {
   react: (emoji: string) => void;
 }
 
-export function useReactions(room: string): ReactionsState {
+export function useReactions(
+  room: string,
+  /** Called with `retryAfterMs` when the server rate-limits a send batch. */
+  onRateLimited?: (retryAfterMs: number) => void,
+): ReactionsState {
   const send = useMutation(api.reactions.send);
   const recent = useQuery(api.reactions.recent, { room });
   const pending = useRef<Map<string, number>>(new Map());
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Keep the latest callback in a ref so `flush` (captured by timers/unmount
+  // cleanup) never goes stale.
+  const onRateLimitedRef = useRef(onRateLimited);
+  onRateLimitedRef.current = onRateLimited;
+
   const flush = useCallback(() => {
     for (const [emoji, count] of pending.current) {
-      void send({ room, emoji, count });
+      void send({ room, emoji, count, machineId: getMachineId() })
+        .then((res) => {
+          // `=== false` so the union narrows under `strict: false`.
+          if (res.ok === false && res.reason === 'rate_limited') {
+            onRateLimitedRef.current?.(res.retryAfterMs);
+          }
+        })
+        .catch(() => {});
     }
     pending.current.clear();
     timer.current = null;

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RATE_LIMITS,
+  type RateLimitConfig,
+  takeToken,
+} from '../convex/lib/rateLimit';
+
+const config: RateLimitConfig = { limit: 3, windowMs: 60_000 };
+const T0 = 1_000_000;
+
+describe('takeToken (fixed-window rate limit)', () => {
+  it('allows the first call and opens a window at now', () => {
+    const decision = takeToken(null, config, T0);
+    expect(decision).toEqual({
+      allowed: true,
+      next: { windowStart: T0, count: 1 },
+    });
+  });
+
+  it('increments within the window up to the limit', () => {
+    let state = { windowStart: T0, count: 1 };
+    for (let i = 2; i <= config.limit; i++) {
+      const decision = takeToken(state, config, T0 + i * 1000);
+      expect(decision.allowed).toBe(true);
+      if (decision.allowed) {
+        expect(decision.next).toEqual({ windowStart: T0, count: i });
+        state = decision.next;
+      }
+    }
+  });
+
+  it('refuses once the window is full, with the time until it resets', () => {
+    const now = T0 + 10_000;
+    const decision = takeToken(
+      { windowStart: T0, count: config.limit },
+      config,
+      now,
+    );
+    expect(decision).toEqual({
+      allowed: false,
+      retryAfterMs: T0 + config.windowMs - now,
+    });
+  });
+
+  it('retryAfterMs shrinks as the window ages', () => {
+    const early = takeToken(
+      { windowStart: T0, count: config.limit },
+      config,
+      T0 + 1_000,
+    );
+    const late = takeToken(
+      { windowStart: T0, count: config.limit },
+      config,
+      T0 + 59_000,
+    );
+    expect(early.allowed).toBe(false);
+    expect(late.allowed).toBe(false);
+    if (early.allowed === false && late.allowed === false) {
+      expect(early.retryAfterMs).toBe(59_000);
+      expect(late.retryAfterMs).toBe(1_000);
+    }
+  });
+
+  it('starts a fresh window once the previous one has elapsed', () => {
+    const now = T0 + config.windowMs;
+    const decision = takeToken(
+      { windowStart: T0, count: config.limit },
+      config,
+      now,
+    );
+    expect(decision).toEqual({
+      allowed: true,
+      next: { windowStart: now, count: 1 },
+    });
+  });
+
+  it('a stale window resets even when under the limit', () => {
+    const now = T0 + config.windowMs + 5_000;
+    const decision = takeToken({ windowStart: T0, count: 1 }, config, now);
+    expect(decision).toEqual({
+      allowed: true,
+      next: { windowStart: now, count: 1 },
+    });
+  });
+
+  it('exhausting a real endpoint config refuses on the call after the limit', () => {
+    const { limit } = RATE_LIMITS['question:ask'];
+    let state: { windowStart: number; count: number } | null = null;
+    for (let i = 0; i < limit; i++) {
+      const decision = takeToken(state, RATE_LIMITS['question:ask'], T0 + i);
+      expect(decision.allowed).toBe(true);
+      if (decision.allowed) state = decision.next;
+    }
+    const refused = takeToken(state, RATE_LIMITS['question:ask'], T0 + limit);
+    expect(refused.allowed).toBe(false);
+  });
+});


### PR DESCRIPTION
## What / why

QA finding **#29** from the 2026-07-02 careers-workshop debrief, in two parts:

### 1. Word-cloud poll: per-attendee answer caps, server-enforced
- `polls` gains `maxAnswersPerAttendee`, set by the presenter when opening the poll (server-clamped **1–5**, default **1** — legacy polls without the field behave as 1).
- `pollSubmitters` rows now carry a per-machine answer `count` (legacy rows read as 1), and `polls.submit` enforces the cap server-side per `machineId` — a client can no longer inflate the cloud by resubmitting.
- Over-cap submissions get a structured `{ ok: false, reason: 'limit_reached' }`; successes return the `remaining` allowance so `/live` can show "N answers left" on multi-answer polls.
- The `/admin` poll-open form gains an **answers per person** (1–5) selector; the open-poll panel shows the active cap.

### 2. Per-machine rate limits on all audience-write endpoints
- New `rateLimits` table: fixed-window counter, one row per `(machineId, kind)`, **reused across windows** (patched, never deleted) so the table stays bounded with no reaper. Pure window logic (`takeToken`) lives in `convex/lib/rateLimit.ts` and is unit-tested; `enforceRateLimit` is the db glue, called after the read-only gates and before any writes so refusals write nothing.
- Wired into `polls.submit` (10/min), `questions.ask` (5/min), `questions.upvote` (30/min), `activities.submit` (5/min), `reactions.send` (30 batches/min — the existing 1–20 count clamp is input clamping, not rate limiting).
- Refused calls return a **structured refusal** `{ ok: false, reason: 'rate_limited', retryAfterMs }` — never a silent drop — and every `/live` surface (poll, Q&A ask + upvote, ordered-actions, reactions bar) shows a countdown notice ("try again in Ns") via the new `useRateLimitNotice` hook + `RateLimitNotice` component.
- `questions.ask`, `activities.submit`, and `reactions.send` now take the `machineId` the other audience writes already used; `questions.upvote` moves from a bare boolean to the structured `{ ok, reason }` shape.
- Chose the simple in-table counter over `@convex-dev/rate-limiter`: the repo's Convex guidelines don't call for the component, and this matches existing patterns (`pollSubmitters`/`questionVotes`-style per-machine rows). Best-effort by design — `machineId` is the pseudo-anonymous localStorage id, so this stops rowdy-room floods, not adversaries minting fresh ids.

## Validation
- `pnpm typecheck` clean (note: repo compiles with `strict: false`, so refusal-union narrowing uses explicit `=== true/false` comparisons — commented where it matters).
- `pnpm vitest run --project unit`: 38/38 pass, incl. 7 new tests for the window logic (`tests/rate-limit.test.ts`).
- `pnpm lint` clean; `npx convex codegen` regenerated bindings.

## Manual test steps
1. Start a talk from `/admin`, open a poll with **answers per person = 3**; on `/live` submit 3 words (note the "N answers left" hint), verify the 4th is refused and the form flips to the submitted state. Re-open a poll with the default 1 and verify single-answer behavior is unchanged.
2. On `/live`, submit 6 questions quickly → the 6th shows the yellow "hit the send limit — try again in Ns" notice, the typed text is kept, and it sends fine after the countdown.
3. Rapid-fire upvotes/reactions past the window limit → same notice appears next to the respective control; reactions resume after the window.
4. Confirm the projected deck and console surfaces are unaffected (no submission forms there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)