### PR TITLE
[superseded] Deep search via Convex full-text index (alternative to #51)

### DIFF
--- a/.github/workflows/index-search.yml
+++ b/.github/workflows/index-search.yml
@@ -1,0 +1,56 @@
+name: Index search
+
+# Rebuild the Convex full-text search corpus (the `documents` table) from the
+# MDX sources whenever content or the search plumbing changes on main. This is
+# the "part of the deployment that indexes the whole site" — kept off preview
+# builds so previews never write to the production Convex deployment.
+#
+# Requires repo secret CONVEX_DEPLOY_KEY (a Convex *production* deploy key).
+# `convex deploy` pushes the schema/functions; `convex import --replace` loads
+# the freshly built corpus and rebuilds the search index.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'data/blog/**'
+      - 'data/talks/**'
+      - 'convex/schema.ts'
+      - 'convex/documents.ts'
+      - 'scripts/build-search-index.mjs'
+      - '.github/workflows/index-search.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: index-search
+  cancel-in-progress: true
+
+jobs:
+  index:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build search corpus
+        run: pnpm search:index
+
+      - name: Deploy Convex + import corpus
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: |
+          if [ -z "$CONVEX_DEPLOY_KEY" ]; then
+            echo "::error::CONVEX_DEPLOY_KEY is not set — add a Convex production deploy key as a repo secret."
+            exit 1
+          fi
+          npx convex deploy -y
+          npx convex import --replace --table documents convex/search-docs.jsonl -y

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ storybook-static
 # temporary working files
 /temp/
 
+# generated search corpus (built at deploy time by scripts/build-search-index.mjs)
+/convex/search-docs.jsonl
+
 # git worktrees (scratch state for parallel branches)
 .worktrees/
 .claude/worktrees/

--- a/components/search/DeepSearch.tsx
+++ b/components/search/DeepSearch.tsx
@@ -1,0 +1,55 @@
+import { useQuery } from 'convex/react';
+import type { Action } from 'kbar';
+import { useKBar, useRegisterActions } from 'kbar';
+import { useRouter } from 'next/router';
+import { useEffect, useMemo, useState } from 'react';
+import { api } from '@/convex/_generated/api';
+
+/**
+ * Convex-backed "deep search": as the user types in the command palette this
+ * queries the full-text `documents` index (titles, tags, summaries, and full
+ * body text) and registers the hits as kbar actions under "Deep search".
+ *
+ * Rendered only when a Convex deployment is configured (see SearchProvider), so
+ * `useQuery` always has a provider. When Convex is absent the palette still
+ * works against the static `public/search.json` list — this just adds body-text
+ * matching on top. Registers nothing until there's a query, so an idle palette
+ * shows the normal navigation + post list.
+ */
+export default function DeepSearch() {
+  const router = useRouter();
+  const { searchQuery } = useKBar((state) => ({
+    searchQuery: state.searchQuery,
+  }));
+
+  // Debounce the live query so we don't fire a Convex read on every keystroke.
+  const [debounced, setDebounced] = useState('');
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(searchQuery.trim()), 180);
+    return () => clearTimeout(id);
+  }, [searchQuery]);
+
+  const results = useQuery(
+    api.documents.search,
+    debounced.length >= 2 ? { query: debounced } : 'skip',
+  );
+
+  const actions = useMemo<Action[]>(() => {
+    if (!results) return [];
+    return results.map((r) => ({
+      id: `deep-${r.type}-${r.slug}`,
+      name: r.title,
+      // Include the raw query in keywords so kbar's own fuzzy matcher never
+      // filters out a result the server already judged relevant.
+      keywords: `${r.tags.join(' ')} ${r.summary ?? ''} ${debounced}`,
+      section: 'Deep search',
+      subtitle: r.snippet || r.summary || r.url,
+      priority: 10,
+      perform: () => router.push(r.url),
+    }));
+  }, [results, debounced, router]);
+
+  useRegisterActions(actions, [actions]);
+
+  return null;
+}

--- a/components/search/KBarModal.tsx
+++ b/components/search/KBarModal.tsx
@@ -76,10 +76,12 @@ function RenderResults() {
                   : 'bg-transparent text-zinc-300 border-transparent hover:bg-zinc-900'
               }`}
             >
-              <div className="flex flex-col">
+              <div className="flex min-w-0 flex-col">
                 <span className="font-bold">{item.name}</span>
                 {item.subtitle && (
-                  <span className="text-xs text-zinc-500">{item.subtitle}</span>
+                  <span className="line-clamp-2 text-xs text-zinc-500">
+                    {item.subtitle}
+                  </span>
                 )}
               </div>
               {item.shortcut?.length && (

--- a/components/search/SearchButton.tsx
+++ b/components/search/SearchButton.tsx
@@ -1,13 +1,21 @@
 import { useKBar } from 'kbar';
 
+/**
+ * Prominent command-palette trigger in the header. Reads as a search field
+ * (icon + placeholder + ⌘K hint) rather than a bare icon, so the palette is
+ * discoverable; collapses to just the icon on narrow screens. Opening it is
+ * still also bound to ⌘K / Ctrl-K by kbar.
+ */
 export default function SearchButton() {
   const { query } = useKBar();
 
   return (
     <button
-      aria-label="Search"
+      type="button"
+      aria-label="Search the site"
+      aria-keyshortcuts="Meta+K Control+K"
       onClick={() => query.toggle()}
-      className="ml-1 mr-1 h-8 w-8 rounded-sm p-1 sm:ml-4 text-white hover:text-brutalist-neonGreen transition-colors drop-shadow-[0_0_5px_rgba(255,255,255,0.3)] hover:drop-shadow-[0_0_8px_rgba(57,255,20,0.8)]"
+      className="group ml-1 flex items-center gap-2 border-2 border-brutalist-cyan bg-black px-2 py-1.5 font-mono text-sm text-zinc-400 transition-all hover:text-white hover:shadow-glow-cyan sm:ml-4 sm:gap-3 sm:px-3"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -15,7 +23,8 @@ export default function SearchButton() {
         viewBox="0 0 24 24"
         strokeWidth={2}
         stroke="currentColor"
-        className="h-6 w-6 text-current"
+        className="h-5 w-5 shrink-0 text-brutalist-cyan"
+        aria-hidden="true"
       >
         <path
           strokeLinecap="round"
@@ -23,6 +32,10 @@ export default function SearchButton() {
           d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
         />
       </svg>
+      <span className="hidden whitespace-nowrap sm:inline">search_system…</span>
+      <kbd className="ml-2 hidden whitespace-nowrap border-2 border-brutalist-pink bg-black px-1.5 py-0.5 text-xs font-bold uppercase leading-none tracking-wide text-brutalist-pink sm:inline-block">
+        ⌘K
+      </kbd>
     </button>
   );
 }

--- a/components/search/SearchProvider.tsx
+++ b/components/search/SearchProvider.tsx
@@ -3,6 +3,8 @@ import { KBarProvider } from 'kbar';
 import { useRouter } from 'next/router';
 import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
+import { isConvexConfigured } from '@/lib/convexClient';
+import DeepSearch from './DeepSearch';
 import KBarModal from './KBarModal';
 
 interface Props {
@@ -84,6 +86,10 @@ export default function SearchProvider({ children }: Props) {
   return (
     <KBarProvider actions={defaultActions}>
       <KBarModal actions={searchActions} isLoading={!loaded} />
+      {/* Full-body search via Convex, layered on top of the static list. Only
+          mounted when a Convex deployment is configured so `useQuery` always
+          has a provider; the palette degrades to search.json otherwise. */}
+      {isConvexConfigured && <DeepSearch />}
       {children}
     </KBarProvider>
   );

--- a/convex/AGENTS.md
+++ b/convex/AGENTS.md
@@ -115,6 +115,28 @@ ever leaves the client; the server only stores the opaque id.
 `_generated/` (api, server, dataModel) is produced by Convex from the schema and
 function signatures. Never hand-edit it — it regenerates on `convex dev` / deploy.
 
+> Exception on the `claude/convex-deep-search` branch: `_generated/api.d.ts` was
+> hand-edited to add the `documents` module so `tsc` resolves `api.documents.*`
+> without a local codegen run. Running `npx convex dev`/`deploy` regenerates it
+> identically — the edit is a stopgap, not a new source of truth.
+
+## SEARCH CORPUS (`documents`)
+
+Site-wide full-text search for the command palette. `documents` is a **derived**
+table — one row per published blog post and talk — not operational data:
+
+- **Source of truth is the MDX**, not Convex. `scripts/build-search-index.mjs`
+  strips each post/talk body to plain text and writes `convex/search-docs.jsonl`.
+- **Indexed at deploy**, off preview builds: `.github/workflows/index-search.yml`
+  runs on push to `main`, `convex deploy`s then `convex import --replace --table
+  documents`, which rebuilds the `search_text` full-text index. Needs repo secret
+  `CONVEX_DEPLOY_KEY` (a Convex production deploy key).
+- **Query**: `api.documents.search({ query, type?, limit? })` (`convex/documents.ts`)
+  via `withSearchIndex('search_text', …)`, returning a bounded display projection.
+- **Client**: `components/search/DeepSearch.tsx` registers hits as kbar actions,
+  mounted only when `isConvexConfigured` so the palette degrades to the static
+  `public/search.json` list when Convex is absent.
+
 ## SEE ALSO
 
 React-side hooks and clients: `lib/usePresence.ts`, `lib/useReactions.ts`,

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as activities from "../activities.js";
 import type * as auth from "../auth.js";
 import type * as crons from "../crons.js";
+import type * as documents from "../documents.js";
 import type * as hello from "../hello.js";
 import type * as http from "../http.js";
 import type * as lib_admin from "../lib/admin.js";
@@ -34,6 +35,7 @@ declare const fullApi: ApiFromModules<{
   activities: typeof activities;
   auth: typeof auth;
   crons: typeof crons;
+  documents: typeof documents;
   hello: typeof hello;
   http: typeof http;
   "lib/admin": typeof lib_admin;

--- a/convex/documents.ts
+++ b/convex/documents.ts
@@ -1,0 +1,49 @@
+import { v } from 'convex/values';
+import { query } from './_generated/server';
+
+/**
+ * Site-wide full-text search over the `documents` corpus (blog posts + talks,
+ * indexed at deploy time from the MDX sources). Backs the command palette's
+ * "deep search" — matching titles, tags, summaries, and full body text, not
+ * just the static title/summary list bundled in `public/search.json`.
+ *
+ * Returns a bounded, display-shaped projection (never the full `text` haystack)
+ * so results are cheap to ship to the client.
+ */
+export const search = query({
+  args: {
+    query: v.string(),
+    type: v.optional(v.union(v.literal('blog'), v.literal('talk'))),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const q = args.query.trim();
+    if (q.length < 2) return [];
+    const take = Math.min(args.limit ?? 8, 20);
+    const { type } = args;
+
+    const rows =
+      type === undefined
+        ? await ctx.db
+            .query('documents')
+            .withSearchIndex('search_text', (s) => s.search('text', q))
+            .take(take)
+        : await ctx.db
+            .query('documents')
+            .withSearchIndex('search_text', (s) =>
+              s.search('text', q).eq('type', type),
+            )
+            .take(take);
+
+    return rows.map((d) => ({
+      slug: d.slug,
+      type: d.type,
+      title: d.title,
+      summary: d.summary,
+      tags: d.tags,
+      date: d.date,
+      url: d.url,
+      snippet: d.snippet,
+    }));
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -218,4 +218,32 @@ export default defineSchema({
   })
     .index('by_activity_created', ['activityId', 'createdAt'])
     .index('by_room_created', ['room', 'createdAt']),
+
+  // Full-text search corpus for the whole site. One row per published blog post
+  // and talk, populated at deploy time from the MDX sources (see
+  // scripts/build-search-index.mjs + .github/workflows/index-search.yml, which
+  // `convex import --replace` this table). This is NOT the source of truth — the
+  // MDX files are — it's a derived, rebuild-on-deploy search index that powers
+  // the command palette's deep (full-body) search. Kept separate from the
+  // live-talk tables above so a reindex never touches operational data.
+  documents: defineTable({
+    slug: v.string(),
+    type: v.union(v.literal('blog'), v.literal('talk')),
+    title: v.string(),
+    summary: v.optional(v.string()),
+    tags: v.array(v.string()),
+    date: v.optional(v.string()),
+    url: v.string(),
+    // The searchable haystack: title + tags + summary + plaintext body, joined
+    // by the indexer and capped well under Convex's 1MB field limit, so a query
+    // matches across all of them in one search index.
+    text: v.string(),
+    // Short human-readable excerpt shown under each palette result.
+    snippet: v.string(),
+  })
+    .index('by_slug', ['slug'])
+    .searchIndex('search_text', {
+      searchField: 'text',
+      filterFields: ['type'],
+    }),
 });

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "post:wizard": "node scripts/compose.mjs",
     "check:seo": "node scripts/audit-seo.mjs",
     "check:deploy": "node scripts/verify-deployment.mjs",
+    "search:index": "node scripts/build-search-index.mjs",
     "lint": "biome check .",
     "format": "biome format --write .",
     "prepare": "husky install",

--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -1,0 +1,98 @@
+/**
+ * Build the full-text search corpus for the whole site.
+ *
+ * Reads every published blog post and talk, strips the MDX body to plain text,
+ * and writes one JSON document per line to `convex/search-docs.jsonl`. The
+ * deploy workflow (.github/workflows/index-search.yml) then loads it into the
+ * Convex `documents` table with `convex import --replace`, which rebuilds the
+ * `search_text` full-text index. That corpus powers the command palette's deep
+ * (full-body) search — the static `public/search.json` only carries titles and
+ * summaries.
+ *
+ * Run standalone with: `pnpm search:index` (or `node scripts/build-search-index.mjs`).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { globby } from 'globby';
+import matter from 'gray-matter';
+import { show_drafts } from '../lib/utils/showDrafts.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const root = path.join(__dirname, '..');
+
+// Cap the indexed haystack per document to stay comfortably under Convex's 1MB
+// per-field limit; the head of a post is more than enough for match relevance.
+const MAX_TEXT = 16000;
+const SNIPPET = 200;
+
+/** Strip MDX/Markdown to readable plain text (best-effort, deterministic). */
+function toPlainText(body) {
+  return body
+    .replace(/^import\s.+$/gm, '') // ESM imports
+    .replace(/^export\s.+$/gm, '') // ESM exports
+    .replace(/```[\s\S]*?```/g, ' ') // fenced code blocks
+    .replace(/`[^`]*`/g, ' ') // inline code
+    .replace(/<!--[\s\S]*?-->/g, ' ') // HTML comments
+    .replace(/\{[\s\S]*?\}/g, ' ') // JSX expressions / mermaid bodies
+    .replace(/<[^>]+>/g, ' ') // JSX / HTML tags
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ') // images
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // links → link text
+    .replace(/^[#>\-*+\s]+/gm, '') // heading / list / quote markers
+    .replace(/[*_~`]/g, '') // leftover emphasis marks
+    .replace(/\s+/g, ' ') // collapse whitespace
+    .trim();
+}
+
+async function collect(dir, type, urlBase) {
+  const base = path.join(root, 'data', dir);
+  if (!fs.existsSync(base)) return [];
+  const files = await globby(['**/*.{md,mdx}'], { cwd: base });
+  const docs = [];
+  for (const file of files) {
+    const { data, content } = matter(
+      fs.readFileSync(path.join(base, file), 'utf8'),
+    );
+    if (data.draft === true && !show_drafts()) continue;
+
+    const slug = file.replace(/\.(mdx|md)$/, '');
+    const tags = Array.isArray(data.tags) ? data.tags.map(String) : [];
+    const summary = typeof data.summary === 'string' ? data.summary : undefined;
+    const plain = toPlainText(content);
+    const text = [data.title ?? slug, tags.join(' '), summary ?? '', plain]
+      .join('\n')
+      .slice(0, MAX_TEXT);
+
+    docs.push({
+      slug,
+      type,
+      title: String(data.title ?? slug),
+      ...(summary ? { summary } : {}),
+      tags,
+      ...(data.date ? { date: String(data.date).slice(0, 10) } : {}),
+      url: `${urlBase}/${slug}`,
+      text,
+      snippet: plain.slice(0, SNIPPET),
+    });
+  }
+  return docs;
+}
+
+async function main() {
+  const docs = [
+    ...(await collect('blog', 'blog', '/blog')),
+    ...(await collect('talks', 'talk', '/talks')),
+  ];
+  const outPath = path.join(root, 'convex', 'search-docs.jsonl');
+  fs.writeFileSync(
+    outPath,
+    `${docs.map((d) => JSON.stringify(d)).join('\n')}\n`,
+  );
+  console.log(`Search corpus: ${docs.length} documents → ${outPath}`);
+}
+
+main().catch((err) => {
+  console.error('❌ Failed to build search index:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Superseded by #51 — kept for the record

This is the **server-side Convex** approach to site-wide deep search, opened only to preserve the history of the rejected alternative. **Do not merge** — closing immediately in favor of the static, lazy-loaded index in #51.

### What this branch did
- `documents` table with a `search_text` full-text `searchIndex` (filterable by type).
- `convex/documents.ts` `search` query over the index.
- Deploy-time indexing: `scripts/build-search-index.mjs` → `convex/search-docs.jsonl`, loaded by a GitHub Action (`.github/workflows/index-search.yml`) via `convex deploy` + `convex import --replace` (needs `CONVEX_DEPLOY_KEY`).
- `components/search/DeepSearch.tsx` querying Convex per keystroke; prominent search button.

### Why it was rejected
The blog's content is fully known at build time, so even this design indexed **at deploy**, never using Convex's realtime edge. For a static corpus a baked, lazy-loaded asset (#51) is simpler, faster (no per-keystroke network), works on any host/offline, and needs no deploy key. Convex stays for the live-talk realtime features, where it earns its keep.

See #51 for the chosen implementation (MiniSearch over a static `search-index.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgZMr5PDNFx97zTCgX4uo7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgZMr5PDNFx97zTCgX4uo7)_