### PR TITLE
feat(moderation): implement ADR-0002 — flagged + presenter-only pre-mask originals

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,10 +51,12 @@ Two independent mechanisms, not to be conflated:
 
 **Mask**:
 The *automatic* mechanism. On ingest, profanity is replaced with asterisks
-(`f**k`). The audience sees the masked text; the original is retained
-presenter-only and the entry is marked `flagged` so the console can highlight it
-(see [ADR-0002](docs/adr/0002-profanity-mask-retains-original.md)).
-_Avoid_: censor, filter, block (blocking is the manual mechanism).
+(`f**k`) and the entry is marked `flagged`: it is auto-Hidden pending presenter
+review, with the pre-mask original retained presenter-only so a false positive
+is judgeable. A restored entry shows the audience only the masked text — the
+original is never public (see
+[ADR-0002](docs/adr/0002-profanity-mask-retains-original.md)).
+_Avoid_: censor, filter, block.
 
 **Hide**:
 The *manual* mechanism. The Presenter removes an entry from the audience-visible

--- a/components/admin/ActivityEvalGrid.tsx
+++ b/components/admin/ActivityEvalGrid.tsx
@@ -45,15 +45,16 @@ export default function ActivityEvalGrid({
               <span className="truncate font-mono text-xs text-brutalist-pink">
                 {s.nickname ?? 'anon'}
               </span>
-              {s.marked ? (
-                <span className="shrink-0 font-mono text-[10px] uppercase text-brutalist-yellow">
-                  ★ marked
-                </span>
-              ) : s.hidden ? (
-                <span className="shrink-0 font-mono text-[10px] uppercase text-zinc-500">
-                  hidden
-                </span>
-              ) : null}
+              <span className="flex shrink-0 gap-1.5 font-mono text-[10px] uppercase">
+                {s.marked && (
+                  <span className="text-brutalist-yellow">★ marked</span>
+                )}
+                {/* ADR-0002: auto-masked ≠ presenter-hidden — tag them apart. */}
+                {s.flagged && (
+                  <span className="text-brutalist-cyan">⚠ masked</span>
+                )}
+                {s.hidden && <span className="text-zinc-500">hidden</span>}
+              </span>
             </div>
             <ol
               className={`mb-2 space-y-0.5 ${s.hidden ? 'line-through' : ''}`}
@@ -65,6 +66,14 @@ export default function ActivityEvalGrid({
                 </li>
               ))}
             </ol>
+            {/* Pre-mask original (ADR-0002): presenter-only, so a false-positive
+                mask ("Scunthorpe") is judgeable at a glance. */}
+            {(s.originalSteps || s.originalNickname) && (
+              <p className="mb-2 border-l-2 border-brutalist-cyan pl-1.5 font-mono text-[10px] text-zinc-400">
+                original: {s.originalNickname && <>“{s.originalNickname}” · </>}
+                {s.originalSteps?.join(' → ')}
+              </p>
+            )}
             <div className="mt-auto flex gap-3 font-mono text-[10px] uppercase">
               <button
                 type="button"

--- a/components/admin/AudienceControls.tsx
+++ b/components/admin/AudienceControls.tsx
@@ -347,12 +347,27 @@ function QAControls({ room }: { room: string }) {
               <span className="w-8 shrink-0 text-center font-bold text-brutalist-yellow">
                 {q.votes}
               </span>
-              <span
-                className={`min-w-0 flex-1 ${q.hidden ? 'line-through' : ''}`}
-              >
-                {q.text}
-                {q.nickname && (
-                  <span className="text-zinc-500"> — {q.nickname}</span>
+              <span className="min-w-0 flex-1">
+                <span className={q.hidden ? 'line-through' : ''}>
+                  {q.text}
+                  {q.nickname && (
+                    <span className="text-zinc-500"> — {q.nickname}</span>
+                  )}
+                </span>
+                {/* ADR-0002: the Mask fired — tag it (auto-hidden ≠ presenter-
+                    hidden) and show the pre-mask original, presenter-only. */}
+                {q.flagged && (
+                  <span className="ml-2 text-xs uppercase text-brutalist-cyan">
+                    ⚠ masked
+                  </span>
+                )}
+                {(q.original || q.originalNickname) && (
+                  <span className="mt-0.5 block border-l-2 border-brutalist-cyan pl-1.5 text-xs text-zinc-400">
+                    original: {q.original}
+                    {q.originalNickname && (
+                      <span> — “{q.originalNickname}”</span>
+                    )}
+                  </span>
                 )}
               </span>
               <div className="flex shrink-0 flex-col gap-1 text-xs uppercase">

--- a/components/talks/OrderedActions.tsx
+++ b/components/talks/OrderedActions.tsx
@@ -27,10 +27,13 @@ function SubmissionCard({
   nickname,
   steps,
   hidden,
+  flagged,
 }: {
   nickname?: string;
   steps: string[];
   hidden?: boolean;
+  /** The profanity Mask fired (console only) — auto-hidden ≠ presenter-hidden. */
+  flagged?: boolean;
 }) {
   return (
     <div
@@ -44,11 +47,10 @@ function SubmissionCard({
         ) : (
           <span />
         )}
-        {hidden && (
-          <span className="font-mono text-xs uppercase text-zinc-500">
-            🚫 hidden
-          </span>
-        )}
+        <span className="flex gap-1.5 font-mono text-xs uppercase">
+          {flagged && <span className="text-brutalist-cyan">⚠ masked</span>}
+          {hidden && <span className="text-zinc-500">🚫 hidden</span>}
+        </span>
       </div>
       <ol className="space-y-0.5">
         {steps.map((step, i) => (
@@ -323,6 +325,7 @@ function Activity({
                   nickname={s.nickname}
                   steps={s.steps}
                   hidden={s.hidden}
+                  flagged={s.flagged}
                 />
               ))
             : audienceWall.map((s) => (

--- a/convex/activities.ts
+++ b/convex/activities.ts
@@ -250,6 +250,7 @@ export const submit = mutation({
       nicknameFlagged = cleaned.flagged;
     }
 
+    const flagged = stepsFlagged || nicknameFlagged;
     await ctx.db.insert('activitySubmissions', {
       activityId: args.activityId,
       room: activity.room,
@@ -258,7 +259,13 @@ export const submit = mutation({
       // Content that tripped the profanity filter is auto-hidden pending
       // presenter review — the masked text still reaches the console feed so it
       // can be restored, but it never lands on the audience wall.
-      hidden: stepsFlagged || nicknameFlagged,
+      hidden: flagged,
+      // ADR-0002: persist the flag and the pre-mask originals (presenter-only,
+      // only the parts that actually matched) so a false-positive mask is
+      // reviewable and auto-hidden ≠ presenter-hidden on the console.
+      flagged: flagged || undefined,
+      originalSteps: stepsFlagged ? trimmed : undefined,
+      originalNickname: nicknameFlagged ? rawNickname : undefined,
       createdAt: Date.now(),
     });
     return { ok: true as const };

--- a/convex/questions.ts
+++ b/convex/questions.ts
@@ -41,8 +41,10 @@ export const ask = mutation({
     const limited = await enforceRateLimit(ctx, machineId, 'question:ask');
     if (limited) return limited;
 
+    const rawText = text.trim().slice(0, MAX_TEXT_LEN);
     const rawNickname = nickname?.trim().slice(0, MAX_NICKNAME_LEN);
     const cleanedNickname = rawNickname ? cleanText(rawNickname) : undefined;
+    const flagged = cleaned.flagged || (cleanedNickname?.flagged ?? false);
     await ctx.db.insert('questions', {
       room,
       text: cleaned.text,
@@ -51,7 +53,13 @@ export const ask = mutation({
       answered: false,
       // Auto-hide anything the profanity filter flagged; the presenter sees it
       // in the moderation feed and can restore it, but the audience never does.
-      hidden: cleaned.flagged || (cleanedNickname?.flagged ?? false),
+      hidden: flagged,
+      // ADR-0002: persist the flag and the pre-mask originals (presenter-only,
+      // only the parts that actually matched) so a false-positive mask is
+      // reviewable and auto-hidden ≠ presenter-hidden on the console.
+      flagged: flagged || undefined,
+      original: cleaned.flagged ? rawText : undefined,
+      originalNickname: cleanedNickname?.flagged ? rawNickname : undefined,
       createdAt: Date.now(),
     });
     return { ok: true as const };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -117,6 +117,16 @@ export default defineSchema({
     answered: v.boolean(),
     /** Presenter has removed this from the audience-visible queue. */
     hidden: v.boolean(),
+    /**
+     * The profanity Mask fired on ingest (ADR-0002). Flagged rows are
+     * auto-hidden pending presenter review; the console tags them so they're
+     * distinguishable from presenter-Hidden rows.
+     */
+    flagged: v.optional(v.boolean()),
+    /** Pre-mask original text — presenter-only (admin feed), never public. */
+    original: v.optional(v.string()),
+    /** Pre-mask original nickname — presenter-only, never public. */
+    originalNickname: v.optional(v.string()),
     createdAt: v.number(),
   }).index('by_room_created', ['room', 'createdAt']),
 
@@ -201,6 +211,16 @@ export default defineSchema({
     steps: v.array(v.string()),
     /** Presenter has removed this from the wall. */
     hidden: v.boolean(),
+    /**
+     * The profanity Mask fired on ingest (ADR-0002). Flagged rows are
+     * auto-hidden pending presenter review; the console tags them so they're
+     * distinguishable from presenter-Hidden rows.
+     */
+    flagged: v.optional(v.boolean()),
+    /** Pre-mask original steps — presenter-only (admin feed), never public. */
+    originalSteps: v.optional(v.array(v.string())),
+    /** Pre-mask original nickname — presenter-only, never public. */
+    originalNickname: v.optional(v.string()),
     /**
      * Presenter has marked this while evaluating submissions with the room
      * (e.g. "discussing this one" / "already covered"). Presenter-only signal —

--- a/docs/adr/0002-profanity-mask-retains-original.md
+++ b/docs/adr/0002-profanity-mask-retains-original.md
@@ -26,3 +26,20 @@ The audience only ever sees masked text — that is unchanged. But we now:
   presenter-only (`requireAdmin`) and it is purged by the Session clear-down like
   all other participation data. This is an accepted, scoped data-retention choice,
   not an oversight.
+
+## Amendment (2026-07-07): flagged entries are auto-Hidden, and what shipped
+
+Implemented as: `flagged` + presenter-only `original`/`originalNickname` on
+`questions`, and `flagged` + `originalSteps`/`originalNickname` on
+`activitySubmissions` — set on ingest only for the parts the Mask actually
+matched, surfaced exclusively through the admin `feed` queries, purged with the
+row.
+
+One deliberate divergence from the original text above: a flagged entry is
+**auto-Hidden pending presenter review**, not shown-masked to the audience.
+Masked profanity on a projected wall is still disruptive for the workshop
+audiences this runs in front of; the console tags flagged rows "⚠ masked"
+(distinguishing them from presenter-Hidden rows) and shows the original, so
+restoring a false positive is one click. If a future audience warrants the
+more permissive shown-masked behaviour, flip the `hidden:` ingest default —
+`flagged` and the originals already carry everything needed.


### PR DESCRIPTION
Step 3 of the whole-system evaluation ([#54](https://github.com/rtkelly13/blog/pull/54), [#55](https://github.com/rtkelly13/blog/pull/55)).

## Why
ADR-0002 says masked entries persist `flagged` and retain the pre-mask original presenter-only — but the schema had neither field: `ask`/`submit` computed `flagged`, collapsed it into `hidden`, and destroyed the original. The matcher deliberately over-matches (Scunthorpe problem), so false positives are expected — and they were unrecoverable and invisible even to you. Auto-hidden was also indistinguishable from presenter-hidden (todo #3).

## What
- **Schema (additive, no migration):** `questions` → `flagged`, `original`, `originalNickname`; `activitySubmissions` → `flagged`, `originalSteps`, `originalNickname`. Set on ingest only for the parts the Mask matched.
- **Exposure:** admin `feed` queries only. Public queries map explicit fields — originals can never leak. Purge already covers them (rows delete whole).
- **Console:** "⚠ masked" tag (cyan, distinct from hidden/marked) + inline `original: …` on /admin Q&A rows and ActivityEvalGrid cards; same tag on in-deck console submission cards.

## One provisional decision (you were AFK — flip if you disagree)
The old ADR text said masked entries are *shown* to the audience (`f**k`); the shipped code *auto-hides* them. I kept **auto-hide pending presenter restore** — masked profanity on a projected wall is still giggle-bait for the teenage-workshop audience — and recorded it as an ADR-0002 amendment + CONTEXT.md Mask rewording. Restoring a false positive is now one click, with the original visible. If you'd rather have shown-masked, it's a one-line ingest change (`hidden: false`) — everything else in this PR already supports it.

## Also noted while here
The "Live-talk flow (headless bypass)" CI check passes **vacuously** — `CONVEX_DEPLOY_KEY_E2E` isn't set, so the job self-skips green (todo #33a confirmed still open; eval step 6 provisions it).

Verified: lint / typecheck / unit (100/100) / full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)