### PR TITLE
feat(auth): E2E bypass provider + CI live-e2e wiring (ADR-0005)

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -1,0 +1,85 @@
+name: Live E2E
+
+# Full live-talk flow (admin cockpit + presenter deck + attendee) driven by
+# tests/live-e2e.mjs in headless-bypass mode — no OAuth, no browser profile.
+# See ADR-0005 (docs/adr/0005-e2e-auth-bypass-and-test-github-branch.md).
+#
+# Required repo secrets (provisioned once, on the dedicated E2E dev deployment):
+#   CONVEX_DEPLOY_KEY_E2E   — deploy key for the E2E Convex deployment
+#   E2E_CONVEX_URL          — that deployment's .convex.cloud URL
+#   E2E_BYPASS_SECRET       — matches AUTH_E2E_BYPASS_SECRET set on it
+# The deployment itself needs: AUTH_E2E_BYPASS_SECRET, SITE_URL=http://localhost:3002,
+# and ADMIN_GITHUB_LOGINS including "e2e-bypass".
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # The E2E Convex deployment is shared state — one run at a time.
+  group: live-e2e
+  cancel-in-progress: false
+
+jobs:
+  live-e2e:
+    name: Live-talk flow (headless bypass)
+    runs-on: ubuntu-latest
+    # Skip gracefully on forks / until the secrets are provisioned.
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          path: blog
+      - uses: ./blog/.github/actions/setup-blog
+        with:
+          install-playwright: "true"
+
+      - name: Check secrets provisioned
+        id: secrets
+        working-directory: blog
+        env:
+          KEY: ${{ secrets.CONVEX_DEPLOY_KEY_E2E }}
+        run: |
+          if [ -z "$KEY" ]; then
+            echo "provisioned=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CONVEX_DEPLOY_KEY_E2E not set — skipping live E2E."
+          else
+            echo "provisioned=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push functions to the E2E deployment
+        if: steps.secrets.outputs.provisioned == 'true'
+        working-directory: blog
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY_E2E }}
+        run: npx convex deploy --yes
+
+      - name: Start dev server (bypass build)
+        if: steps.secrets.outputs.provisioned == 'true'
+        working-directory: blog
+        env:
+          NEXT_PUBLIC_CONVEX_URL: ${{ secrets.E2E_CONVEX_URL }}
+          NEXT_PUBLIC_E2E_BYPASS: "1"
+          NEXT_PUBLIC_E2E_BYPASS_SECRET: ${{ secrets.E2E_BYPASS_SECRET }}
+        run: |
+          pnpm dev -p 3002 > dev.log 2>&1 &
+          for i in $(seq 1 60); do
+            curl -sf -o /dev/null http://localhost:3002 && break
+            sleep 2
+          done
+
+      - name: Run live E2E harness
+        if: steps.secrets.outputs.provisioned == 'true'
+        working-directory: blog
+        env:
+          BASE_URL: http://localhost:3002
+          E2E_BYPASS: "1"
+        run: node tests/live-e2e.mjs
+
+      - name: Server log on failure
+        if: failure()
+        working-directory: blog
+        run: tail -50 dev.log || true

--- a/components/admin/AdminGate.tsx
+++ b/components/admin/AdminGate.tsx
@@ -4,6 +4,15 @@ import type { ReactNode } from 'react';
 import { api } from '@/convex/_generated/api';
 import { isConvexConfigured } from '@/lib/convexClient';
 
+// E2E bypass sign-in is offered only when the build opts in — and never on the
+// test-github branch, whose whole point is exercising the real OAuth flow.
+// (Hard-coded, not configurable: matching the server-side guard philosophy in
+// convex/auth.ts.) The secret is public to this bundle by design: it only
+// exists on dev/CI deployments, where the bypass provider is enabled anyway.
+const E2E_BYPASS_AVAILABLE =
+  process.env.NEXT_PUBLIC_E2E_BYPASS === '1' &&
+  process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF !== 'test-github';
+
 function SignIn() {
   const { signIn } = useAuthActions();
   // Return to the page the sign-in was launched from (default is SITE_URL = "/").
@@ -21,6 +30,20 @@ function SignIn() {
       >
         Sign in with GitHub
       </button>
+      {E2E_BYPASS_AVAILABLE && (
+        <button
+          type="button"
+          data-testid="e2e-signin"
+          onClick={() =>
+            void signIn('e2e', {
+              secret: process.env.NEXT_PUBLIC_E2E_BYPASS_SECRET ?? '',
+            })
+          }
+          className="ml-3 mt-4 border-2 border-brutalist-yellow px-5 py-2 font-bold uppercase text-brutalist-yellow"
+        >
+          E2E dev sign-in
+        </button>
+      )}
     </div>
   );
 }

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,11 +1,80 @@
 import GitHub from '@auth/core/providers/github';
-import { convexAuth } from '@convex-dev/auth/server';
+import { ConvexCredentials } from '@convex-dev/auth/providers/ConvexCredentials';
+import {
+  convexAuth,
+  createAccount,
+  retrieveAccount,
+} from '@convex-dev/auth/server';
+
+/**
+ * The production deployment, hard-coded. The E2E bypass provider below must
+ * never exist there, even if someone sets the env var by mistake — this guard
+ * is deliberately not configuration.
+ */
+const PROD_DEPLOYMENT = 'fiery-minnow-77';
+
+/**
+ * The E2E bypass is available only when the deployment opts in by setting
+ * AUTH_E2E_BYPASS_SECRET — and never on production (see PROD_DEPLOYMENT).
+ * The test-github branch deployment tests the real OAuth flow, so it simply
+ * never sets the secret (and its client build hides the button — see
+ * AdminGate). Signing in via the bypass does NOT grant admin by itself: the
+ * synthetic user's login must also be on ADMIN_GITHUB_LOGINS, per deployment.
+ */
+function e2eBypassEnabled(): boolean {
+  if (!process.env.AUTH_E2E_BYPASS_SECRET) return false;
+  if ((process.env.CONVEX_CLOUD_URL ?? '').includes(PROD_DEPLOYMENT)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Credentials provider for headless E2E runs: exchanges the deployment's
+ * shared secret for a session as a synthetic user. No OAuth hop, so the
+ * live-e2e harness (and CI) can sign in without a pre-authenticated browser
+ * profile. See docs/adr/0005-e2e-auth-bypass-and-test-github-branch.md.
+ */
+const e2eBypass = ConvexCredentials({
+  id: 'e2e',
+  authorize: async (credentials, ctx) => {
+    const expected = process.env.AUTH_E2E_BYPASS_SECRET;
+    if (!e2eBypassEnabled() || !expected) return null;
+    if (
+      typeof credentials.secret !== 'string' ||
+      credentials.secret !== expected
+    ) {
+      return null;
+    }
+
+    const login = process.env.AUTH_E2E_BYPASS_LOGIN ?? 'e2e-bypass';
+    // retrieveAccount throws (InvalidAccountId) when the account doesn't
+    // exist yet — treat that as "create it".
+    const existing = await retrieveAccount(ctx, {
+      provider: 'e2e',
+      account: { id: login },
+    }).catch(() => null);
+    if (existing) return { userId: existing.user._id };
+
+    const created = await createAccount(ctx, {
+      provider: 'e2e',
+      account: { id: login },
+      profile: {
+        name: 'E2E Bypass',
+        githubLogin: login,
+      },
+    });
+    return { userId: created.user._id };
+  },
+});
 
 /**
  * GitHub-only auth for the presenter/admin surfaces. The `profile` mapping keeps
  * the GitHub `login` on the user row (see the custom `users` table in schema.ts)
  * so mutations can allowlist by username against ADMIN_GITHUB_LOGINS. Requires
  * AUTH_GITHUB_ID / AUTH_GITHUB_SECRET env vars on the deployment.
+ *
+ * Dev/CI deployments may additionally opt into the `e2e` bypass provider above.
  */
 export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
   providers: [
@@ -20,5 +89,6 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
         };
       },
     }),
+    ...(e2eBypassEnabled() ? [e2eBypass] : []),
   ],
 });

--- a/docs/adr/0005-e2e-auth-bypass-and-test-github-branch.md
+++ b/docs/adr/0005-e2e-auth-bypass-and-test-github-branch.md
@@ -1,0 +1,59 @@
+# ADR-0005: E2E auth bypass + dedicated `test-github` branch for the real OAuth flow
+
+Date: 2026-07-03
+Status: accepted
+Revises: [ADR-0004](0004-preview-environments-and-auth.md)
+
+## Context
+
+ADR-0004 established why per-branch Vercel previews can't run admin-driven
+E2E: an ephemeral `*.convex.site` URL can't be pre-registered as a GitHub
+OAuth callback. The consequence was that the live-e2e harness could only run
+against a browser profile someone had interactively signed in — which also
+blocked wiring it into CI.
+
+## Decision
+
+Split the two concerns:
+
+1. **Headless auth for tests — the `e2e` bypass provider.** A
+   `ConvexCredentials` provider (`convex/auth.ts`) exchanges a deployment's
+   shared secret (`AUTH_E2E_BYPASS_SECRET`) for a session as a synthetic
+   user. Layered guards:
+   - the provider is registered only when the deployment sets the secret;
+   - it is **hard-coded off for the production deployment**
+     (`fiery-minnow-77`) — not configuration, a constant in the source;
+   - signing in via the bypass grants nothing by itself: the synthetic
+     user's login (`AUTH_E2E_BYPASS_LOGIN`, default `e2e-bypass`) must also
+     be on that deployment's `ADMIN_GITHUB_LOGINS`;
+   - the client button renders only when built with
+     `NEXT_PUBLIC_E2E_BYPASS=1`, and **never on the `test-github` branch**
+     (hard-coded check on `NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF`).
+
+2. **Real OAuth stays testable — the long-lived `test-github` branch.** A
+   branch has a *stable* Vercel URL (unlike per-PR previews), so it CAN be
+   pre-registered as a GitHub OAuth callback. `test-github` is deployed with
+   the bypass disabled and GitHub enabled: when the OAuth flow itself needs
+   testing, that's the environment. Setup (one-time, manual):
+   - dedicated Convex deployment with `SITE_URL=<test-github branch URL>`,
+     `AUTH_GITHUB_ID`/`AUTH_GITHUB_SECRET` for a GitHub OAuth app registered
+     to that URL, and **no** `AUTH_E2E_BYPASS_SECRET`;
+   - Vercel branch env for `test-github`: `NEXT_PUBLIC_CONVEX_URL` pointing
+     at that deployment, and no `NEXT_PUBLIC_E2E_BYPASS`.
+
+3. **CI wiring** (`.github/workflows/live-e2e.yml`): with OAuth out of the
+   test path, the harness (`E2E_BYPASS=1`) launches headless Chromium, signs
+   in via the bypass button, and runs the full live-talk flow on PRs against
+   a dedicated E2E Convex deployment. The job no-ops until its secrets are
+   provisioned.
+
+## Consequences
+
+- CI can exercise the whole audience-participation flow without a
+  pre-authenticated profile.
+- The real sign-in path is no longer covered implicitly by every local
+  harness run — it must be exercised deliberately against `test-github`
+  (or production, post-deploy).
+- The bypass secret in `NEXT_PUBLIC_*` is visible in dev/CI bundles by
+  design; those deployments are disposable and the secret is worthless
+  against production, where the provider cannot exist.

--- a/docs/live-e2e-harness.md
+++ b/docs/live-e2e-harness.md
@@ -21,9 +21,26 @@ It exercises, in one pass:
 
 ## Running it
 
-Point it at a running server and an already-authenticated Chrome exposed over
-CDP (the [agent-browser](https://github.com/) dev profile, or any Chrome
-launched with `--remote-debugging-port`):
+Two auth modes:
+
+**Headless bypass (CI, or local without a signed-in profile).** With the
+`e2e` bypass provider enabled on the Convex deployment (ADR-0005) and the app
+built with `NEXT_PUBLIC_E2E_BYPASS=1`, the harness launches its own headless
+Chromium and signs in via the bypass button — no OAuth, no profile:
+
+```bash
+E2E_BYPASS=1 BASE_URL=http://localhost:3002 pnpm test:live-e2e
+```
+
+This is what `.github/workflows/live-e2e.yml` runs on PRs. The real GitHub
+sign-in flow is deliberately not covered here — exercise it against the
+long-lived `test-github` branch deployment (bypass hard-disabled there) or
+production.
+
+**CDP attach (original mode).** Point it at a running server and an
+already-authenticated Chrome exposed over CDP (the
+[agent-browser](https://github.com/) dev profile, or any Chrome launched with
+`--remote-debugging-port`):
 
 ```bash
 # 1. dev server

--- a/tests/live-e2e.mjs
+++ b/tests/live-e2e.mjs
@@ -25,7 +25,21 @@ import puppeteer from 'puppeteer-core';
 
 const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3002';
 const CDP_URL = process.env.CDP_URL ?? 'http://127.0.0.1:53460';
+// When set (and the app was built with NEXT_PUBLIC_E2E_BYPASS=1), the harness
+// launches its own headless browser and signs in via the `e2e` bypass provider
+// instead of attaching to a pre-authenticated profile over CDP. This is the
+// CI path — no OAuth, no profile. See ADR-0005.
+const E2E_BYPASS = process.env.E2E_BYPASS === '1';
 const SLUG = 'e2e-debug-deck';
+
+/** Resolve a Chromium executable for headless bypass mode: an explicit
+ * CHROME_PATH wins; otherwise use Playwright's installed chromium (present in
+ * this repo's CI for the visual suites). */
+async function chromiumPath() {
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  const { chromium } = await import('@playwright/test');
+  return chromium.executablePath();
+}
 
 // ── tiny assertion harness ──────────────────────────────────────────────────
 const results = [];
@@ -192,12 +206,23 @@ async function newTab(browser, url) {
 
 // ── the run ─────────────────────────────────────────────────────────────────
 async function main() {
-  step(`Connecting to browser at ${CDP_URL}`);
-  const browser = await puppeteer.connect({
-    browserURL: CDP_URL,
-    defaultViewport: null,
-    protocolTimeout: 30000,
-  });
+  let browser;
+  if (E2E_BYPASS) {
+    step('Launching headless browser (E2E bypass auth)');
+    browser = await puppeteer.launch({
+      executablePath: await chromiumPath(),
+      headless: true,
+      defaultViewport: { width: 1400, height: 900 },
+      protocolTimeout: 30000,
+    });
+  } else {
+    step(`Connecting to browser at ${CDP_URL}`);
+    browser = await puppeteer.connect({
+      browserURL: CDP_URL,
+      defaultViewport: null,
+      protocolTimeout: 30000,
+    });
+  }
 
   // Close any stray tabs left by a previous run so they don't starve the deck.
   for (const p of await browser.pages()) {
@@ -206,12 +231,31 @@ async function main() {
 
   const admin = await newTab(browser, '/admin');
 
+  // Bypass mode: a fresh browser has no session — sign in via the e2e provider
+  // (button rendered only when the app was built with NEXT_PUBLIC_E2E_BYPASS=1).
+  if (E2E_BYPASS) {
+    const btn = await until(() => admin.$('[data-testid="e2e-signin"]'), {
+      timeout: 20000,
+    });
+    record('admin: e2e sign-in button present', Boolean(btn));
+    if (btn) await btn.click();
+  }
+
   // Sanity: we're signed in as an admin (cockpit visible, no sign-in wall).
   // AdminGate validates the token server-side, which can take a beat.
   const signedIn = await waitForText(admin, 'signed in as', { timeout: 25000 });
-  record('admin: signed in (reused OAuth session)', Boolean(signedIn));
+  record(
+    E2E_BYPASS
+      ? 'admin: signed in (e2e bypass)'
+      : 'admin: signed in (reused OAuth session)',
+    Boolean(signedIn),
+  );
   if (!signedIn) {
-    console.error('\nNot signed in — open the CDP browser and sign in first.');
+    console.error(
+      E2E_BYPASS
+        ? '\nBypass sign-in failed — is AUTH_E2E_BYPASS_SECRET set on the deployment, NEXT_PUBLIC_E2E_BYPASS=1 on the app build, and the bypass login on ADMIN_GITHUB_LOGINS?'
+        : '\nNot signed in — open the CDP browser and sign in first.',
+    );
     printSummaryAndExit();
     return;
   }


### PR DESCRIPTION
## What

Implements the auth split designed in review: a **dev/CI-only bypass** so the live-e2e harness runs headless (making CI wiring possible), with the **real GitHub OAuth flow kept testable** on a dedicated long-lived branch.

- **`convex/auth.ts`** — new `e2e` ConvexCredentials provider: exchanges the deployment's `AUTH_E2E_BYPASS_SECRET` for a session as a synthetic user. Guards, layered:
  - provider registered only when the deployment sets the secret;
  - **hard-coded off for production** (`fiery-minnow-77`) — a source constant, not config;
  - bypass sign-in grants nothing unless the synthetic login (`e2e-bypass`) is on that deployment's `ADMIN_GITHUB_LOGINS`.
- **`AdminGate`** — "E2E dev sign-in" button only when built with `NEXT_PUBLIC_E2E_BYPASS=1`, and **hard-coded never on the `test-github` branch** (`NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF` check).
- **`tests/live-e2e.mjs`** — `E2E_BYPASS=1` launches its own headless Chromium (Playwright's binary) and signs in via the button; the CDP-attach mode is unchanged.
- **`.github/workflows/live-e2e.yml`** — PR job running the full flow against a dedicated E2E Convex deployment; no-ops gracefully until its secrets are provisioned (`CONVEX_DEPLOY_KEY_E2E`, `E2E_CONVEX_URL`, `E2E_BYPASS_SECRET`).
- **ADR-0005** — records the decision; revises ADR-0004's "local or prod only" constraint.
- **`test-github` branch** — pushed from main; its stable Vercel URL can be pre-registered as a GitHub OAuth callback (the thing ephemeral previews can't do). One-time manual setup listed in the ADR.

## Verified locally

- `npx convex run auth:signIn` with the correct secret mints a session; a wrong secret returns `tokens: null`.
- Full harness in headless bypass mode: **19/21** — sign-in, follow, poll, Q&A, ordered-actions + reveal, reactions, clear-down all green; the 2 failures are the pre-existing harness drift from #35 (identical on main, tracked in todo).
- Production deployment has no bypass env vars, and the hard guard makes them inert anyway.

## Post-merge manual steps (one-time)

1. Create the E2E Convex deployment + set its env (`AUTH_E2E_BYPASS_SECRET`, `SITE_URL=http://localhost:3002`, `ADMIN_GITHUB_LOGINS=e2e-bypass`), add the three repo secrets — the Live E2E job activates itself.
2. For `test-github`: dedicated Convex deployment + GitHub OAuth app registered to the branch's stable Vercel URL, per ADR-0005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)