### PR TITLE
feat(ops): secrets/ provisioning files + pnpm provision script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ storybook-static
 
 # local scratch TODO (code-review findings, not for commit)
 todo.md
+
+# provisioning secrets (see secrets/README.md) — never commit values
+/secrets/*.env

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -201,6 +201,17 @@ Env vars by deployment:
 | `AUTH_E2E_BYPASS_SECRET` | **never** | ✅ | ✅ | Arms the bypass provider |
 | `AUTH_E2E_BYPASS_LOGIN` | — | optional | optional | Synthetic login (default `e2e-bypass`) |
 
+### Provisioning from files
+
+The gitignored `secrets/` directory (see `secrets/README.md`) is the local
+source of truth for all of the above — one dotenv file per target, pushed
+with `pnpm provision <convex-dev|convex-prod|convex-preview|ci|vercel-preview>`.
+Per-target files make cross-environment mistakes structural rather than
+disciplinary: `convex-prod` additionally refuses any `E2E`/`BYPASS` key
+before pushing. `convex-preview` prints values for manual dashboard entry
+(Convex project-default env vars have no CLI). Rotation = edit file, re-run
+target.
+
 Commands:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "format": "biome format --write .",
     "prepare": "husky install",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "provision": "node scripts/provision.mjs"
   },
   "dependencies": {
     "@auth/core": "0.37.0",

--- a/scripts/provision.mjs
+++ b/scripts/provision.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Push provisioning secrets from the gitignored secrets/ files to their
+ * targets. One file per target so dev values can't reach prod by accident;
+ * see secrets/README.md and docs/auth.md §9.
+ *
+ *   pnpm provision convex-dev      → npx convex env set --from-file
+ *   pnpm provision convex-prod     → …--prod (refuses bypass/e2e keys)
+ *   pnpm provision ci              → gh secret set (per key)
+ *   pnpm provision vercel-preview  → vercel env add <name> preview
+ *   pnpm provision convex-preview  → prints values (dashboard-only:
+ *                                    project default env vars have no CLI)
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const target = process.argv[2];
+const dir = path.join(process.cwd(), 'secrets');
+
+function parse(file) {
+  const p = path.join(dir, file);
+  if (!fs.existsSync(p)) fail(`missing ${p} — see secrets/README.md`);
+  return fs
+    .readFileSync(p, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim() && !l.startsWith('#'))
+    .map((l) => {
+      const i = l.indexOf('=');
+      return [l.slice(0, i), l.slice(i + 1)];
+    })
+    .filter(([, v]) => v !== '');
+}
+
+function fail(msg) {
+  console.error(`provision: ${msg}`);
+  process.exit(1);
+}
+
+function run(cmd, args, input) {
+  execFileSync(cmd, args, { stdio: input ? ['pipe', 1, 2] : 'inherit', input });
+}
+
+const targets = {
+  'convex-dev': () => {
+    run('npx', ['convex', 'env', 'set', '--from-file', 'secrets/convex.dev.env']);
+  },
+  'convex-prod': () => {
+    // Structural guard on top of the hard-coded one in convex/auth.ts: the
+    // bypass must never even be *pushed* at prod.
+    const banned = parse('convex.prod.env').filter(([k]) =>
+      /E2E|BYPASS/i.test(k),
+    );
+    if (banned.length) {
+      fail(`convex.prod.env contains ${banned.map(([k]) => k).join(', ')} — remove before provisioning prod`);
+    }
+    run('npx', ['convex', 'env', 'set', '--prod', '--from-file', 'secrets/convex.prod.env']);
+  },
+  ci: () => {
+    for (const [k, v] of parse('ci.env')) {
+      run('gh', ['secret', 'set', k], v);
+      console.log(`set repo secret ${k}`);
+    }
+  },
+  'vercel-preview': () => {
+    for (const [k, v] of parse('vercel.preview.env')) {
+      // Re-adding an existing var fails; remove first (ignore absence).
+      try {
+        run('vercel', ['env', 'rm', k, 'preview', '--yes']);
+      } catch {}
+      run('vercel', ['env', 'add', k, 'preview'], v);
+      console.log(`set vercel preview env ${k}`);
+    }
+  },
+  'convex-preview': () => {
+    console.log(
+      'Project default env vars have no CLI — enter these in the Convex dashboard',
+    );
+    console.log('(project settings → Default environment variables → Preview):\n');
+    for (const [k, v] of parse('convex.preview.env')) console.log(`${k}=${v}`);
+  },
+};
+
+if (!target || !targets[target]) {
+  fail(`usage: pnpm provision <${Object.keys(targets).join('|')}>`);
+}
+targets[target]();

--- a/scripts/provision.mjs
+++ b/scripts/provision.mjs
@@ -43,7 +43,13 @@ function run(cmd, args, input) {
 
 const targets = {
   'convex-dev': () => {
-    run('npx', ['convex', 'env', 'set', '--from-file', 'secrets/convex.dev.env']);
+    run('npx', [
+      'convex',
+      'env',
+      'set',
+      '--from-file',
+      'secrets/convex.dev.env',
+    ]);
   },
   'convex-prod': () => {
     // Structural guard on top of the hard-coded one in convex/auth.ts: the
@@ -52,9 +58,18 @@ const targets = {
       /E2E|BYPASS/i.test(k),
     );
     if (banned.length) {
-      fail(`convex.prod.env contains ${banned.map(([k]) => k).join(', ')} — remove before provisioning prod`);
+      fail(
+        `convex.prod.env contains ${banned.map(([k]) => k).join(', ')} — remove before provisioning prod`,
+      );
     }
-    run('npx', ['convex', 'env', 'set', '--prod', '--from-file', 'secrets/convex.prod.env']);
+    run('npx', [
+      'convex',
+      'env',
+      'set',
+      '--prod',
+      '--from-file',
+      'secrets/convex.prod.env',
+    ]);
   },
   ci: () => {
     for (const [k, v] of parse('ci.env')) {
@@ -76,7 +91,9 @@ const targets = {
     console.log(
       'Project default env vars have no CLI — enter these in the Convex dashboard',
     );
-    console.log('(project settings → Default environment variables → Preview):\n');
+    console.log(
+      '(project settings → Default environment variables → Preview):\n',
+    );
     for (const [k, v] of parse('convex.preview.env')) console.log(`${k}=${v}`);
   },
 };

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,0 +1,39 @@
+# Provisioning secrets
+
+Local-only source of truth for deployment secrets — the recovery path for
+rebuilding any environment without archaeology. **Every `*.env` here is
+gitignored; only this README is committed.** Full design: docs/auth.md §9.
+
+One file per target, so pushing dev values at prod is structurally
+impossible (and `pnpm provision convex-prod` refuses any `E2E`/`BYPASS` key
+outright):
+
+| File | Target | Push with |
+|---|---|---|
+| `convex.dev.env` | dev deployment (keen-shark-231) | `pnpm provision convex-dev` |
+| `convex.prod.env` | prod (fiery-minnow-77) — **never** bypass keys | `pnpm provision convex-prod` |
+| `convex.preview.env` | Convex project default env vars (previews inherit) | `pnpm provision convex-preview` (prints — dashboard-only) |
+| `ci.env` | GitHub Actions repo secrets | `pnpm provision ci` |
+| `vercel.preview.env` | Vercel Preview environment | `pnpm provision vercel-preview` |
+
+Expected keys per file:
+
+```
+convex.dev.env:      AUTH_GITHUB_ID, AUTH_GITHUB_SECRET (dev OAuth app),
+                     SITE_URL=http://localhost:3002,
+                     ADMIN_GITHUB_LOGINS, AUTH_E2E_BYPASS_SECRET
+convex.prod.env:     AUTH_GITHUB_ID, AUTH_GITHUB_SECRET (prod OAuth app),
+                     SITE_URL=https://www.ryankelly.dev, ADMIN_GITHUB_LOGINS
+convex.preview.env:  AUTH_E2E_BYPASS_SECRET, ADMIN_GITHUB_LOGINS
+ci.env:              AUTH_E2E_BYPASS_SECRET, VERCEL_AUTOMATION_BYPASS_SECRET
+vercel.preview.env:  CONVEX_DEPLOY_KEY (preview deploy key)
+```
+
+Deliberately excluded: `JWKS` / `JWT_PRIVATE_KEY` — per-deployment signing
+keys Convex Auth generates itself; copying them between deployments is
+wrong. If lost, re-run the Convex Auth setup for that deployment.
+
+Rotation = edit the file, re-run the matching `pnpm provision` target(s).
+If this directory is lost: values are recoverable from the live
+deployments (`npx convex env list [--prod]`), the GitHub OAuth apps, and
+the Vercel/Convex dashboards.


### PR DESCRIPTION
## What

Makes deployment secrets reusable from local dotenv files, per the question "can I put the values in a .env file for prod and dev?" — yes, structured so it's safe:

- **`secrets/*.env`** (gitignored, one file per target): `convex.dev.env`, `convex.prod.env`, `convex.preview.env`, `ci.env`, `vercel.preview.env`. Only `secrets/README.md` is committed.
- **`pnpm provision <target>`** (`scripts/provision.mjs`) maps each file to its CLI: `convex env set --from-file` (dev/prod), `gh secret set` (CI), `vercel env add` (preview env), and prints values for the dashboard-only Convex project defaults.
- **Safety is structural**: separate files per environment, plus the `convex-prod` target hard-refuses any `E2E`/`BYPASS` key before pushing — backstopping the hard-coded guard in `convex/auth.ts`.
- `JWKS`/`JWT_PRIVATE_KEY` deliberately excluded (per-deployment signing keys, not portable).
- docs/auth.md §9 gains the provisioning flow.

## Verified locally

- `pnpm provision` with no/unknown target → usage error, exit 1.
- `convex-preview` prints the two dashboard values.
- Injected `AUTH_E2E_BYPASS_SECRET` into `convex.prod.env` → `convex-prod` refused, exit 1; removed.
- `convex-dev` pushed against the live dev deployment → idempotent ("already set").
- Commit inspected: no `.env` files tracked.

The dev/prod files are already populated on this machine from the live deployments; `ci.env` and `vercel.preview.env` hold placeholders pending the two dashboard-minted keys (todo 33a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)