### PR TITLE
Add virtual-monorepo post + deterministic header/OG image engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ storybook-static
 # temporary working files
 /temp/
 
+# build-generated per-post OG cards (produced by scripts/generate-og-images.mjs)
+/public/static/og/
+
 # git worktrees (scratch state for parallel branches)
 .worktrees/
 .claude/worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Talk routes: `pages/talks/` (deck landing + `present` presenter view), `pages/li
 | Remark plugins     | `lib/remark-*.ts`      | Custom: code-title, toc-headings, references, img-to-jsx |
 | Bibliography / durable links | `lib/remark-references.ts`, `components/References.tsx` | Auto [n] citations + References section (original + archived link); `pnpm archive-links` saves URLs to the Wayback Machine |
 | Design tokens      | `tailwind.config.js`   | Brutalist colors, shadows, typography        |
+| Header / OG images | `lib/og/headerImage.mjs` | Deterministic SVG engine (see lib/AGENTS.md) |
 | Global CSS         | `css/tailwind.css`     | Tailwind v4 imports, CSS vars, utilities     |
 | Tests              | `tests/*.spec.ts`      | See tests/AGENTS.md                          |
 | Build scripts      | `scripts/*.mjs`        | sitemap, search, tag-rss, create-post        |
@@ -198,7 +199,8 @@ pnpm build
 ├── next build (Turbopack)
 ├── scripts/generate-sitemap.mjs
 ├── scripts/generate-search.mjs
-└── scripts/generate-tag-rss.mjs
+├── scripts/generate-tag-rss.mjs
+└── scripts/generate-og-images.mjs   # deterministic per-post OG cards → public/static/og/<slug>.png
 ```
 
 Custom: requires building external `@rtkelly/mermaid-toolkit` first in CI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,37 @@
 **Commit:** e6620e1
 **Branch:** main
 
+## AUTHORSHIP POLICY (READ FIRST)
+
+**The prose is human-authored. The words a reader reads are written by Ryan.**
+
+This blog is working toward *fully human-authored words*. The narrative body of
+every post and talk — the sentences and paragraphs in `data/blog/**` and
+`data/talks/**` — is written by the human author. Agents must **not** draft,
+ghostwrite, or rewrite that prose, and must not "polish" it into their own
+phrasing. When a post's body is still an AI-generated draft, treat it as a
+scaffold to be replaced by the author's own words, not as finished copy.
+
+**Agents assist with everything *around* the words** — this is not only allowed,
+it's the point:
+
+- **Shape, not sentences** — propose an outline, section order, or where an idea
+  belongs; suggest that a section is missing or overlong. Leave the actual
+  wording to the author.
+- **Peripheral & utility artifacts** — diagrams (`<Diagram>`/Mermaid), header and
+  OG images (`lib/og/`), code samples, tables, frontmatter, tags, file
+  scaffolding, MDX component wiring, links, and asset generation.
+- **Mechanics** — fix typos, broken links, Markdown/MDX syntax, and formatting;
+  never reword for content.
+- **Everything outside `data/`** — components, layouts, `lib/`, tests, build
+  tooling, CI — is normal agent territory.
+
+Reader-facing metadata that is prose (a post `summary`) may be *drafted* by an
+agent as a suggestion, but the author owns the final wording.
+
+Rule of thumb: **if a reader reads it as the author's voice, a human wrote it;
+if it's structure, code, or an asset, an agent can.**
+
 ## OVERVIEW
 
 Personal blog for Ryan Kelly (ryankelly.dev). Next.js 16 + React 19, Tailwind CSS v4, MDX content, brutalist design system.

--- a/components/PostHeaderImage.stories.tsx
+++ b/components/PostHeaderImage.stories.tsx
@@ -1,0 +1,61 @@
+// @ts-nocheck
+import type { Meta, StoryObj } from '@storybook/react';
+import PostHeaderImage from './PostHeaderImage';
+
+const meta = {
+  title: 'Components/PostHeaderImage',
+  component: PostHeaderImage,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Deterministic, asset-free post hero. The palette, decorative field, and layout are a pure function of `slug`, so the same post always renders the same banner — and it is pixel-identical to the rasterised OG card produced at build time by `scripts/generate-og-images.mjs`. Change the slug to see the palette/motif change.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['banner', 'og'],
+      description: 'Aspect variant: on-page hero (2:1) vs social card (1.91:1)',
+    },
+    title: { control: 'text' },
+    slug: { control: 'text', description: 'Determinism seed' },
+    date: { control: 'text' },
+  },
+} satisfies Meta<typeof PostHeaderImage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const LongTitle: Story = {
+  args: {
+    title: 'The Virtual Monorepo: Giving Coding Agents One World to Reason About',
+    slug: 'virtual-monorepo-coding-agents',
+    tags: ['ai', 'coding-agents', 'monorepo', 'architecture'],
+    date: '2026-07-04',
+    variant: 'banner',
+  },
+};
+
+export const ShortTitle: Story = {
+  args: {
+    title: 'AWS Batch - Cookbook',
+    slug: 'aws-batch/cookbook',
+    tags: ['aws', 'aws-batch', 'docker'],
+    date: '2022-08-19',
+    variant: 'banner',
+  },
+};
+
+export const SocialCard: Story = {
+  args: {
+    title: 'Reviving My Blog After 3 Years',
+    slug: 'blog-upgrade-2026',
+    tags: ['nextjs', 'tailwind', 'react', 'design'],
+    date: '2026-01-15',
+    variant: 'og',
+  },
+};

--- a/components/PostHeaderImage.stories.tsx
+++ b/components/PostHeaderImage.stories.tsx
@@ -32,7 +32,8 @@ type Story = StoryObj<typeof meta>;
 
 export const LongTitle: Story = {
   args: {
-    title: 'The Virtual Monorepo: Giving Coding Agents One World to Reason About',
+    title:
+      'The Virtual Monorepo: Giving Coding Agents One World to Reason About',
     slug: 'virtual-monorepo-coding-agents',
     tags: ['ai', 'coding-agents', 'monorepo', 'architecture'],
     date: '2026-07-04',

--- a/components/PostHeaderImage.tsx
+++ b/components/PostHeaderImage.tsx
@@ -1,0 +1,43 @@
+import { buildHeaderSvg } from '@/lib/og/headerImage';
+
+interface PostHeaderImageProps {
+  title: string;
+  slug: string;
+  tags?: string[];
+  date?: string;
+  /** Aspect variant: on-page hero (2:1) vs social card (1.91:1). */
+  variant?: 'banner' | 'og';
+  className?: string;
+}
+
+/**
+ * Deterministic, asset-free post hero. Renders the shared SVG engine inline so
+ * the on-page banner is pixel-identical to the rasterised OG card produced by
+ * `scripts/generate-og-images.mjs` (both call `buildHeaderSvg`). Inline SVG
+ * means no network request and crisp rendering at any size; the site's loaded
+ * webfonts apply automatically.
+ */
+export default function PostHeaderImage({
+  title,
+  slug,
+  tags,
+  date,
+  variant = 'banner',
+  className,
+}: PostHeaderImageProps) {
+  const dims =
+    variant === 'og'
+      ? { width: 1200, height: 630 }
+      : { width: 1200, height: 600 };
+
+  const svg = buildHeaderSvg({ title, slug, tags, date, ...dims });
+
+  // Non-user SVG generated locally from post metadata (text is XML-escaped
+  // inside the engine), so inlining it is safe.
+  return (
+    <div
+      className={className}
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}

--- a/components/PostHeaderImage.tsx
+++ b/components/PostHeaderImage.tsx
@@ -35,9 +35,6 @@ export default function PostHeaderImage({
   // Non-user SVG generated locally from post metadata (text is XML-escaped
   // inside the engine), so inlining it is safe.
   return (
-    <div
-      className={className}
-      dangerouslySetInnerHTML={{ __html: svg }}
-    />
+    <div className={className} dangerouslySetInnerHTML={{ __html: svg }} />
   );
 }

--- a/components/SEO.tsx
+++ b/components/SEO.tsx
@@ -119,7 +119,9 @@ export const BlogSEO = ({
   // With no explicit front-matter image, fall back to the post's
   // deterministic, build-generated OG card (scripts/generate-og-images.mjs)
   // rather than the generic site banner, so every post shares a unique card.
-  const fallbackImage = slug ? `/static/og/${slug}.png` : siteMetadata.socialBanner;
+  const fallbackImage = slug
+    ? `/static/og/${slug}.png`
+    : siteMetadata.socialBanner;
   const imagesArr =
     images.length === 0
       ? [fallbackImage]

--- a/components/SEO.tsx
+++ b/components/SEO.tsx
@@ -110,14 +110,19 @@ export const BlogSEO = ({
   date,
   lastmod,
   url,
+  slug,
   images = [],
 }: BlogSeoProps) => {
   const router = useRouter();
   const publishedAt = new Date(date).toISOString();
   const modifiedAt = new Date(lastmod || date).toISOString();
+  // With no explicit front-matter image, fall back to the post's
+  // deterministic, build-generated OG card (scripts/generate-og-images.mjs)
+  // rather than the generic site banner, so every post shares a unique card.
+  const fallbackImage = slug ? `/static/og/${slug}.png` : siteMetadata.socialBanner;
   const imagesArr =
     images.length === 0
-      ? [siteMetadata.socialBanner]
+      ? [fallbackImage]
       : typeof images === 'string'
         ? [images]
         : images;

--- a/data/blog/virtual-monorepo-coding-agents.mdx
+++ b/data/blog/virtual-monorepo-coding-agents.mdx
@@ -9,11 +9,10 @@ tags:
     "developer-tools",
     "architecture",
     "workflow",
-    "python",
-    "opencode",
+    "productivity",
   ]
 draft: true
-summary: "Eleven repositories, five languages, 90k+ files — and a coding agent that only sees one folder at a time. This is how a 'virtual monorepo' (a config-only brain, symlinked to independent repos) gives agents a single, coherent world to navigate, and why that turns out to matter more for the agents than for the humans."
+summary: "A pile of separate repositories, several languages, and a coding agent that only ever sees one folder at a time. This is the 'virtual monorepo' — a config-only 'brain' repo symlinked to your real repos — and why it turns out to matter more for the agents than for the humans."
 images: []
 layout: PostLayout
 authors: ["default"]
@@ -21,77 +20,76 @@ authors: ["default"]
 
 # The problem nobody warns you about
 
-At work we have eleven repositories. A .NET rights-application with 45,000 files
-and 448k lines of code. A React monorepo. A pile of Python ETL pipelines with
-2.75 _million_ lines between them. A data platform, a CMS, a public artist site,
-E2E test suites, bootstrap scripts. Five languages, independent git histories,
-independent deploys. Ninety-thousand-plus files if you add it all up.
+Most companies past a certain age don't have _a_ codebase. They have a dozen.
+A backend here, a couple of frontends there, a stack of data pipelines, some
+infrastructure, a few standalone tools, the test suites nobody wants to touch.
+Different languages, independent git histories, independent deploys. It's the
+normal end state of any organisation that's been shipping for more than a few
+years, and — day #1 to day #1000 — it mostly works fine.
 
-None of that is unusual. Plenty of companies live in a polyrepo world and are
-perfectly happy. What _changed_ is that I now spend a large chunk of my day
-handing work to coding agents — OpenCode, Claude Code, Gemini — and a coding
-agent has one brutal limitation that a human developer mostly doesn't:
+I live in exactly that world at work. And plenty of teams are perfectly happy in
+it. What _changed_ for me is that I now spend a large chunk of my day handing
+work to coding agents, and a coding agent has one brutal limitation that a human
+developer mostly doesn't:
 
 **its working directory is its entire universe.**
 
-A human engineer holds the shape of the whole company in their head. They know
-that authentication lives in the rights-app, that reporting queries hit the data
-platform, that the people-to-GitHub mapping is a JSON file in the platform repo.
-They `cd` between clones without thinking. An agent, dropped into one repo, sees
-one repo. Ask it "who calls this function across our services" and it can't —
-the other services aren't on its filesystem. Ask it "follow our git conventions"
-and it will follow whatever it can find in _this_ repo, which may be nothing.
+A human engineer holds the shape of the whole system in their head. They know
+that authentication lives in one service, that reporting queries hit another,
+that the "who owns what" mapping is a file buried in a third. They `cd` between
+clones without thinking. An agent, dropped into one repo, sees one repo. Ask it
+"who calls this function across our services" and it can't — the other services
+aren't on its filesystem. Ask it to "follow our conventions" and it will follow
+whatever it happens to find in _this_ repo, which is often nothing.
 
-The obvious fix is "put everything in a monorepo." But merging eleven repos with
-independent histories, CI, and deploy cadences is a multi-quarter migration
-nobody has budget for, and it throws away the independence that makes the repos
+The obvious fix is "put everything in a monorepo." But merging a dozen repos with
+independent histories, CI, and release cadences is a multi-quarter migration
+nobody has budget for, and it throws away the independence that makes each repo
 easy to reason about in the first place.
 
-So we did something cheaper and, it turns out, better suited to agents: a
-**virtual monorepo**.
+So instead of a real monorepo, there's a much cheaper move that — it turns out —
+suits agents even better: a **virtual monorepo**.
 
 # Brain and body
 
 The idea is a split between a **brain** and a **body**.
 
-The **body** is all the real product repositories, cloned side by side under one
-parent directory (`~/code/sentric/`). They stay exactly what they are — separate
-git repos, separate CI, separate deploys. Nothing about them changes.
+The **body** is all your real repositories, cloned side by side under one parent
+directory. They stay exactly what they are — separate git repos, separate CI,
+separate deploys. Nothing about them changes.
 
-The **brain** is a single small repo — we call it `workspace` — that tracks
-*no product source code at all*. It holds configuration, documentation, shared
-CLIs, environment setup, and the agent instructions. Then it exposes the entire
-body through **one symlink**:
+The **brain** is a single small repo that tracks _no product source code at all_.
+It holds configuration, documentation, shared tooling, and — crucially — the
+agent instructions. Then it exposes the entire body through **one symlink**:
 
 ```
 ~/code/
-├── sentric/                       # BODY — independent git repos
-│   ├── rights-application/
-│   ├── data-platform/
-│   ├── sentric-frontends/
-│   ├── publishing-dashboard/
-│   └── ... 7 more
+├── company/                       # BODY — independent git repos
+│   ├── backend-service/
+│   ├── web-frontend/
+│   ├── data-pipelines/
+│   └── ... more repos
 │
 └── workspace/                     # BRAIN — config + docs + tooling only
     ├── AGENTS.md                  # canonical agent instructions
     ├── docs/                      # runbooks, conventions, process
-    ├── src/                       # workspace CLIs (Python / uv)
-    └── projects  ->  ../sentric   # the whole body, one symlink
+    ├── tools/                     # small cross-repo CLIs
+    └── projects  ->  ../company   # the whole body, one symlink
 ```
 
-That `projects -> ../sentric` symlink is the whole trick. From inside the brain,
-`projects/rights-application/`, `projects/data-platform/`, and every other repo
-are _right there_ on the filesystem. One `ln -s` on macOS and Linux, a junction
-point on Windows.
+That `projects -> ../company` symlink is the whole trick. From inside the brain,
+`projects/backend-service/`, `projects/web-frontend/`, and every other repo are
+_right there_ on the filesystem. One `ln -s` on macOS and Linux, a junction point
+on Windows, and a small bootstrap script to hide the difference.
 
-<Diagram type="mermaid" caption="Brain/Body: one symlink turns eleven repos into one navigable tree">
+<Diagram type="mermaid" caption="Brain/Body: one symlink turns many repos into one navigable tree">
 {`graph TD
-    A[workspace<br/>THE BRAIN<br/>config · docs · CLIs]
+    A[workspace<br/>THE BRAIN<br/>config · docs · tools]
     P[projects/ symlink]
-    B1[rights-application]
-    B2[data-platform]
-    B3[sentric-frontends]
-    B4[...7 more repos]
+    B1[backend-service]
+    B2[web-frontend]
+    B3[data-pipelines]
+    B4[...more repos]
     A --> P
     P --> B1
     P --> B2
@@ -106,37 +104,36 @@ point on Windows.
     linkStyle default stroke:#fff,stroke-width:2px`}
 </Diagram>
 
-The name I keep coming back to is **"one world to reason about."** A real
-monorepo gives you atomic cross-repo commits, which is genuinely something we
+The phrase I keep coming back to is **"one world to reason about."** A real
+monorepo gives you atomic cross-repo commits, which is genuinely something you
 give up here. But most of what makes a monorepo pleasant day to day isn't atomic
 commits — it's that _everything is in one tree you can see at once_. The virtual
 monorepo buys you exactly that property, for the price of a symlink, without
-touching a single product repo's history.
+rewriting a single repo's history.
 
 # Why this is really a coding-agent story
 
 I want to be honest about the framing. A virtual monorepo is _nice_ for humans —
 it's convenient to have one folder. But humans already had a workaround: they
-kept the mental model in their heads. The reason we actually built the tooling
-around this, the reason it earned real investment, is that **agents don't have
-heads.** Everything a human "just knows" has to become a file, a symlink, or a
-command. The virtual monorepo is the substrate that makes that possible. Here's
-what we hang off it.
+kept the mental model in their heads. The reason this pattern earns real
+investment is that **agents don't have heads.** Everything a human "just knows"
+has to become a file, a symlink, or a command an agent can run. The virtual
+monorepo is the substrate that makes that possible. Here's what you hang off it.
 
 ## 1. One filesystem root, one permission grant
 
 When an agent runs inside the brain, cross-repo work stops being impossible and
-becomes a plain relative path. "Find every caller of this batch constant" is now
-a search over `projects/**` instead of a task that requires cloning three repos
-the agent doesn't know exist.
+becomes a plain relative path. "Find every caller of this function" is now a
+search over `projects/**` instead of a task that needs the agent to clone three
+repos it doesn't know exist.
 
-It also collapses the permissions story. Instead of granting an agent read
-access repo-by-repo, you grant it the one parent directory (`~/code/sentric`)
-and it can see the whole body. We even tell the agent's ignore file to
-_explicitly_ allow traversing the symlink:
+It also collapses the permissions story. Instead of granting an agent read access
+repo-by-repo, you grant it the one parent directory and it can see the whole body.
+You can even tell the agent's ignore file to _explicitly_ allow traversing the
+symlink while still hiding the noise:
 
 ```gitignore
-# .opencodeignore — let the agent see the code via the symlink
+# let the agent see the code via the symlink
 !projects/
 
 # ...while still ignoring the junk
@@ -147,125 +144,111 @@ node_modules/
 
 <NoteBlock title="the subtle part" color="yellow">
 The brain tracks the symlink, not the code behind it. So `git status` in the
-workspace never fills up with a diff of eleven repos — the body's changes belong
-to the body's repos. The agent sees everything; version control still sees clean
+brain never fills up with a diff of a dozen repos — the body's changes belong to
+the body's repos. The agent sees everything; version control still sees clean
 boundaries.
 </NoteBlock>
 
 ## 2. A hierarchical AGENTS.md knowledge base
 
-A single filesystem is necessary but not sufficient — an agent staring at 90,000
-files needs a map, not just access. So the brain's `AGENTS.md` is a genuine
-navigation document, and it's the _root_ of a hierarchy: it points down into each
-domain's own `AGENTS.md`.
+A single filesystem is necessary but not sufficient — an agent staring at tens of
+thousands of files needs a _map_, not just access. So the brain's `AGENTS.md`
+becomes a genuine navigation document, and it's the _root_ of a hierarchy: it
+points down into each repo's own `AGENTS.md`.
 
-The root file carries the things an agent would otherwise have to rediscover
-every session: which domains exist and roughly how big they are, a **"WHERE TO
-LOOK"** table mapping tasks to paths, and domain entry points. A representative
-slice:
+The root file carries the things an agent would otherwise rediscover every single
+session: which domains exist and roughly how big they are, a **"where to look"**
+table mapping tasks to paths, and the entry point for each domain. Something like:
 
 | Task | Location |
 | :--- | :------- |
-| Batch job patterns | `projects/rights-application/core/Sentric.Constants/Batch/` |
-| Shared UI components | `projects/sentric-frontends/packages/ui/` |
-| Table schemas | `projects/data-platform/sql/schema/` |
-| Reviewer lookup data | `projects/platform/data/people.json` |
+| Background job patterns | `projects/backend-service/jobs/` |
+| Shared UI components | `projects/web-frontend/packages/ui/` |
+| Database schemas | `projects/data-pipelines/schema/` |
+| Who-owns-what mapping | `projects/platform/data/people.json` |
 
-That table is pure leverage for an agent. It's the difference between "grep the
-whole tree and hope" and "go straight to the four files that matter."
+That table is pure leverage. It's the difference between "grep the whole tree and
+hope" and "go straight to the four files that matter."
 
 ## 3. One source of instructions, every agent
 
 Here's a mess the multi-tool era created: every coding agent looks for a
-_different_ filename. Claude Code reads `CLAUDE.md`. Gemini reads `GEMINI.md`.
-OpenCode has its own config. The naive response is to maintain the same guidance
-in four places and watch them drift apart within a week.
+_different_ filename for its instructions. One reads `AGENTS.md`. Another wants its
+own dotfile. A third has its own config format. The naive response is to maintain
+the same guidance in three or four places and watch them drift apart within a week.
 
-The virtual monorepo's brain refuses to do that. `AGENTS.md` is the one canonical
-source. The tool-specific files are three-line pointers:
+The brain refuses to do that. `AGENTS.md` is the one canonical source; the
+tool-specific files become three-line pointers back to it:
 
 ```markdown
-# CLAUDE.md
-This file provides guidance to Claude Code when working with code in this repo.
+# <TOOL>.md
+This file provides guidance to <tool> when working with code in this repo.
 
 ## Documentation
-See [AGENTS.md](./AGENTS.md) for project guidance, architecture, and
-development instructions.
+See AGENTS.md for project guidance, architecture, and development instructions.
 ```
 
-`GEMINI.md` is the same file with a different name at the top. And because those
-alias files are easy to forget or let rot, the workspace ships a CLI to keep them
-honest:
+And because those alias files are easy to forget or let rot, it's worth a tiny CLI
+that regenerates and verifies them from the canonical source:
 
 ```bash
-uv run docs agent-context check   # is this checkout wired up for every tool?
-uv run docs agent-context fix     # regenerate the aliases from AGENTS.md
+tools/agent-context check   # is this checkout wired up for every tool?
+tools/agent-context fix     # regenerate the aliases from AGENTS.md
 ```
 
-Write the instructions once; every agent, whichever filename it happens to hunt
-for, lands on the same truth.
+Write the instructions once; every agent, whichever filename it hunts for, lands
+on the same truth.
 
 ## 4. The brain gives agents _verbs_, not just files
 
 This is the part I underestimated at first. Files are nouns — an agent can read
-them. But the brain also ships a suite of Python CLIs (run through `uv`) that
-give agents _verbs_: things they can do across the whole virtual monorepo.
+them. But the brain can also ship small cross-repo CLIs that give agents _verbs_:
+things they can _do_ across the whole virtual monorepo. The two that matter map
+onto the two questions an agent actually asks:
 
-```bash
-uv run help                     # discover every workspace command
-uv run docs search "<query>"    # semantic search across all repos' docs
-uv run workspace intel ...      # structural code navigation (definitions, callers)
-uv run workspace web            # browse the whole thing interactively
-```
+- **"Where is this documented?"** → a docs-search command backed by an index
+  across every repo's documentation. Instead of an agent widening `grep` queries
+  against `docs/**` until it gives up, it gets ranked results in one shot.
+- **"How does this code fit together?"** → a **code-intelligence** command. If you
+  index your repos into a graph and expose it (an MCP server is the natural fit),
+  an agent can ask for _structural_ answers — every caller of a function, the
+  dependency edges between modules, the blast radius of a change — across repos,
+  without pulling a single file into its context window.
 
-Two of those are worth dwelling on, because they map onto the two questions an
-agent actually asks:
-
-- **"Where is this documented?"** → `docs search`. Instead of an agent widening
-  grep queries against `docs/**` until it gives up, it hits a real index across
-  every repo's documentation. The AGENTS.md even codifies the handoff: use docs
-  search for runbooks and terminology _first_.
-- **"How does this code fit together?"** → **code intelligence**. We run a
-  Codebase Memory graph as an MCP server, so an agent can call `search_nodes`,
-  `query_graph`, or `trace_call_path` and get _structural_ answers — every caller
-  of a function, the dependency edges between modules, the blast radius of a
-  change — across repos, without reading a single file into its context window.
-
-That second one is the payoff a plain symlink could never give you. Cross-repo
-impact analysis is precisely the thing an agent-in-one-repo _cannot_ do, and the
-virtual monorepo plus a graph index makes it a single tool call.
+That second one is the payoff a plain symlink could never give you on its own.
+Cross-repo impact analysis is precisely the thing an agent-in-one-repo _cannot_
+do, and a virtual monorepo plus a graph index turns it into a single tool call.
 
 <NoteBlock title="nouns vs verbs" color="primary">
-A folder of files tells an agent what exists. A folder of files _plus a CLI_
-tells it what it can do. The brain is deliberately the second thing — the code
-lives in the body; the capabilities live in the brain.
+A folder of files tells an agent what exists. A folder of files _plus a CLI_ tells
+it what it can do. The brain is deliberately the second thing — the code lives in
+the body; the capabilities live in the brain.
 </NoteBlock>
 
 ## 5. Guardrails written down once, enforced everywhere
 
-Every "please don't do that" an agent needs to hear lives in the brain, so it's
-in scope no matter which repo the work touches. A few real ones:
+Every "please don't do that" an agent needs to hear lives in the brain, so it's in
+scope no matter which repo the work touches:
 
 - **Run lint and type-check before every push** — CI will reject failures and it
-  blocks other engineers.
-- **Never merge a PR with failing checks**, even when GitHub lets you.
-- **Always use the self-hosted Pulumi S3 backend, never Pulumi Cloud** — and if
-  you hit an Access Denied on the state bucket, _stop_; that's intentional, not a
-  puzzle to route around.
-- **Don't run `gh aw compile` headless** — it silently hangs in a sandbox with no
-  TTY; use the workspace's compile-script wrapper instead.
+  blocks everyone else.
+- **Never merge a PR with failing checks**, even when the platform lets you.
+- **If a deploy or a state operation returns "access denied", _stop_** — that's a
+  permission boundary doing its job, not a puzzle to route around.
+- The one non-obvious command gotcha that has bitten every new engineer, written
+  down so the agent learns it the same way a new hire would.
 
-That last one is the kind of hard-won, non-obvious knowledge that used to live
-only in a senior engineer's memory. Now it's a line in `AGENTS.md`, so the agent
-learns it the same way a new hire would — except it never forgets.
+That last category is the interesting one: hard-won, non-obvious knowledge that
+used to live only in a senior engineer's memory. Now it's a line in `AGENTS.md`,
+and the agent never forgets it.
 
-## 6. Shared agent definitions ride along too
+## 6. Shared agent assets ride along too
 
-Because the body is just more repos under the same symlink, shared _agent_
-assets travel the same road. We keep a `playbook` repo — migration agents, reusable
-skills, coding conventions, a domain glossary — and it shows up at
-`projects/playbook/` like everything else. Define a migration skill once; every
-agent working anywhere in the virtual monorepo can reach it.
+Because the body is just more repos under the same symlink, shared _agent_ assets
+travel the same road. Keep a "playbook" repo — reusable skills, migration recipes,
+coding conventions, a domain glossary — and it shows up alongside everything else.
+Define a skill once; every agent working anywhere in the virtual monorepo can
+reach it.
 
 # The honest tradeoffs
 
@@ -277,33 +260,33 @@ I don't want to sell this as free. It isn't.
 - **Symlinks are a cross-platform tax.** `ln -s` on Unix, junctions on Windows,
   and a bootstrap script to paper over the difference. It mostly just works, but
   "mostly" is carrying weight.
-- **The brain can drift from the body.** A "WHERE TO LOOK" path rots when a repo
-  reorganizes. The fix is discipline plus doc-lint tooling, but drift is a real
-  failure mode — a confidently wrong map is worse than no map.
+- **The brain can drift from the body.** A "where to look" path rots when a repo
+  reorganises. The fix is discipline plus doc-lint tooling — but a confidently
+  wrong map is worse than no map.
 - **"Where's the source of truth?" needs a firm answer.** The whole thing falls
-  apart the moment someone copies guidance into a `CLAUDE.md` instead of pointing
-  at `AGENTS.md`. The convention has to be enforced, not just hoped for.
+  apart the moment someone pastes guidance into a tool-specific dotfile instead of
+  pointing at `AGENTS.md`. The convention has to be enforced, not just hoped for.
 
-None of these outweigh the payoff for us, but they're the questions to ask before
-copying the pattern.
+None of these outweigh the payoff for me, but they're the questions to ask before
+adopting the pattern.
 
 # The takeaway
 
 I went into this thinking a virtual monorepo was a convenience for _me_ — one
-folder instead of eleven. What I actually built was a **world model for
-agents**: a single filesystem they can traverse, a map that tells them where to
-look, one set of instructions every tool reads, a CLI of verbs they can call, and
-guardrails they can't forget.
+folder instead of a dozen. What I actually built was a **world model for agents**:
+a single filesystem they can traverse, a map that tells them where to look, one
+set of instructions every tool reads, a CLI of verbs they can call, and guardrails
+they can't forget.
 
-The reframe I'd offer anyone drowning in polyrepo sprawl and trying to get
-serious about coding agents: you probably can't afford a real monorepo, and you
-may not want one. But you can almost certainly afford a symlink and a config repo.
+The reframe I'd offer anyone drowning in polyrepo sprawl and trying to get serious
+about coding agents: you probably can't afford a real monorepo, and you may not
+even want one. But you can almost certainly afford a symlink and a config repo.
 Give your agents one world to reason about, and they start reasoning about it
 remarkably well.
 
 ---
 
-_The workspace tooling described here is internal, but the pattern is
-repository-shaped and portable: a config-only "brain" repo, one symlink to a
-parent folder of your real repos, a canonical `AGENTS.md`, and a small CLI that
-gives agents search and code-intelligence over the whole tree._
+_The pattern is deliberately repository-shaped and portable: a config-only "brain"
+repo, one symlink to a parent folder of your real repos, a canonical `AGENTS.md`,
+and a small CLI that gives agents search and code-intelligence over the whole
+tree. No product code moves; nothing about your existing repos has to change._

--- a/data/blog/virtual-monorepo-coding-agents.mdx
+++ b/data/blog/virtual-monorepo-coding-agents.mdx
@@ -170,6 +170,35 @@ table mapping tasks to paths, and the entry point for each domain. Something lik
 That table is pure leverage. It's the difference between "grep the whole tree and
 hope" and "go straight to the four files that matter."
 
+### Progressive disclosure: the root file is a router, not an encyclopaedia
+
+The temptation is to cram everything into that root `AGENTS.md` — every repo's
+build commands, conventions, and gotchas in one giant file. Don't. It would blow
+the agent's context window on the way in, most of it irrelevant to the task at
+hand, and it would rot the moment any repo changed.
+
+The pattern that actually works is **progressive disclosure**. The root file
+stays deliberately thin: enough to orient — what exists, how big, and _where to
+go next_ — and then it does one job well, which is to **steer the agent to the
+`AGENTS.md` of the appropriate repo.** The agent reads the map, decides it's a
+job about the data pipelines, and only _then_ opens `projects/data-pipelines/AGENTS.md`
+for the detail. That repo's file can disclose further still — pointing at a
+subdirectory's `AGENTS.md`, a runbook, a schema doc — so context arrives in
+layers, just-in-time, only for the slice of the world the task actually touches.
+
+<NoteBlock title="why layered beats flat" color="primary">
+Three wins fall out of it: the agent's context stays lean and on-topic; each
+repo _owns_ its own guidance, so nothing drifts out of sync with a copy in the
+brain; and the instructions the agent ends up reading are always the version that
+lives right next to the code it's about to change.
+</NoteBlock>
+
+This post is itself a small example of the idea. It won't teach you the specifics
+of any one repo — that's not its job. For the concrete conventions, commands, and
+entry points, the move is the same one an agent makes: **start at the root
+`AGENTS.md`, and let it steer you to the `AGENTS.md` of the repo you actually care
+about.**
+
 ## 3. One source of instructions, every agent
 
 Here's a mess the multi-tool era created: every coding agent looks for a

--- a/data/blog/virtual-monorepo-coding-agents.mdx
+++ b/data/blog/virtual-monorepo-coding-agents.mdx
@@ -1,0 +1,309 @@
+---
+title: "The Virtual Monorepo: Giving Coding Agents One World to Reason About"
+date: "2026-07-04"
+tags:
+  [
+    "ai",
+    "coding-agents",
+    "monorepo",
+    "developer-tools",
+    "architecture",
+    "workflow",
+    "python",
+    "opencode",
+  ]
+draft: true
+summary: "Eleven repositories, five languages, 90k+ files — and a coding agent that only sees one folder at a time. This is how a 'virtual monorepo' (a config-only brain, symlinked to independent repos) gives agents a single, coherent world to navigate, and why that turns out to matter more for the agents than for the humans."
+images: []
+layout: PostLayout
+authors: ["default"]
+---
+
+# The problem nobody warns you about
+
+At work we have eleven repositories. A .NET rights-application with 45,000 files
+and 448k lines of code. A React monorepo. A pile of Python ETL pipelines with
+2.75 _million_ lines between them. A data platform, a CMS, a public artist site,
+E2E test suites, bootstrap scripts. Five languages, independent git histories,
+independent deploys. Ninety-thousand-plus files if you add it all up.
+
+None of that is unusual. Plenty of companies live in a polyrepo world and are
+perfectly happy. What _changed_ is that I now spend a large chunk of my day
+handing work to coding agents — OpenCode, Claude Code, Gemini — and a coding
+agent has one brutal limitation that a human developer mostly doesn't:
+
+**its working directory is its entire universe.**
+
+A human engineer holds the shape of the whole company in their head. They know
+that authentication lives in the rights-app, that reporting queries hit the data
+platform, that the people-to-GitHub mapping is a JSON file in the platform repo.
+They `cd` between clones without thinking. An agent, dropped into one repo, sees
+one repo. Ask it "who calls this function across our services" and it can't —
+the other services aren't on its filesystem. Ask it "follow our git conventions"
+and it will follow whatever it can find in _this_ repo, which may be nothing.
+
+The obvious fix is "put everything in a monorepo." But merging eleven repos with
+independent histories, CI, and deploy cadences is a multi-quarter migration
+nobody has budget for, and it throws away the independence that makes the repos
+easy to reason about in the first place.
+
+So we did something cheaper and, it turns out, better suited to agents: a
+**virtual monorepo**.
+
+# Brain and body
+
+The idea is a split between a **brain** and a **body**.
+
+The **body** is all the real product repositories, cloned side by side under one
+parent directory (`~/code/sentric/`). They stay exactly what they are — separate
+git repos, separate CI, separate deploys. Nothing about them changes.
+
+The **brain** is a single small repo — we call it `workspace` — that tracks
+*no product source code at all*. It holds configuration, documentation, shared
+CLIs, environment setup, and the agent instructions. Then it exposes the entire
+body through **one symlink**:
+
+```
+~/code/
+├── sentric/                       # BODY — independent git repos
+│   ├── rights-application/
+│   ├── data-platform/
+│   ├── sentric-frontends/
+│   ├── publishing-dashboard/
+│   └── ... 7 more
+│
+└── workspace/                     # BRAIN — config + docs + tooling only
+    ├── AGENTS.md                  # canonical agent instructions
+    ├── docs/                      # runbooks, conventions, process
+    ├── src/                       # workspace CLIs (Python / uv)
+    └── projects  ->  ../sentric   # the whole body, one symlink
+```
+
+That `projects -> ../sentric` symlink is the whole trick. From inside the brain,
+`projects/rights-application/`, `projects/data-platform/`, and every other repo
+are _right there_ on the filesystem. One `ln -s` on macOS and Linux, a junction
+point on Windows.
+
+<Diagram type="mermaid" caption="Brain/Body: one symlink turns eleven repos into one navigable tree">
+{`graph TD
+    A[workspace<br/>THE BRAIN<br/>config · docs · CLIs]
+    P[projects/ symlink]
+    B1[rights-application]
+    B2[data-platform]
+    B3[sentric-frontends]
+    B4[...7 more repos]
+    A --> P
+    P --> B1
+    P --> B2
+    P --> B3
+    P --> B4
+    style A fill:#000,stroke:#22d3ee,stroke-width:3px,stroke-dasharray:8 4,color:#22d3ee,rx:0,ry:0
+    style P fill:#000,stroke:#facc15,stroke-width:3px,color:#facc15,rx:0,ry:0
+    style B1 fill:#000,stroke:#ec4899,stroke-width:3px,color:#ec4899,rx:0,ry:0
+    style B2 fill:#000,stroke:#ec4899,stroke-width:3px,color:#ec4899,rx:0,ry:0
+    style B3 fill:#000,stroke:#ec4899,stroke-width:3px,color:#ec4899,rx:0,ry:0
+    style B4 fill:#000,stroke:#ec4899,stroke-width:3px,color:#ec4899,rx:0,ry:0
+    linkStyle default stroke:#fff,stroke-width:2px`}
+</Diagram>
+
+The name I keep coming back to is **"one world to reason about."** A real
+monorepo gives you atomic cross-repo commits, which is genuinely something we
+give up here. But most of what makes a monorepo pleasant day to day isn't atomic
+commits — it's that _everything is in one tree you can see at once_. The virtual
+monorepo buys you exactly that property, for the price of a symlink, without
+touching a single product repo's history.
+
+# Why this is really a coding-agent story
+
+I want to be honest about the framing. A virtual monorepo is _nice_ for humans —
+it's convenient to have one folder. But humans already had a workaround: they
+kept the mental model in their heads. The reason we actually built the tooling
+around this, the reason it earned real investment, is that **agents don't have
+heads.** Everything a human "just knows" has to become a file, a symlink, or a
+command. The virtual monorepo is the substrate that makes that possible. Here's
+what we hang off it.
+
+## 1. One filesystem root, one permission grant
+
+When an agent runs inside the brain, cross-repo work stops being impossible and
+becomes a plain relative path. "Find every caller of this batch constant" is now
+a search over `projects/**` instead of a task that requires cloning three repos
+the agent doesn't know exist.
+
+It also collapses the permissions story. Instead of granting an agent read
+access repo-by-repo, you grant it the one parent directory (`~/code/sentric`)
+and it can see the whole body. We even tell the agent's ignore file to
+_explicitly_ allow traversing the symlink:
+
+```gitignore
+# .opencodeignore — let the agent see the code via the symlink
+!projects/
+
+# ...while still ignoring the junk
+.venv/
+node_modules/
+**/__pycache__/
+```
+
+<NoteBlock title="the subtle part" color="yellow">
+The brain tracks the symlink, not the code behind it. So `git status` in the
+workspace never fills up with a diff of eleven repos — the body's changes belong
+to the body's repos. The agent sees everything; version control still sees clean
+boundaries.
+</NoteBlock>
+
+## 2. A hierarchical AGENTS.md knowledge base
+
+A single filesystem is necessary but not sufficient — an agent staring at 90,000
+files needs a map, not just access. So the brain's `AGENTS.md` is a genuine
+navigation document, and it's the _root_ of a hierarchy: it points down into each
+domain's own `AGENTS.md`.
+
+The root file carries the things an agent would otherwise have to rediscover
+every session: which domains exist and roughly how big they are, a **"WHERE TO
+LOOK"** table mapping tasks to paths, and domain entry points. A representative
+slice:
+
+| Task | Location |
+| :--- | :------- |
+| Batch job patterns | `projects/rights-application/core/Sentric.Constants/Batch/` |
+| Shared UI components | `projects/sentric-frontends/packages/ui/` |
+| Table schemas | `projects/data-platform/sql/schema/` |
+| Reviewer lookup data | `projects/platform/data/people.json` |
+
+That table is pure leverage for an agent. It's the difference between "grep the
+whole tree and hope" and "go straight to the four files that matter."
+
+## 3. One source of instructions, every agent
+
+Here's a mess the multi-tool era created: every coding agent looks for a
+_different_ filename. Claude Code reads `CLAUDE.md`. Gemini reads `GEMINI.md`.
+OpenCode has its own config. The naive response is to maintain the same guidance
+in four places and watch them drift apart within a week.
+
+The virtual monorepo's brain refuses to do that. `AGENTS.md` is the one canonical
+source. The tool-specific files are three-line pointers:
+
+```markdown
+# CLAUDE.md
+This file provides guidance to Claude Code when working with code in this repo.
+
+## Documentation
+See [AGENTS.md](./AGENTS.md) for project guidance, architecture, and
+development instructions.
+```
+
+`GEMINI.md` is the same file with a different name at the top. And because those
+alias files are easy to forget or let rot, the workspace ships a CLI to keep them
+honest:
+
+```bash
+uv run docs agent-context check   # is this checkout wired up for every tool?
+uv run docs agent-context fix     # regenerate the aliases from AGENTS.md
+```
+
+Write the instructions once; every agent, whichever filename it happens to hunt
+for, lands on the same truth.
+
+## 4. The brain gives agents _verbs_, not just files
+
+This is the part I underestimated at first. Files are nouns — an agent can read
+them. But the brain also ships a suite of Python CLIs (run through `uv`) that
+give agents _verbs_: things they can do across the whole virtual monorepo.
+
+```bash
+uv run help                     # discover every workspace command
+uv run docs search "<query>"    # semantic search across all repos' docs
+uv run workspace intel ...      # structural code navigation (definitions, callers)
+uv run workspace web            # browse the whole thing interactively
+```
+
+Two of those are worth dwelling on, because they map onto the two questions an
+agent actually asks:
+
+- **"Where is this documented?"** → `docs search`. Instead of an agent widening
+  grep queries against `docs/**` until it gives up, it hits a real index across
+  every repo's documentation. The AGENTS.md even codifies the handoff: use docs
+  search for runbooks and terminology _first_.
+- **"How does this code fit together?"** → **code intelligence**. We run a
+  Codebase Memory graph as an MCP server, so an agent can call `search_nodes`,
+  `query_graph`, or `trace_call_path` and get _structural_ answers — every caller
+  of a function, the dependency edges between modules, the blast radius of a
+  change — across repos, without reading a single file into its context window.
+
+That second one is the payoff a plain symlink could never give you. Cross-repo
+impact analysis is precisely the thing an agent-in-one-repo _cannot_ do, and the
+virtual monorepo plus a graph index makes it a single tool call.
+
+<NoteBlock title="nouns vs verbs" color="primary">
+A folder of files tells an agent what exists. A folder of files _plus a CLI_
+tells it what it can do. The brain is deliberately the second thing — the code
+lives in the body; the capabilities live in the brain.
+</NoteBlock>
+
+## 5. Guardrails written down once, enforced everywhere
+
+Every "please don't do that" an agent needs to hear lives in the brain, so it's
+in scope no matter which repo the work touches. A few real ones:
+
+- **Run lint and type-check before every push** — CI will reject failures and it
+  blocks other engineers.
+- **Never merge a PR with failing checks**, even when GitHub lets you.
+- **Always use the self-hosted Pulumi S3 backend, never Pulumi Cloud** — and if
+  you hit an Access Denied on the state bucket, _stop_; that's intentional, not a
+  puzzle to route around.
+- **Don't run `gh aw compile` headless** — it silently hangs in a sandbox with no
+  TTY; use the workspace's compile-script wrapper instead.
+
+That last one is the kind of hard-won, non-obvious knowledge that used to live
+only in a senior engineer's memory. Now it's a line in `AGENTS.md`, so the agent
+learns it the same way a new hire would — except it never forgets.
+
+## 6. Shared agent definitions ride along too
+
+Because the body is just more repos under the same symlink, shared _agent_
+assets travel the same road. We keep a `playbook` repo — migration agents, reusable
+skills, coding conventions, a domain glossary — and it shows up at
+`projects/playbook/` like everything else. Define a migration skill once; every
+agent working anywhere in the virtual monorepo can reach it.
+
+# The honest tradeoffs
+
+I don't want to sell this as free. It isn't.
+
+- **No atomic cross-repo commits.** This is the real cost. A change spanning the
+  API and the frontend is still two PRs in two repos. The virtual monorepo makes
+  them _visible together_; it doesn't make them _commit together_.
+- **Symlinks are a cross-platform tax.** `ln -s` on Unix, junctions on Windows,
+  and a bootstrap script to paper over the difference. It mostly just works, but
+  "mostly" is carrying weight.
+- **The brain can drift from the body.** A "WHERE TO LOOK" path rots when a repo
+  reorganizes. The fix is discipline plus doc-lint tooling, but drift is a real
+  failure mode — a confidently wrong map is worse than no map.
+- **"Where's the source of truth?" needs a firm answer.** The whole thing falls
+  apart the moment someone copies guidance into a `CLAUDE.md` instead of pointing
+  at `AGENTS.md`. The convention has to be enforced, not just hoped for.
+
+None of these outweigh the payoff for us, but they're the questions to ask before
+copying the pattern.
+
+# The takeaway
+
+I went into this thinking a virtual monorepo was a convenience for _me_ — one
+folder instead of eleven. What I actually built was a **world model for
+agents**: a single filesystem they can traverse, a map that tells them where to
+look, one set of instructions every tool reads, a CLI of verbs they can call, and
+guardrails they can't forget.
+
+The reframe I'd offer anyone drowning in polyrepo sprawl and trying to get
+serious about coding agents: you probably can't afford a real monorepo, and you
+may not want one. But you can almost certainly afford a symlink and a config repo.
+Give your agents one world to reason about, and they start reasoning about it
+remarkably well.
+
+---
+
+_The workspace tooling described here is internal, but the pattern is
+repository-shaped and portable: a config-only "brain" repo, one symlink to a
+parent folder of your real repos, a canonical `AGENTS.md`, and a small CLI that
+gives agents search and code-intelligence over the whole tree._

--- a/layouts/PostBanner.tsx
+++ b/layouts/PostBanner.tsx
@@ -33,9 +33,10 @@ export default function PostBanner({
 }: Props) {
   const { slug, date, title, images } = frontMatter;
 
-  // Use first image from frontmatter, or fallback to placeholder
+  // Use first image from frontmatter, or fall back to the post's deterministic
+  // build-generated OG card (scripts/generate-og-images.mjs).
   const displayImage =
-    images && images.length > 0 ? images[0] : '/static/images/twitter-card.png';
+    images && images.length > 0 ? images[0] : `/static/og/${slug}.png`;
 
   return (
     <>

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -10,6 +10,7 @@ import Comments from '@/components/comments';
 import Link from '@/components/Link';
 import NewsletterForm from '@/components/NewsletterForm';
 import PageTitle from '@/components/PageTitle';
+import PostHeaderImage from '@/components/PostHeaderImage';
 import References, { ReferencesContext } from '@/components/References';
 import { BlogSEO } from '@/components/SEO';
 import SectionContainer from '@/components/SectionContainer';
@@ -68,7 +69,8 @@ export default function PostLayout({
   hasManualReferences,
   seriesData,
 }: Props) {
-  const { slug, fileName, date, title, tags } = frontMatter;
+  const { slug, fileName, date, title, tags, images } = frontMatter;
+  const hasExplicitImage = Array.isArray(images) && images.length > 0;
   const [activeId, setActiveId] = useState<string | undefined>(undefined);
 
   useEffect(() => {
@@ -114,6 +116,18 @@ export default function PostLayout({
         {...frontMatter}
       />
       <article>
+        {!hasExplicitImage && (
+          <div className="pt-6">
+            <PostHeaderImage
+              title={title}
+              slug={slug}
+              tags={tags}
+              date={date}
+              variant="banner"
+              className="w-full border-2 border-brutalist-cyan shadow-hard-cyan [&>svg]:block [&>svg]:h-auto [&>svg]:w-full"
+            />
+          </div>
+        )}
         <div className="xl:divide-y xl:divide-zinc-800">
           <header className="pt-6 xl:pb-6">
             <div className="space-y-1 text-center">

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -22,6 +22,9 @@ lib/
 ├── remark-toc-headings.ts  # TOC extraction plugin
 ├── remark-references.ts    # Bibliography collection + [n] citation markers
 ├── remark-img-to-jsx.ts    # Image → JSX plugin
+├── og/                 # Deterministic header / OG-card image engine
+│   ├── headerImage.mjs # Source of truth: buildHeaderSvg() → SVG string
+│   └── headerImage.ts  # Thin typed re-export for .tsx imports
 └── utils/              # Small helpers
     ├── files.ts        # getAllFilesRecursively
     ├── kebabCase.ts    # Slug generation
@@ -29,6 +32,26 @@ lib/
     ├── htmlEscaper.ts  # RSS escaping
     └── showDrafts.ts   # Draft visibility check
 ```
+
+## HEADER / OG IMAGE ENGINE
+
+`og/headerImage.mjs` deterministically builds a brutalist SVG banner from post
+front matter (`title`, `slug`, `tags`, `date`). Output is a pure function of the
+seed (`slug`), so the same post always renders the same image. One engine backs
+two consumers, guaranteeing they match:
+
+- **On-page hero** — `components/PostHeaderImage.tsx` renders the SVG inline
+  (`variant="banner"`, 2:1). `PostLayout` shows it when a post has no explicit
+  `images`.
+- **Social/OG card** — `scripts/generate-og-images.mjs` rasterises the `og`
+  preset (1200×630) to `public/static/og/<slug>.png` at build time (part of
+  `pnpm build`; also `pnpm og:images`). `components/SEO.tsx` and `PostBanner`
+  fall back to `/static/og/<slug>.png` when front matter has no image.
+
+The `.mjs` + `.ts` split mirrors `utils/showDrafts.*`: the `.mjs` is the single
+implementation (importable by the Node build script), the `.ts` is a typed
+re-export for the React component. Wrapping uses a font-independent metric so
+inline and rasterised layouts are identical regardless of webfont load state.
 
 > **(#19) Hooks are a new `lib/` category.** `lib/` was originally scoped to the
 > MDX pipeline + utilities; it now also holds React hooks (`usePresence`,

--- a/lib/og/headerImage.mjs
+++ b/lib/og/headerImage.mjs
@@ -36,7 +36,8 @@ const THEMES = [
   { grid: '#00ffff', sun: '#ff8c00', shadow: '#00ffff', tag: '#ff8c00' }, // neon cyan / orange
 ];
 
-const DISPLAY_FONT = "'Space Grotesk', 'Arial Black', 'Helvetica Neue', sans-serif";
+const DISPLAY_FONT =
+  "'Space Grotesk', 'Arial Black', 'Helvetica Neue', sans-serif";
 const MONO_FONT = "'IBM Plex Mono', 'SFMono-Regular', 'Courier New', monospace";
 
 /** Named size presets. `banner` is a 2:1 hero; `og` is the 1.91:1 social card. */

--- a/lib/og/headerImage.mjs
+++ b/lib/og/headerImage.mjs
@@ -1,0 +1,313 @@
+/**
+ * Deterministic header / social-card image engine.
+ *
+ * Given a post's front matter it produces a self-contained SVG string. The
+ * output is a pure function of the inputs: the same `seed` (slug) always yields
+ * the same palette, decorative field, and layout. That determinism is the whole
+ * point — every post gets a distinct-but-stable brutalist banner with zero
+ * hand-authored assets, and the exact same engine backs both:
+ *
+ *   1. the on-page hero (rendered inline as SVG by `components/PostHeaderImage`)
+ *   2. the social/OG card (rasterised to PNG at build time by
+ *      `scripts/generate-og-images.mjs`, wired into SEO meta tags)
+ *
+ * The implementation is framework-agnostic ESM JS so it can be imported by both
+ * a `.tsx` component and a `.mjs` build script (see the `headerImage.ts`
+ * re-export, mirroring the `showDrafts.mjs` / `showDrafts.ts` pair).
+ */
+
+// --- Design tokens (mirror tailwind.config.js brutalist palette) -------------
+
+const BG = '#0a0a1a'; // brutalist.darkBg — same as the CyberHero background
+const FG = '#ffffff';
+
+/**
+ * Themes mirror the CyberHero's synthwave language: a `grid` colour for the
+ * perspective floor + flat lattice, and a `sun` colour for the horizon ring and
+ * circuits. `shadow` is the title's hard-shadow accent, `tag` the chip colour.
+ * One theme is chosen deterministically per post from the seed.
+ */
+const THEMES = [
+  { grid: '#39ff14', sun: '#ff8c00', shadow: '#ff8c00', tag: '#39ff14' }, // classic synthwave (neon green / cyber orange)
+  { grid: '#22d3ee', sun: '#ec4899', shadow: '#ec4899', tag: '#22d3ee' }, // cyan / pink
+  { grid: '#ff8c00', sun: '#39ff14', shadow: '#39ff14', tag: '#ff8c00' }, // orange / green
+  { grid: '#d9a9ff', sun: '#00ffff', shadow: '#d9a9ff', tag: '#00ffff' }, // purple / cyan
+  { grid: '#facc15', sun: '#ec4899', shadow: '#facc15', tag: '#ec4899' }, // yellow / pink
+  { grid: '#00ffff', sun: '#ff8c00', shadow: '#00ffff', tag: '#ff8c00' }, // neon cyan / orange
+];
+
+const DISPLAY_FONT = "'Space Grotesk', 'Arial Black', 'Helvetica Neue', sans-serif";
+const MONO_FONT = "'IBM Plex Mono', 'SFMono-Regular', 'Courier New', monospace";
+
+/** Named size presets. `banner` is a 2:1 hero; `og` is the 1.91:1 social card. */
+export const HEADER_PRESETS = {
+  banner: { width: 1200, height: 600 },
+  og: { width: 1200, height: 630 },
+};
+
+// --- Deterministic primitives ------------------------------------------------
+
+/** FNV-1a 32-bit hash → stable unsigned int seed. */
+function fnv1a(str) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/** Escape the five XML-significant characters for safe inclusion in SVG text. */
+function esc(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Greedy word-wrap using a font-independent metric so layout is identical
+ * whether or not the webfont has loaded (the rasteriser and the browser agree).
+ * Shrinks the font size stepwise until the text fits `maxLines`, then truncates.
+ */
+function wrapTitle(title, maxWidth, startSize, minSize, maxLines) {
+  const words = String(title).trim().split(/\s+/);
+  const CHAR_W = 0.58; // avg glyph width as a fraction of font size (bold display)
+
+  for (let size = startSize; size >= minSize; size -= 4) {
+    const maxChars = Math.max(6, Math.floor(maxWidth / (size * CHAR_W)));
+    const lines = [];
+    let line = '';
+    for (const word of words) {
+      const candidate = line ? `${line} ${word}` : word;
+      if (candidate.length <= maxChars) {
+        line = candidate;
+      } else {
+        if (line) lines.push(line);
+        line = word;
+      }
+    }
+    if (line) lines.push(line);
+    if (lines.length <= maxLines) return { lines, size };
+  }
+
+  // Did not fit even at minSize — hard-wrap and ellipsise the overflow.
+  const maxChars = Math.max(6, Math.floor(maxWidth / (minSize * CHAR_W)));
+  const lines = [];
+  let line = '';
+  for (const word of words) {
+    const candidate = line ? `${line} ${word}` : word;
+    if (candidate.length <= maxChars) {
+      line = candidate;
+    } else {
+      if (line) lines.push(line);
+      line = word;
+    }
+    if (lines.length === maxLines) break;
+  }
+  if (line && lines.length < maxLines) lines.push(line);
+  if (lines.length === maxLines) {
+    const last = lines[maxLines - 1];
+    lines[maxLines - 1] = `${last.slice(0, Math.max(0, maxChars - 1))}…`;
+  }
+  return { lines, size: minSize };
+}
+
+/** Synthwave perspective floor grid receding to a central vanishing point. */
+function perspectiveGrid(width, height, horizon, color) {
+  const vpX = width / 2;
+  const parts = [];
+  // Receding horizontals: bunch near the horizon (quadratic easing), thicker
+  // and more opaque toward the viewer.
+  const rows = 15;
+  for (let i = 1; i <= rows; i++) {
+    const t = i / rows;
+    const y = horizon + (height - horizon) * (t * t);
+    const op = (0.14 + 0.42 * t).toFixed(3);
+    parts.push(
+      `<line x1="0" y1="${y.toFixed(1)}" x2="${width}" y2="${y.toFixed(1)}" stroke="${color}" stroke-width="${(1 + t).toFixed(2)}" opacity="${op}"/>`,
+    );
+  }
+  // Converging verticals: fan from beyond both edges of the base to the VP.
+  const cols = 18;
+  for (let i = 0; i <= cols; i++) {
+    const x0 = (i / cols) * (width * 2) - width * 0.5;
+    parts.push(
+      `<line x1="${x0.toFixed(1)}" y1="${height}" x2="${vpX}" y2="${horizon}" stroke="${color}" stroke-width="1.3" opacity="0.28"/>`,
+    );
+  }
+  return parts.join('');
+}
+
+/** Horizon "sun": soft glow + ring + venetian slats, like the CyberHero circle. */
+function sun(cx, cy, r, color) {
+  const parts = [
+    `<circle cx="${cx}" cy="${cy}" r="${r}" fill="${color}" opacity="0.14" filter="url(#glow)"/>`,
+    `<circle cx="${cx}" cy="${cy}" r="${r}" fill="none" stroke="${color}" stroke-width="4" opacity="0.75"/>`,
+  ];
+  // Venetian slats across the lower half — increasingly tall toward the base.
+  for (let i = 1; i <= 6; i++) {
+    const y = Math.round(cy + (r * i) / 7);
+    const h = 3 + i * 1.5;
+    parts.push(
+      `<rect x="${cx - r}" y="${y}" width="${2 * r}" height="${h.toFixed(1)}" fill="${BG}" opacity="0.9"/>`,
+    );
+  }
+  return parts.join('');
+}
+
+/** A couple of angular circuit traces reaching toward the sun (CyberHero echo). */
+function circuits(width, height, cx, cy, color) {
+  const y1 = Math.round(cy - height * 0.06);
+  const y2 = Math.round(cy + height * 0.05);
+  return (
+    `<path d="M${width} ${y1} L${cx + 150} ${y1} L${cx + 110} ${y1 - 34} L${cx + 40} ${y1 - 34}" fill="none" stroke="${color}" stroke-width="2" opacity="0.3"/>` +
+    `<path d="M${width} ${y2} L${cx + 130} ${y2} L${cx + 96} ${y2 + 30} L${cx + 30} ${y2 + 30}" fill="none" stroke="${color}" stroke-width="2" opacity="0.3"/>`
+  );
+}
+
+// --- Engine ------------------------------------------------------------------
+
+/**
+ * @typedef {Object} HeaderImageOptions
+ * @property {string} title        Post title (required).
+ * @property {string} [seed]       Determinism seed; defaults to slug || title.
+ * @property {string} [slug]       Post slug (used as seed and default eyebrow).
+ * @property {string[]} [tags]     Tags rendered as chips (first 4 used).
+ * @property {string} [date]       ISO date shown in the eyebrow.
+ * @property {string} [siteName]   Footer brand line.
+ * @property {number} [width]      Canvas width (default 1200).
+ * @property {number} [height]     Canvas height (default 630).
+ */
+
+/**
+ * Produce a deterministic brutalist header SVG for a post.
+ * @param {HeaderImageOptions} options
+ * @returns {string} A complete, standalone `<svg>…</svg>` string.
+ */
+export function buildHeaderSvg(options) {
+  const {
+    title,
+    slug,
+    tags = [],
+    date,
+    siteName = 'ryankelly.dev',
+    width = 1200,
+    height = 630,
+  } = options;
+
+  const seed = fnv1a(options.seed || slug || title || 'post');
+  const theme = THEMES[seed % THEMES.length];
+
+  // Geometry, all derived from the canvas so any size stays balanced.
+  const inset = Math.round(width * 0.018);
+  const pad = Math.round(width * 0.05);
+  const innerX = inset + pad;
+  const innerW = width - 2 * inset - 2 * pad;
+
+  // Synthwave horizon + sun (mirrors the CyberHero grid/circle).
+  const horizon = Math.round(height * 0.64);
+  const sunCx = Math.round(width / 2);
+  const sunR = Math.round(height * 0.26);
+
+  const eyebrowSize = Math.round(width * 0.02);
+  const tagSize = Math.round(width * 0.019);
+  const footerSize = Math.round(width * 0.021);
+
+  // Eyebrow: `> YYYY-MM-DD` or the slug, in accent mono.
+  const eyebrowText = date
+    ? new Date(date).toISOString().slice(0, 10)
+    : String(slug || '').replace(/[-/]/g, ' ');
+  const eyebrowY = inset + pad + eyebrowSize;
+
+  // The title lives in the band above the horizon; tags sit on the horizon,
+  // footer at the very bottom over the receding grid.
+  const tagsText = tags
+    .slice(0, 4)
+    .map((t) => `[ ${esc(t)} ]`)
+    .join('  ');
+  const footerY = height - inset - Math.round(pad * 0.5);
+  const tagsY = horizon - Math.round(tagSize * 0.9);
+  const titleBottom = tagsY - Math.round(tagSize * 1.9);
+  const titleTop = eyebrowY + Math.round(height * 0.03);
+
+  // Title: wrap to fit width (≤3 lines), then shrink to fit the band height so
+  // it never crosses into the tags/horizon.
+  const wrapped = wrapTitle(
+    title || 'Untitled',
+    innerW,
+    Math.round(width * 0.072),
+    Math.round(width * 0.042),
+    3,
+  );
+  const availH = titleBottom - titleTop;
+  const titleSize = Math.max(
+    Math.round(width * 0.042),
+    Math.min(wrapped.size, Math.floor(availH / (wrapped.lines.length * 1.16))),
+  );
+  const lines = wrapped.lines;
+  const lineHeight = Math.round(titleSize * 1.12);
+  const shadowOffset = Math.max(3, Math.round(titleSize * 0.05));
+  const blockH = lines.length * lineHeight;
+  const firstBaseline =
+    titleTop + Math.round((availH - blockH) / 2) + Math.round(titleSize * 0.82);
+
+  // Title lines drawn twice: an offset accent "hard shadow" under white text.
+  const titleSvg = lines
+    .map((line, i) => {
+      const y = firstBaseline + i * lineHeight;
+      const t = esc(line);
+      return (
+        `<text x="${innerX + shadowOffset}" y="${y + shadowOffset}" font-family="${DISPLAY_FONT}" font-size="${titleSize}" font-weight="700" fill="${theme.shadow}" opacity="0.9">${t}</text>` +
+        `<text x="${innerX}" y="${y}" font-family="${DISPLAY_FONT}" font-size="${titleSize}" font-weight="700" fill="${FG}">${t}</text>`
+      );
+    })
+    .join('');
+
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="${esc(title)}">`,
+    '<defs>',
+    // soft glow for the sun
+    `<filter id="glow" x="-50%" y="-50%" width="200%" height="200%"><feGaussianBlur stdDeviation="${Math.round(sunR * 0.12)}"/></filter>`,
+    // faint flat lattice for the sky (above the horizon)
+    `<pattern id="sky" width="44" height="44" patternUnits="userSpaceOnUse"><path d="M44 0 H0 V44" fill="none" stroke="${theme.grid}" stroke-width="1" opacity="0.05"/></pattern>`,
+    // vertical scrim: darken top (title contrast) and bottom (footer contrast)
+    `<linearGradient id="scrim" x1="0" y1="0" x2="0" y2="1">`,
+    `<stop offset="0" stop-color="${BG}" stop-opacity="0.55"/>`,
+    `<stop offset="0.2" stop-color="${BG}" stop-opacity="0.12"/>`,
+    `<stop offset="0.55" stop-color="${BG}" stop-opacity="0"/>`,
+    `<stop offset="0.74" stop-color="${BG}" stop-opacity="0.28"/>`,
+    `<stop offset="1" stop-color="${BG}" stop-opacity="0.85"/>`,
+    `</linearGradient>`,
+    '</defs>',
+    // base + sky lattice
+    `<rect width="${width}" height="${height}" fill="${BG}"/>`,
+    `<rect width="${width}" height="${horizon}" fill="url(#sky)"/>`,
+    // sun behind the grid, then the receding floor grid, then circuits
+    sun(sunCx, horizon, sunR, theme.sun),
+    perspectiveGrid(width, height, horizon, theme.grid),
+    circuits(width, height, sunCx, horizon, theme.sun),
+    // horizon line
+    `<line x1="0" y1="${horizon}" x2="${width}" y2="${horizon}" stroke="${theme.grid}" stroke-width="2" opacity="0.6"/>`,
+    // scrim for text legibility
+    `<rect width="${width}" height="${height}" fill="url(#scrim)"/>`,
+    // brutalist inset frame
+    `<rect x="${inset}" y="${inset}" width="${width - 2 * inset}" height="${height - 2 * inset}" fill="none" stroke="${FG}" stroke-width="2"/>`,
+    // top accent bar
+    `<rect x="${innerX}" y="${inset + Math.round(pad * 0.45)}" width="${Math.round(width * 0.06)}" height="6" fill="${theme.grid}"/>`,
+    // eyebrow
+    `<text x="${innerX}" y="${eyebrowY}" font-family="${MONO_FONT}" font-size="${eyebrowSize}" font-weight="700" fill="${theme.grid}" letter-spacing="2">&gt; ${esc(eyebrowText)}</text>`,
+    // title
+    titleSvg,
+    // tags
+    tagsText
+      ? `<text x="${innerX}" y="${tagsY}" font-family="${MONO_FONT}" font-size="${tagSize}" font-weight="500" fill="${theme.tag}">${tagsText}</text>`
+      : '',
+    // footer brand
+    `<text x="${innerX}" y="${footerY}" font-family="${MONO_FONT}" font-size="${footerSize}" font-weight="700" fill="${FG}">${esc(siteName)}</text>`,
+    `<text x="${width - inset - pad}" y="${footerY}" text-anchor="end" font-family="${MONO_FONT}" font-size="${footerSize}" font-weight="700" fill="${theme.sun}">//</text>`,
+    `</svg>`,
+  ].join('');
+}

--- a/lib/og/headerImage.ts
+++ b/lib/og/headerImage.ts
@@ -1,0 +1,19 @@
+// Typed re-export of the deterministic header-image engine for app-side (.tsx)
+// imports. The implementation lives once in `headerImage.mjs` — this file adds
+// no logic, it only gives TypeScript a resolution target and named types
+// (mirroring the `showDrafts.mjs` / `showDrafts.ts` pairing used in `lib/`).
+// `allowJs` + the JSDoc in the `.mjs` supply the runtime types.
+import { buildHeaderSvg, HEADER_PRESETS } from './headerImage.mjs';
+
+export type HeaderImageOptions = {
+  title: string;
+  seed?: string;
+  slug?: string;
+  tags?: string[];
+  date?: string;
+  siteName?: string;
+  width?: number;
+  height?: number;
+};
+
+export { buildHeaderSvg, HEADER_PRESETS };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "start": "next-remote-watch ./data",
     "dev": "next dev --turbopack",
-    "build": "next build && node ./scripts/generate-sitemap.mjs && node ./scripts/generate-search.mjs && node ./scripts/generate-tag-rss.mjs && node ./scripts/build-search-index.mjs",
+    "build": "next build && node ./scripts/generate-sitemap.mjs && node ./scripts/generate-search.mjs && node ./scripts/generate-tag-rss.mjs && node ./scripts/build-search-index.mjs && node ./scripts/generate-og-images.mjs",
+    "og:images": "node ./scripts/generate-og-images.mjs",
     "serve": "next start",
     "analyze": "cross-env ANALYZE=true next build",
     "test": "vitest",

--- a/scripts/audit-seo.mjs
+++ b/scripts/audit-seo.mjs
@@ -30,9 +30,11 @@ async function auditSEO() {
     if (!data.tags || !Array.isArray(data.tags) || data.tags.length === 0)
       issues.push('Missing or Invalid Tags');
 
-    // Warnings
+    // Warnings — no explicit social image is fine: the build falls back to a
+    // deterministic generated OG card (scripts/generate-og-images.mjs). This is
+    // informational only, not a failure.
     if (!data.images || data.images.length === 0)
-      warnings.push('No Social Image (images: [])');
+      warnings.push('No explicit social image — using generated OG card');
 
     if (issues.length > 0 || warnings.length > 0) {
       if (issues.length > 0) issuesFound++;

--- a/scripts/generate-og-images.mjs
+++ b/scripts/generate-og-images.mjs
@@ -2,14 +2,14 @@
  * Generate per-post social/OG card PNGs from the deterministic SVG engine.
  *
  * For every blog post this renders `buildHeaderSvg(... , og preset)` and
- * rasterises it to `public/static/og/<slug>.png` (1200×630) using the same
- * Playwright-screenshot approach as `generate-og-image.mjs` /
- * `generate-favicon.mjs`. Output filenames are derived from the slug, so they
- * are stable and the SEO layer can reference `/static/og/<slug>.png` without a
- * lookup table.
+ * rasterises it to `public/static/og/<slug>.png` (1200×630) with `sharp`.
+ * sharp is browser-free (libvips/resvg under the hood), so this runs anywhere
+ * `next build` runs — CI and Vercel — with no Playwright/Chromium dependency.
+ * Output filenames are derived from the slug, so they are stable and the SEO
+ * layer can reference `/static/og/<slug>.png` without a lookup table.
  *
- * Idempotent: re-running only rewrites PNGs whose source metadata changed
- * (tracked via a `.manifest.json` of content hashes) unless `--force` is passed.
+ * Idempotent: re-running only rewrites PNGs whose source SVG changed (tracked
+ * via a `.manifest.json` of content hashes) unless `--force` is passed.
  */
 import crypto from 'node:crypto';
 import fs from 'node:fs';
@@ -17,7 +17,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { globby } from 'globby';
 import matter from 'gray-matter';
-import { chromium } from 'playwright';
+import sharp from 'sharp';
 import { buildHeaderSvg, HEADER_PRESETS } from '../lib/og/headerImage.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -29,28 +29,6 @@ const blogDir = path.join(root, 'data', 'blog');
 const outDir = path.join(root, 'public', 'static', 'og');
 const manifestPath = path.join(outDir, '.manifest.json');
 
-/** Best-effort @font-face injection so the raster matches the live site fonts. */
-function buildFontFaceCss() {
-  const families = [
-    { family: 'Space Grotesk', pkg: 'space-grotesk' },
-    { family: 'IBM Plex Mono', pkg: 'ibm-plex-mono' },
-  ];
-  const faces = [];
-  for (const { family, pkg } of families) {
-    const filesDir = path.join(root, 'node_modules', '@fontsource', pkg, 'files');
-    if (!fs.existsSync(filesDir)) continue;
-    for (const file of fs.readdirSync(filesDir)) {
-      const m = file.match(/-latin-(\d+)-normal\.woff2$/);
-      if (!m) continue;
-      const url = new URL(`file://${path.join(filesDir, file)}`).href;
-      faces.push(
-        `@font-face{font-family:'${family}';font-style:normal;font-weight:${m[1]};src:url('${url}') format('woff2');}`,
-      );
-    }
-  }
-  return faces.join('\n');
-}
-
 async function generate() {
   const files = await globby(['**/*.{md,mdx}'], { cwd: blogDir });
   fs.mkdirSync(outDir, { recursive: true });
@@ -61,11 +39,6 @@ async function generate() {
   const nextManifest = {};
 
   const { width, height } = HEADER_PRESETS.og;
-  const fontCss = buildFontFaceCss();
-
-  const browser = await chromium.launch();
-  const page = await browser.newPage({ viewport: { width, height } });
-
   let written = 0;
   let skipped = 0;
 
@@ -92,21 +65,12 @@ async function generate() {
     }
 
     fs.mkdirSync(path.dirname(pngPath), { recursive: true });
-    await page.setContent(
-      `<!DOCTYPE html><html><head><style>` +
-        `${fontCss}body{margin:0;padding:0}svg{display:block}` +
-        `</style></head><body>${svg}</body></html>`,
-      { waitUntil: 'load' },
-    );
-    await page.evaluate(() => document.fonts.ready);
-    await page.screenshot({ path: pngPath, type: 'png' });
+    await sharp(Buffer.from(svg)).png().toFile(pngPath);
     written++;
     console.log(`  ✓ ${slug}.png`);
   }
 
-  await browser.close();
   fs.writeFileSync(manifestPath, `${JSON.stringify(nextManifest, null, 2)}\n`);
-
   console.log(
     `\nOG images: ${written} written, ${skipped} unchanged (${files.length} posts).`,
   );

--- a/scripts/generate-og-images.mjs
+++ b/scripts/generate-og-images.mjs
@@ -1,0 +1,118 @@
+/**
+ * Generate per-post social/OG card PNGs from the deterministic SVG engine.
+ *
+ * For every blog post this renders `buildHeaderSvg(... , og preset)` and
+ * rasterises it to `public/static/og/<slug>.png` (1200×630) using the same
+ * Playwright-screenshot approach as `generate-og-image.mjs` /
+ * `generate-favicon.mjs`. Output filenames are derived from the slug, so they
+ * are stable and the SEO layer can reference `/static/og/<slug>.png` without a
+ * lookup table.
+ *
+ * Idempotent: re-running only rewrites PNGs whose source metadata changed
+ * (tracked via a `.manifest.json` of content hashes) unless `--force` is passed.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { globby } from 'globby';
+import matter from 'gray-matter';
+import { chromium } from 'playwright';
+import { buildHeaderSvg, HEADER_PRESETS } from '../lib/og/headerImage.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const root = path.join(__dirname, '..');
+
+const force = process.argv.includes('--force');
+const blogDir = path.join(root, 'data', 'blog');
+const outDir = path.join(root, 'public', 'static', 'og');
+const manifestPath = path.join(outDir, '.manifest.json');
+
+/** Best-effort @font-face injection so the raster matches the live site fonts. */
+function buildFontFaceCss() {
+  const families = [
+    { family: 'Space Grotesk', pkg: 'space-grotesk' },
+    { family: 'IBM Plex Mono', pkg: 'ibm-plex-mono' },
+  ];
+  const faces = [];
+  for (const { family, pkg } of families) {
+    const filesDir = path.join(root, 'node_modules', '@fontsource', pkg, 'files');
+    if (!fs.existsSync(filesDir)) continue;
+    for (const file of fs.readdirSync(filesDir)) {
+      const m = file.match(/-latin-(\d+)-normal\.woff2$/);
+      if (!m) continue;
+      const url = new URL(`file://${path.join(filesDir, file)}`).href;
+      faces.push(
+        `@font-face{font-family:'${family}';font-style:normal;font-weight:${m[1]};src:url('${url}') format('woff2');}`,
+      );
+    }
+  }
+  return faces.join('\n');
+}
+
+async function generate() {
+  const files = await globby(['**/*.{md,mdx}'], { cwd: blogDir });
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const manifest = fs.existsSync(manifestPath)
+    ? JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+    : {};
+  const nextManifest = {};
+
+  const { width, height } = HEADER_PRESETS.og;
+  const fontCss = buildFontFaceCss();
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width, height } });
+
+  let written = 0;
+  let skipped = 0;
+
+  for (const file of files) {
+    const slug = file.replace(/\.(mdx|md)$/, '');
+    const { data } = matter(fs.readFileSync(path.join(blogDir, file), 'utf8'));
+
+    const svg = buildHeaderSvg({
+      title: data.title || slug,
+      slug,
+      tags: Array.isArray(data.tags) ? data.tags : [],
+      date: data.date,
+      width,
+      height,
+    });
+
+    const hash = crypto.createHash('sha1').update(svg).digest('hex');
+    nextManifest[slug] = hash;
+
+    const pngPath = path.join(outDir, `${slug}.png`);
+    if (!force && manifest[slug] === hash && fs.existsSync(pngPath)) {
+      skipped++;
+      continue;
+    }
+
+    fs.mkdirSync(path.dirname(pngPath), { recursive: true });
+    await page.setContent(
+      `<!DOCTYPE html><html><head><style>` +
+        `${fontCss}body{margin:0;padding:0}svg{display:block}` +
+        `</style></head><body>${svg}</body></html>`,
+      { waitUntil: 'load' },
+    );
+    await page.evaluate(() => document.fonts.ready);
+    await page.screenshot({ path: pngPath, type: 'png' });
+    written++;
+    console.log(`  ✓ ${slug}.png`);
+  }
+
+  await browser.close();
+  fs.writeFileSync(manifestPath, `${JSON.stringify(nextManifest, null, 2)}\n`);
+
+  console.log(
+    `\nOG images: ${written} written, ${skipped} unchanged (${files.length} posts).`,
+  );
+}
+
+generate().catch((err) => {
+  console.error('❌ Error generating OG images:', err);
+  process.exit(1);
+});

--- a/tests/header-image.test.ts
+++ b/tests/header-image.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { buildHeaderSvg, HEADER_PRESETS } from '../lib/og/headerImage.mjs';
+
+const base = {
+  title: 'The Virtual Monorepo: Giving Coding Agents One World',
+  slug: 'virtual-monorepo-coding-agents',
+  tags: ['ai', 'coding-agents', 'monorepo'],
+  date: '2026-07-04',
+};
+
+describe('buildHeaderSvg', () => {
+  it('is deterministic — same input yields identical output', () => {
+    expect(buildHeaderSvg(base)).toBe(buildHeaderSvg(base));
+  });
+
+  it('varies by seed (slug)', () => {
+    // Omit date so the eyebrow reflects the slug — this guarantees a diff
+    // regardless of how many themes the seed happens to bucket into.
+    const a = buildHeaderSvg({ ...base, date: undefined, slug: 'one' });
+    const b = buildHeaderSvg({ ...base, date: undefined, slug: 'two' });
+    expect(a).not.toBe(b);
+  });
+
+  it('emits a well-formed standalone SVG at the requested size', () => {
+    const svg = buildHeaderSvg({ ...base, ...HEADER_PRESETS.og });
+    expect(svg.startsWith('<svg')).toBe(true);
+    expect(svg.trimEnd().endsWith('</svg>')).toBe(true);
+    expect(svg).toContain('width="1200"');
+    expect(svg).toContain('height="630"');
+  });
+
+  it('exposes banner and og presets', () => {
+    expect(HEADER_PRESETS.banner).toEqual({ width: 1200, height: 600 });
+    expect(HEADER_PRESETS.og).toEqual({ width: 1200, height: 630 });
+  });
+
+  it('handles missing tags and date without throwing', () => {
+    const svg = buildHeaderSvg({ title: 'Solo', slug: 'solo' });
+    expect(svg.startsWith('<svg')).toBe(true);
+    expect(svg.trimEnd().endsWith('</svg>')).toBe(true);
+  });
+
+  // Safety: the output is injected via dangerouslySetInnerHTML, so it must never
+  // contain executable or event-handler markup, and front-matter text must be
+  // XML-escaped rather than interpolated raw.
+  describe('is safe to inline', () => {
+    it('contains no script or event-handler markup', () => {
+      const svg = buildHeaderSvg(base);
+      expect(svg).not.toMatch(/<script/i);
+      expect(svg).not.toMatch(/\son\w+=/i); // onload=, onclick=, ...
+      expect(svg).not.toMatch(/javascript:/i);
+    });
+
+    it('escapes angle brackets, ampersands and quotes in the title', () => {
+      const svg = buildHeaderSvg({
+        ...base,
+        title: '<script>alert("x")</script> & \'more\'',
+      });
+      // The raw injection must not survive into the markup...
+      expect(svg).not.toContain('<script>alert');
+      // ...it must appear escaped instead.
+      expect(svg).toContain('&lt;script&gt;');
+      expect(svg).toContain('&amp;');
+      expect(svg).toContain('&quot;');
+      expect(svg).toContain('&#39;');
+      // And the document is still a single well-formed SVG.
+      expect(svg.startsWith('<svg')).toBe(true);
+      expect(svg.trimEnd().endsWith('</svg>')).toBe(true);
+    });
+
+    it('escapes malicious tag values too', () => {
+      const svg = buildHeaderSvg({ ...base, tags: ['<img src=x onerror=1>'] });
+      expect(svg).not.toContain('<img src=x');
+      expect(svg).toContain('&lt;img');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two related changes:

1. **New post** — `data/blog/virtual-monorepo-coding-agents.mdx` (draft): the "virtual monorepo" pattern (a config-only "brain" repo symlinked to independent repos) and why it matters most as a coherent world model for coding agents. Written to be organisation-agnostic — no company/product/repo names, just the general pattern.

2. **Deterministic header / OG image system** — a single SVG engine drives both the on-page hero and per-post social cards, so every post gets a distinct-but-stable image with zero hand-authored assets.

## The image engine

- `lib/og/headerImage.mjs` — pure, deterministic `buildHeaderSvg(frontMatter)` → SVG string. Output is a function of the slug (FNV-1a hash → theme). The visual language mirrors the site's `CyberHero`: a synthwave perspective floor grid receding to a vanishing point, a glowing horizon ring-"sun" with venetian slats, and circuit traces. Palette pulled from `tailwind.config.js`.
- `lib/og/headerImage.ts` — thin typed re-export (mirrors the existing `lib/utils/showDrafts.mjs` / `.ts` pairing) so the `.tsx` component gets types while the Node build script imports the `.mjs` directly.

### Two consumers, one engine

- **On-page hero** — `components/PostHeaderImage.tsx` renders the SVG inline; `layouts/PostLayout.tsx` shows it when a post has no explicit `images`. Inline SVG keeps it vector-crisp and lets the site's webfonts apply.
- **Social/OG card** — `scripts/generate-og-images.mjs` rasterises the `og` preset (1200×630) to `public/static/og/<slug>.png` at build time (wired into `pnpm build`; also `pnpm og:images`). `components/SEO.tsx` and `layouts/PostBanner.tsx` fall back to `/static/og/<slug>.png` when front matter has no image, so every post gets a unique card.

Generated PNGs are gitignored build artifacts (`/public/static/og/`).

## Safety

The hero uses `dangerouslySetInnerHTML` for the locally-generated SVG. `tests/header-image.test.ts` guards this: it asserts the output contains no `<script>` / `on*=` / `javascript:` markup and that front-matter title/tag values are XML-escaped rather than interpolated raw, alongside determinism, well-formedness, and both size presets.

## Notes for review

- `components/PostHeaderImage.stories.tsx` adds Storybook coverage (long title, short title, OG variant).
- Docs updated: `AGENTS.md` (build pipeline + where-to-look) and `lib/AGENTS.md` (engine section).
- The post is `draft: true` and keeps `images: []`, so it renders with the generated card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgZMr5PDNFx97zTCgX4uo7