### PR TITLE
fix(talks): mid-talk safety — reveal-beat guards, surfaced control errors, slug picker

### DIFF
--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -71,8 +71,10 @@ function ConfigBadges({
 
 function Dashboard({
   talkDurations,
+  talkOptions,
 }: {
   talkDurations?: Record<string, number>;
+  talkOptions?: { slug: string; title: string }[];
 }) {
   const current = useQuery(api.talks.current);
   const viewer = useQuery(api.talks.viewer);
@@ -131,7 +133,7 @@ function Dashboard({
       <div className="grid gap-6 md:grid-cols-2">
         {/* Start / control */}
         <Card title="Start / control a talk">
-          <TalkControls />
+          <TalkControls talkOptions={talkOptions} />
         </Card>
 
         {/* Broadcast launcher */}
@@ -240,13 +242,16 @@ function Dashboard({
  */
 export default function AdminDashboard({
   talkDurations,
+  talkOptions,
 }: {
   /** slug → frontmatter durationMins, baked in by pages/admin getStaticProps. */
   talkDurations?: Record<string, number>;
+  /** Real deck slugs/titles for the start form, from the same getStaticProps. */
+  talkOptions?: { slug: string; title: string }[];
 }) {
   return (
     <AdminGate>
-      <Dashboard talkDurations={talkDurations} />
+      <Dashboard talkDurations={talkDurations} talkOptions={talkOptions} />
     </AdminGate>
   );
 }

--- a/components/admin/AudienceControls.tsx
+++ b/components/admin/AudienceControls.tsx
@@ -4,13 +4,8 @@ import { useCountdown } from '@/components/talks/OrderedActions';
 import { api } from '@/convex/_generated/api';
 import type { Id } from '@/convex/_generated/dataModel';
 import ActivityEvalGrid from './ActivityEvalGrid';
+import ErrorLine from './ErrorLine';
 import { useRunAction } from './useRunAction';
-
-/** Shared error line for the admin panels. */
-function ErrorLine({ error }: { error: string | null }) {
-  if (!error) return null;
-  return <p className="font-mono text-xs text-brutalist-pink">{error}</p>;
-}
 
 // The presenter owns the reveal by default ("manual" arms no timer); the timed
 // presets are an opt-in fallback that can still be cancelled while pending.

--- a/components/admin/ErrorLine.tsx
+++ b/components/admin/ErrorLine.tsx
@@ -1,0 +1,10 @@
+/**
+ * Renders a `useRunAction` error (or nothing). Shared by every presenter
+ * control surface — /admin panels, the console sidebar, and slide-embedded
+ * launch/reveal controls — so a lapsed admin session shows the thrown
+ * "Unauthorized…" instead of a silently dead button.
+ */
+export default function ErrorLine({ error }: { error: string | null }) {
+  if (!error) return null;
+  return <p className="font-mono text-xs text-brutalist-pink">{error}</p>;
+}

--- a/components/admin/TalkControls.tsx
+++ b/components/admin/TalkControls.tsx
@@ -17,18 +17,39 @@ const FEATURE_TOGGLES: { key: keyof TalkConfig; label: string }[] = [
 /**
  * Start / end a talk and choose its profile + feature toggles. Assumes it's
  * rendered inside an admin gate — the mutations are identity-gated server-side.
+ * `talkOptions` (real deck slugs from frontmatter) drives a picker so the
+ * Session can only target a deck that exists — a typo'd slug silently makes a
+ * room the deck never drives. Free-text only as a fallback when no options
+ * were baked in.
  */
-export default function TalkControls() {
+export default function TalkControls({
+  talkOptions,
+}: {
+  talkOptions?: { slug: string; title: string }[];
+}) {
   const current = useQuery(api.talks.current);
   const start = useMutation(api.talks.start);
   const end = useMutation(api.talks.end);
   const updateConfig = useMutation(api.talks.updateConfig);
 
-  const [slug, setSlug] = useState('so-you-want-to-build-software');
-  const [title, setTitle] = useState('So You Want To Build Software?');
+  const options = talkOptions ?? [];
+  const [slug, setSlug] = useState(
+    options[0]?.slug ?? 'so-you-want-to-build-software',
+  );
+  const [title, setTitle] = useState(
+    options[0]?.title ?? 'So You Want To Build Software?',
+  );
   const [presetId, setPresetId] = useState(TALK_PRESETS[0].id);
   const [config, setConfig] = useState<TalkConfig>(TALK_PRESETS[0].config);
   const { run, error } = useRunAction();
+
+  const pickTalk = (nextSlug: string) => {
+    setSlug(nextSlug);
+    const picked = options.find((o) => o.slug === nextSlug);
+    // Title follows the picked deck but stays editable (it's the Session's
+    // display name, e.g. "… — dry run").
+    if (picked) setTitle(picked.title);
+  };
 
   const applyPreset = (id: string) => {
     setPresetId(id);
@@ -95,12 +116,29 @@ export default function TalkControls() {
 
   return (
     <div className="space-y-3 font-mono">
-      <input
-        value={slug}
-        onChange={(e) => setSlug(e.target.value)}
-        placeholder="talk slug"
-        className="w-full border-2 border-white bg-black px-3 py-2 text-white"
-      />
+      {options.length > 0 ? (
+        <label className="block text-xs uppercase text-zinc-400">
+          Talk
+          <select
+            value={slug}
+            onChange={(e) => pickTalk(e.target.value)}
+            className="mt-1 w-full border-2 border-white bg-black px-3 py-2 text-white"
+          >
+            {options.map((o) => (
+              <option key={o.slug} value={o.slug}>
+                {o.title} ({o.slug})
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : (
+        <input
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          placeholder="talk slug"
+          className="w-full border-2 border-white bg-black px-3 py-2 text-white"
+        />
+      )}
       <input
         value={title}
         onChange={(e) => setTitle(e.target.value)}

--- a/components/admin/useRunAction.ts
+++ b/components/admin/useRunAction.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 /**
  * Runs an async admin action (typically a Convex mutation), surfacing any thrown
@@ -12,7 +12,9 @@ export function useRunAction() {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
-  const run = async (fn: () => Promise<unknown>) => {
+  // Stable identity so effects can list `run` as a dependency without
+  // re-registering listeners every render.
+  const run = useCallback(async (fn: () => Promise<unknown>) => {
     setError(null);
     setBusy(true);
     try {
@@ -22,7 +24,7 @@ export function useRunAction() {
     } finally {
       setBusy(false);
     }
-  };
+  }, []);
 
   return { run, error, busy };
 }

--- a/components/talks/BreakTimer.tsx
+++ b/components/talks/BreakTimer.tsx
@@ -1,5 +1,7 @@
 import { useMutation, useQuery } from 'convex/react';
 import { useEffect, useState } from 'react';
+import ErrorLine from '@/components/admin/ErrorLine';
+import { useRunAction } from '@/components/admin/useRunAction';
 import { api } from '@/convex/_generated/api';
 import { breakView } from '@/lib/breakCountdown';
 import { useDeckMode } from './DeckModeContext';
@@ -26,22 +28,26 @@ const CONTROL_BTN =
 function BreakButtons({ room }: { room: string }) {
   const extendBreak = useMutation(api.talks.extendBreak);
   const endBreak = useMutation(api.talks.endBreak);
+  const { run, error } = useRunAction();
   return (
-    <div className="flex justify-center gap-2">
-      <button
-        type="button"
-        onClick={() => extendBreak({ room, byMs: EXTEND_MS }).catch(() => {})}
-        className={`${CONTROL_BTN} bg-brutalist-yellow`}
-      >
-        +1 min
-      </button>
-      <button
-        type="button"
-        onClick={() => endBreak({ room }).catch(() => {})}
-        className={`${CONTROL_BTN} bg-brutalist-pink`}
-      >
-        ✕ End break
-      </button>
+    <div className="space-y-2">
+      <div className="flex justify-center gap-2">
+        <button
+          type="button"
+          onClick={() => run(() => extendBreak({ room, byMs: EXTEND_MS }))}
+          className={`${CONTROL_BTN} bg-brutalist-yellow`}
+        >
+          +1 min
+        </button>
+        <button
+          type="button"
+          onClick={() => run(() => endBreak({ room }))}
+          className={`${CONTROL_BTN} bg-brutalist-pink`}
+        >
+          ✕ End break
+        </button>
+      </div>
+      <ErrorLine error={error} />
     </div>
   );
 }
@@ -59,6 +65,7 @@ function Countdown({
   const isAdmin = useQuery(api.talks.isAdmin) === true;
   const status = useQuery(api.talks.breakStatus, { room });
   const startBreak = useMutation(api.talks.startBreak);
+  const { run, error } = useRunAction();
   const now = useNow(status != null);
   const view = status ? breakView(now, status.startedAt, status.endsAt) : null;
   // The projected deck (presenter mode) must stay clean — the room sees it. The
@@ -78,12 +85,13 @@ function Countdown({
         <button
           type="button"
           onClick={() =>
-            startBreak({ room, durationMs: minutes * 60_000 }).catch(() => {})
+            run(() => startBreak({ room, durationMs: minutes * 60_000 }))
           }
           className="border-2 border-white bg-brutalist-pink px-5 py-2 font-mono font-bold uppercase text-black shadow-hard-md"
         >
           ▶ Start {minutes} min break
         </button>
+        <ErrorLine error={error} />
       </div>
     );
   }
@@ -138,6 +146,7 @@ function Countdown({
 export function BreakControl({ room }: { room: string }) {
   const status = useQuery(api.talks.breakStatus, { room });
   const startBreak = useMutation(api.talks.startBreak);
+  const { run, error } = useRunAction();
   const [mins, setMins] = useState(5);
   const now = useNow(status != null);
   const view = status ? breakView(now, status.startedAt, status.endsAt) : null;
@@ -179,10 +188,12 @@ export function BreakControl({ room }: { room: string }) {
           <button
             type="button"
             onClick={() =>
-              startBreak({
-                room,
-                durationMs: Math.max(1, Math.floor(mins || 0)) * 60_000,
-              }).catch(() => {})
+              run(() =>
+                startBreak({
+                  room,
+                  durationMs: Math.max(1, Math.floor(mins || 0)) * 60_000,
+                }),
+              )
             }
             className={`${CONTROL_BTN} bg-brutalist-cyan`}
           >
@@ -190,6 +201,7 @@ export function BreakControl({ room }: { room: string }) {
           </button>
         </div>
       )}
+      <ErrorLine error={error} />
     </div>
   );
 }

--- a/components/talks/DeckSidebars.tsx
+++ b/components/talks/DeckSidebars.tsx
@@ -1,6 +1,8 @@
 import { useMutation, useQuery } from 'convex/react';
 import { useEffect, useRef, useState } from 'react';
 import ActivityEvalGrid from '@/components/admin/ActivityEvalGrid';
+import ErrorLine from '@/components/admin/ErrorLine';
+import { useRunAction } from '@/components/admin/useRunAction';
 import PresenceBadge from '@/components/PresenceBadge';
 import Reactions from '@/components/Reactions';
 import TalkStatsChart from '@/components/TalkStatsChart';
@@ -171,6 +173,7 @@ export function ConsoleSidebar({
   // so submissions can be evaluated from the console without leaving the deck.
   const activityFeed = useQuery(api.activities.feed, { room });
   const end = useMutation(api.talks.end);
+  const { run: runEnd, error: endError } = useRunAction();
 
   const last = slides.length - 1;
   const idx = Math.min(Math.max(currentSlide, 0), Math.max(last, 0));
@@ -316,13 +319,16 @@ export function ConsoleSidebar({
         <TalkStatsChart room={room} threshold={0} />
       </div>
 
-      <button
-        type="button"
-        onClick={() => end({}).catch(() => {})}
-        className="mt-auto border-2 border-white bg-brutalist-pink px-4 py-2 font-mono text-sm font-bold uppercase text-black shadow-hard-md"
-      >
-        End talk
-      </button>
+      <div className="mt-auto space-y-2">
+        <button
+          type="button"
+          onClick={() => runEnd(() => end({}))}
+          className="w-full border-2 border-white bg-brutalist-pink px-4 py-2 font-mono text-sm font-bold uppercase text-black shadow-hard-md"
+        >
+          End talk
+        </button>
+        <ErrorLine error={endError} />
+      </div>
     </aside>
   );
 }

--- a/components/talks/LivePoll.tsx
+++ b/components/talks/LivePoll.tsx
@@ -1,5 +1,7 @@
 import { useMutation, useQuery } from 'convex/react';
 import { useState } from 'react';
+import ErrorLine from '@/components/admin/ErrorLine';
+import { useRunAction } from '@/components/admin/useRunAction';
 import { api } from '@/convex/_generated/api';
 import { getMachineId } from '@/lib/machineId';
 import { useRateLimitNotice } from '@/lib/useRateLimitNotice';
@@ -45,6 +47,8 @@ function Poll({
   // submit confirms; the server is the source of truth via `remaining`).
   const [answersLeft, setAnswersLeft] = useState<number | null>(null);
   const { secondsLeft, notify } = useRateLimitNotice();
+  // Slide-embedded start is a presenter control — surface its failures.
+  const { run: runStart, error: startError } = useRunAction();
 
   // No open poll yet. An admin on a slide that declares a prompt can start it in
   // one click (the poll question lives with the slide).
@@ -58,11 +62,12 @@ function Poll({
         <p className="mb-3 font-mono text-sm text-zinc-300">{prompt}</p>
         <button
           type="button"
-          onClick={() => start({ room, prompt }).catch(() => {})}
+          onClick={() => runStart(() => start({ room, prompt }))}
           className="border-2 border-white bg-brutalist-pink px-5 py-2 font-mono font-bold uppercase text-black shadow-hard-md"
         >
           ▶ Start poll
         </button>
+        <ErrorLine error={startError} />
       </div>
     );
   }

--- a/components/talks/OrderedActions.tsx
+++ b/components/talks/OrderedActions.tsx
@@ -1,11 +1,14 @@
 import { useMutation, useQuery } from 'convex/react';
 import { useEffect, useState } from 'react';
+import ErrorLine from '@/components/admin/ErrorLine';
+import { useRunAction } from '@/components/admin/useRunAction';
 import { api } from '@/convex/_generated/api';
 import { getMachineId } from '@/lib/machineId';
 import { useRateLimitNotice } from '@/lib/useRateLimitNotice';
 import { useDeckMode } from './DeckModeContext';
 import RateLimitNotice from './RateLimitNotice';
 import { ResolvedRoom } from './ResolvedRoom';
+import { useActivitySlideRegistry, useSlideIndex } from './RevealBeatContext';
 
 /** Live-updating seconds remaining until `revealAt` (null once elapsed/absent). */
 export function useCountdown(
@@ -104,6 +107,19 @@ function Activity({
     activity && !activity.revealed ? activity.revealAt : null,
   );
 
+  // Presenter controls (open / reveal / cancel) surface their errors — a lapsed
+  // admin session must not look like a working button.
+  const { run: runControl, error: controlError } = useRunAction();
+
+  // On a driving deck, tell the deck which slide declares the open activity so
+  // the reveal beat arms there (matched by prompt; see RevealBeatContext).
+  const slideIndex = useSlideIndex();
+  const registry = useActivitySlideRegistry();
+  useEffect(() => {
+    if (!registry || slideIndex == null || !activity || !prompt) return;
+    if (activity.prompt === prompt) registry.report(activity._id, slideIndex);
+  }, [registry, slideIndex, activity, prompt]);
+
   // No open activity yet. An admin on a slide that declares a prompt + default
   // answer can launch it in one click (config lives with the slide, not /admin).
   if (!activity) {
@@ -118,17 +134,20 @@ function Activity({
         <button
           type="button"
           onClick={() =>
-            openActivity({
-              room,
-              prompt: prompt as string,
-              options: defaultOptions as string[],
-              revealDelayMs: revealAfterMs,
-            }).catch(() => {})
+            runControl(() =>
+              openActivity({
+                room,
+                prompt: prompt as string,
+                options: defaultOptions as string[],
+                revealDelayMs: revealAfterMs,
+              }),
+            )
           }
           className="border-2 border-white bg-brutalist-yellow px-5 py-2 font-mono font-bold uppercase text-black shadow-hard-md"
         >
           ▶ Open activity
         </button>
+        <ErrorLine error={controlError} />
       </div>
     );
   }
@@ -280,25 +299,30 @@ function Activity({
               hand on the console, and an opt-in auto-reveal timer can be
               cancelled here while it's still pending. */}
           {isConsole && !activity.revealed && (
-            <div className="mt-3 flex flex-wrap gap-2">
-              <button
-                type="button"
-                onClick={() => revealNow({ id: activity._id }).catch(() => {})}
-                className="border-2 border-white bg-brutalist-cyan px-4 py-2 font-mono text-xs font-bold uppercase text-black shadow-hard-md"
-              >
-                Reveal to room now
-              </button>
-              {countdown != null && (
+            <div className="mt-3 space-y-2">
+              <div className="flex flex-wrap gap-2">
                 <button
                   type="button"
                   onClick={() =>
-                    cancelReveal({ id: activity._id }).catch(() => {})
+                    runControl(() => revealNow({ id: activity._id }))
                   }
-                  className="border-2 border-white bg-black px-4 py-2 font-mono text-xs font-bold uppercase text-white"
+                  className="border-2 border-white bg-brutalist-cyan px-4 py-2 font-mono text-xs font-bold uppercase text-black shadow-hard-md"
                 >
-                  ✕ Cancel timer
+                  Reveal to room now
                 </button>
-              )}
+                {countdown != null && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      runControl(() => cancelReveal({ id: activity._id }))
+                    }
+                    className="border-2 border-white bg-black px-4 py-2 font-mono text-xs font-bold uppercase text-white"
+                  >
+                    ✕ Cancel timer
+                  </button>
+                )}
+              </div>
+              <ErrorLine error={controlError} />
             </div>
           )}
         </div>

--- a/components/talks/RevealBeatContext.tsx
+++ b/components/talks/RevealBeatContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Index of the deck slide this component is embedded in. Spectacle keeps every
+ * slide mounted, so a slide-embedded widget can use this to say "I live on
+ * slide N" regardless of which slide is showing. Null outside a deck (e.g. on
+ * /live).
+ */
+const SlideIndexContext = createContext<number | null>(null);
+
+export const SlideIndexProvider = SlideIndexContext.Provider;
+
+export function useSlideIndex(): number | null {
+  return useContext(SlideIndexContext);
+}
+
+/**
+ * Registry a *driving* deck (presenter/console, admin, live-here) provides so
+ * slide-embedded activity widgets can report which slide declares the
+ * currently-open activity. The reveal beat then arms on that slide — not on
+ * whichever slide the presenter happened to be on when the activity opened
+ * (e.g. opened from /admin while off the activity slide). Null on every
+ * non-driving surface, so widgets can skip reporting entirely.
+ */
+export type ActivitySlideRegistry = {
+  report: (activityId: string, slideIndex: number) => void;
+};
+
+const ActivitySlideRegistryContext =
+  createContext<ActivitySlideRegistry | null>(null);
+
+export const ActivitySlideRegistryProvider =
+  ActivitySlideRegistryContext.Provider;
+
+export function useActivitySlideRegistry(): ActivitySlideRegistry | null {
+  return useContext(ActivitySlideRegistryContext);
+}

--- a/components/talks/SpectacleDeck.tsx
+++ b/components/talks/SpectacleDeck.tsx
@@ -1,6 +1,6 @@
 import { useConvexAuth, useMutation, useQuery } from 'convex/react';
 import { useRouter } from 'next/router';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Box,
   Deck,
@@ -10,6 +10,7 @@ import {
   Progress,
   Slide,
 } from 'spectacle';
+import { useRunAction } from '@/components/admin/useRunAction';
 import { api } from '@/convex/_generated/api';
 import { isConvexConfigured } from '@/lib/convexClient';
 import type { SlideWindow } from '@/lib/slideTiming';
@@ -20,6 +21,10 @@ import {
   ConsoleSidebar,
   PresenterQuestionsSidebar,
 } from './DeckSidebars';
+import {
+  ActivitySlideRegistryProvider,
+  SlideIndexProvider,
+} from './RevealBeatContext';
 import SlideBody from './SlideBody';
 import { brutalistTheme } from './theme';
 
@@ -79,7 +84,9 @@ function Chrome({
 function renderSlides(slides: DeckSlide[]) {
   return slides.map((slide, i) => (
     <Slide key={i} backgroundColor="#000000">
-      <SlideBody code={slide.code} />
+      <SlideIndexProvider value={i}>
+        <SlideBody code={slide.code} />
+      </SlideIndexProvider>
       {slide.notesCode ? (
         <Notes>
           <SlideBody code={slide.notesCode} />
@@ -234,35 +241,72 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
       ? openActivity._id
       : null;
 
+  // Slide-embedded activity widgets report which slide *declares* the open
+  // activity (matched by prompt — Spectacle keeps every slide mounted, so the
+  // declaring slide's widget is live even while the presenter is elsewhere).
+  // Keyed by activity id; an activity launched from /admin with a prompt no
+  // slide declares simply never registers.
+  const [declaredSlides, setDeclaredSlides] = useState<Record<string, number>>(
+    {},
+  );
+  const slideRegistry = useMemo(
+    () => ({
+      report: (activityId: string, slideIndex: number) =>
+        setDeclaredSlides((m) =>
+          m[activityId] === slideIndex ? m : { ...m, [activityId]: slideIndex },
+        ),
+    }),
+    [],
+  );
+
   // Record the slide the presenter is on the moment a reveal arms (derived
   // during render so it captures the arm-time slide, not later navigation).
+  // Only the fallback for activities no slide declares — the declaring slide,
+  // when known, always wins (fixes arming the wrong slide when the activity is
+  // opened from /admin while the presenter is elsewhere in the deck).
   const prevPendingRef = useRef<string | null>(null);
   const armedSlideRef = useRef<number | null>(null);
   if (pendingReveal !== prevPendingRef.current) {
     prevPendingRef.current = pendingReveal;
     armedSlideRef.current = pendingReveal ? deckIndex : null;
   }
-  // Arm the next-key reveal only while the presenter is still on the activity's
-  // own slide — advancing on any other slide navigates normally instead of
+  const armedSlide =
+    (pendingReveal != null ? declaredSlides[pendingReveal] : undefined) ??
+    armedSlideRef.current;
+  // Arm the next-key reveal only while the presenter is on the activity's own
+  // slide — advancing on any other slide navigates normally instead of
   // prematurely broadcasting the answer.
   const revealArmed =
-    pendingReveal != null && deckIndex === armedSlideRef.current
-      ? pendingReveal
-      : null;
+    pendingReveal != null && deckIndex === armedSlide ? pendingReveal : null;
 
+  // Surface reveal failures (e.g. a lapsed admin session) instead of a silent
+  // no-op — the beat consumes the keypress, so a swallowed error looks like a
+  // dead deck.
+  const { run: runReveal, error: revealError } = useRunAction();
   useEffect(() => {
     if (!revealArmed) return;
     const ADVANCE = new Set([' ', 'Spacebar', 'ArrowRight', 'PageDown']);
     const onKey = (e: KeyboardEvent) => {
       if (!ADVANCE.has(e.key)) return;
+      // Never steal keys from form fields (console break-minutes input etc.) —
+      // same guard as the "Q" toggle above.
+      const t = e.target as HTMLElement | null;
+      if (
+        t &&
+        (t.tagName === 'INPUT' ||
+          t.tagName === 'TEXTAREA' ||
+          t.isContentEditable)
+      ) {
+        return;
+      }
       // Beat Spectacle's own handler and consume this press.
       e.preventDefault();
       e.stopImmediatePropagation();
-      revealNow({ id: revealArmed }).catch(() => {});
+      void runReveal(() => revealNow({ id: revealArmed }));
     };
     document.addEventListener('keydown', onKey, true);
     return () => document.removeEventListener('keydown', onKey, true);
-  }, [revealArmed, revealNow]);
+  }, [revealArmed, revealNow, runReveal]);
 
   const template = ({
     slideNumber,
@@ -295,10 +339,35 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
 
   const deckEl = (
     <DeckModeProvider value={mode}>
-      <Deck theme={brutalistTheme} template={template}>
-        {renderSlides(slides)}
-      </Deck>
+      <ActivitySlideRegistryProvider value={drivingDeck ? slideRegistry : null}>
+        <Deck theme={brutalistTheme} template={template}>
+          {renderSlides(slides)}
+        </Deck>
+      </ActivitySlideRegistryProvider>
     </DeckModeProvider>
+  );
+
+  // Reveal-beat failure chip — shown on any driving deck (the presenter HUD is
+  // presenter-mode-only, and the console needs the feedback too).
+  const revealErrorChip = drivingDeck && revealError && (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: '3.5rem',
+        right: '1rem',
+        zIndex: 40,
+        border: '2px solid #f472b6',
+        background: '#000',
+        color: '#f472b6',
+        padding: '0.3rem 0.6rem',
+        fontFamily: MONO,
+        fontSize: '0.75rem',
+        textTransform: 'uppercase',
+        fontWeight: 700,
+      }}
+    >
+      reveal failed: {revealError}
+    </div>
   );
 
   const sidebar =
@@ -430,6 +499,7 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
         >
           {deckEl}
           {hud}
+          {revealErrorChip}
         </div>
         <div
           style={{
@@ -448,6 +518,7 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
     <>
       {deckEl}
       {hud}
+      {revealErrorChip}
     </>
   );
 }

--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -16,19 +16,25 @@ const AdminDashboard = dynamic(
 
 // Talk targets come from deck frontmatter (build-time fs), which the
 // client-only dashboard can't read — so bake a slug → durationMins map into
-// the page props for the live-talk clock. Drafts included: admins run those.
+// the page props for the live-talk clock, plus the slug/title list so the
+// start form offers real decks instead of free-text (a typo'd slug makes a
+// room the deck never drives). Drafts included: admins run those.
 export const getStaticProps: GetStaticProps<{
   talkDurations: Record<string, number>;
+  talkOptions: { slug: string; title: string }[];
 }> = async () => {
   const talkDurations: Record<string, number> = {};
+  const talkOptions: { slug: string; title: string }[] = [];
   for (const talk of getAllTalksFrontMatter(true)) {
     if (talk.durationMins != null) talkDurations[talk.slug] = talk.durationMins;
+    talkOptions.push({ slug: talk.slug, title: talk.title });
   }
-  return { props: { talkDurations } };
+  return { props: { talkDurations, talkOptions } };
 };
 
 export default function AdminPage({
   talkDurations,
+  talkOptions,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <>
@@ -37,7 +43,10 @@ export default function AdminPage({
         <h1 className="mb-6 font-display text-3xl font-bold uppercase text-white">
           [ Admin ]
         </h1>
-        <AdminDashboard talkDurations={talkDurations} />
+        <AdminDashboard
+          talkDurations={talkDurations}
+          talkOptions={talkOptions}
+        />
       </article>
     </>
   );


### PR DESCRIPTION
Step 2 of the whole-system live-session evaluation ([step 1: #54](https://github.com/rtkelly13/blog/pull/54)) — the three issues most likely to bite mid-talk.

## Reveal beat (todo #1)
- Capture-phase advance-key interceptor gains the INPUT/TEXTAREA/contentEditable guard its sibling "Q" handler already had — **Space in the console break-minutes input no longer reveals the answer to the room**.
- The beat arms on the slide that **declares** the open activity, not whichever slide the presenter was on when it opened. Mechanism: `SlideIndexContext` (provided per slide; Spectacle keeps all slides mounted) + an `ActivitySlideRegistry` the driving deck provides; the `OrderedActions` widget reports its slide when its declared prompt matches the open activity. Admin-launched activities with undeclared prompts keep the old arm-time-slide fallback — the live-e2e harness exercises exactly that path, unchanged.
- Reveal failures now render a fixed deck chip ("reveal failed: …") instead of silently consuming the keypress.

## Surfaced control errors (todo #7)
All deck/console presenter controls route through `useRunAction` + `ErrorLine` instead of `.catch(() => {})`: console **End talk**, in-deck activity **open / reveal-now / cancel-timer**, slide-embedded **poll start**, **break start/extend/end**. A lapsed admin session now shows the `Unauthorized…` message instead of dead buttons — the exact failure `useRunAction` was written for, previously wired only into /admin. (`presenterPing`'s swallow is kept deliberately: 5s heartbeat, non-interactive.)

`ErrorLine` extracted to `components/admin/ErrorLine.tsx`; `useRunAction.run` is now `useCallback`-stable so the beat effect can depend on it without re-registering every render.

## Session start (eval E1)
/admin's start form picks from **real deck slugs** (baked via `getStaticProps` alongside the existing `talkDurations` pattern, drafts included). Title auto-fills from the picked deck, stays editable. Previously a typo'd free-text slug created a Session no deck would drive, silently.

## Verification
lint / typecheck / unit (100/100) / full production build all green. The live-e2e harness run (needs the local stack) lands with eval step 6; the deck-reveal check there covers the fallback arming path this PR preserves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)