### PR TITLE
feat(admin): full session delete — purge data and remove the log entry

### DIFF
--- a/components/admin/SessionManager.tsx
+++ b/components/admin/SessionManager.tsx
@@ -84,10 +84,55 @@ function ClearDownButton({
   );
 }
 
+function DeleteSessionButton({ room, live }: { room: string; live: boolean }) {
+  const deleteSession = useMutation(api.sessions.deleteSession);
+  const { run, error, busy } = useRunAction();
+  const [armed, setArmed] = useState(false);
+
+  // Same guard as clear-down: a live session must be ended first.
+  if (live) return null;
+
+  if (!armed) {
+    return (
+      <button
+        type="button"
+        onClick={() => setArmed(true)}
+        className="border-2 border-zinc-500 px-3 py-1.5 font-mono text-xs font-bold uppercase text-zinc-400 hover:border-brutalist-pink hover:bg-brutalist-pink hover:text-black"
+      >
+        Delete
+      </button>
+    );
+  }
+
+  return (
+    <span className="flex items-center gap-2">
+      <span className="font-mono text-xs uppercase text-brutalist-pink">
+        {error ?? 'Gone forever?'}
+      </span>
+      <button
+        type="button"
+        disabled={busy}
+        onClick={() => run(() => deleteSession({ room }))}
+        className="border-2 border-brutalist-pink bg-brutalist-pink px-3 py-1.5 font-mono text-xs font-bold uppercase text-black disabled:opacity-40"
+      >
+        {busy ? '…' : 'Yes, delete'}
+      </button>
+      <button
+        type="button"
+        onClick={() => setArmed(false)}
+        className="font-mono text-xs uppercase text-zinc-400 underline"
+      >
+        Cancel
+      </button>
+    </span>
+  );
+}
+
 /**
  * Admin "Sessions" panel: every live run of a talk (a session = the room every
- * feature scopes to), newest first, with the volume of data it generated and a
- * per-session "Clear down" that wipes that data (keeping the session record).
+ * feature scopes to), newest first, with the volume of data it generated, a
+ * per-session "Clear down" that wipes that data (keeping the session record),
+ * and a "Delete" that removes the session — data and log entry — entirely.
  */
 export default function SessionManager() {
   const data = useQuery(api.sessions.list, {});
@@ -127,12 +172,13 @@ export default function SessionManager() {
               submissions
             </p>
           </div>
-          <div className="shrink-0">
+          <div className="flex shrink-0 items-center gap-2">
             <ClearDownButton
               room={s.room}
               live={s.status === 'live'}
               hasData={s.hasData}
             />
+            <DeleteSessionButton room={s.room} live={s.status === 'live'} />
           </div>
         </div>
       ))}

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -203,6 +203,29 @@ export const clearDown = mutation({
 });
 
 /**
+ * Admin: permanently delete a session — purge all data it generated AND remove
+ * the `talks` row itself, so it disappears from the session log. Irreversible;
+ * to keep the log entry but drop the audience content, use `clearDown`. A live
+ * session must be ended first (same guard, same reason).
+ */
+export const deleteSession = mutation({
+  args: { room: v.string() },
+  handler: async (ctx, { room }) => {
+    await requireAdmin(ctx);
+
+    const talk = await ctx.db.get(room as Id<'talks'>);
+    if (!talk) return { ok: true }; // already gone — deleting is idempotent
+    if (talk.status === 'live') {
+      throw new Error('End the talk before deleting the session.');
+    }
+
+    await purgeSessionData(ctx, room);
+    await ctx.db.delete(talk._id);
+    return { ok: true };
+  },
+});
+
+/**
  * Scheduled (crons.ts): auto-expire ended sessions past the retention window.
  * Purges each old session's generated data while keeping its `talks` row, so the
  * session log stays but the (possibly unmasked) audience content does not.


### PR DESCRIPTION
## What

Adds a permanent **Delete** to the admin Sessions panel, alongside the existing Clear down.

- **`sessions.deleteSession`** (Convex): `requireAdmin`-gated; refuses live sessions (same guard and reason as `clearDown`); purges everything the room generated via the shared `purgeSessionData`, then deletes the `talks` row itself. Idempotent if the row is already gone.
- **SessionManager**: every ended session row gains a **Delete** button with the armed two-step confirm ("Gone forever? / Yes, delete"). Clear down keeps its exact behaviour (wipe data, keep the log entry).

## Why

Clear down deliberately preserves the session log — but drill/test sessions shouldn't live in history at all. Requested after the QA-fix testing session left nine zeroed drill rows in the log.

## Testing

- Verified live against the dev deployment: deleted all nine PR-drill sessions through the new button — data purged and rows removed reactively (37 → 28).
- Live-session guard enforced server-side and mirrored in the UI (no button until ended).
- A CSV + snapshot backup of both deployments was taken beforehand (`temp/backup-2026-07-02/`, local only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)