### PR TITLE
fix(live): honour the qa toggle end-to-end + stop false-success submissions

### DIFF
--- a/components/talks/OrderedActions.tsx
+++ b/components/talks/OrderedActions.tsx
@@ -95,6 +95,7 @@ function Activity({
   const [steps, setSteps] = useState<string[]>(['']);
   const [sending, setSending] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
   const { secondsLeft, notify } = useRateLimitNotice();
 
   const consoleActivity = feedRes?.authorized ? feedRes.activity : null;
@@ -176,10 +177,18 @@ function Activity({
       if (res.ok === false && res.reason === 'rate_limited') {
         // Refused, not dropped: keep the typed steps and show when to retry.
         notify(res.retryAfterMs);
+      } else if (res.ok === false) {
+        // Any other refusal (activities toggled off mid-type): say so and keep
+        // the typed steps — a "✓ Submitted!" here would be a lie.
+        setSendError('Submissions are closed for this session.');
       } else {
         setSteps(['']);
         setSubmitted(true);
+        setSendError(null);
       }
+    } catch {
+      // e.g. the activity closed while typing (`submit` throws).
+      setSendError('This activity has closed — your steps were not sent.');
     } finally {
       setSending(false);
     }
@@ -236,6 +245,11 @@ function Activity({
               </div>
             ))}
             <RateLimitNotice secondsLeft={secondsLeft} />
+            {sendError && (
+              <p className="border-2 border-brutalist-pink bg-black p-3 font-mono text-sm text-brutalist-pink">
+                {sendError}
+              </p>
+            )}
             <div className="flex flex-col gap-2 pt-1 sm:flex-row">
               <button
                 type="button"

--- a/components/talks/QuestionQueue.tsx
+++ b/components/talks/QuestionQueue.tsx
@@ -47,17 +47,24 @@ function Queue({
 }) {
   const mode = useDeckMode();
   const data = useQuery(api.questions.list, { room });
+  const current = useQuery(api.talks.current);
   const ask = useMutation(api.questions.ask);
   const upvote = useMutation(api.questions.upvote);
   const { voted, mark } = useVoted();
 
   const [text, setText] = useState('');
   const [sending, setSending] = useState(false);
+  const [refused, setRefused] = useState<string | null>(null);
   const { secondsLeft, notify } = useRateLimitNotice();
+
+  // Q&A toggled off for this session: the server drops ask/upvote, so don't
+  // offer the form or live vote buttons — the queue stays readable (the server
+  // keeps `list` visible deliberately; see convex/questions.ts).
+  const qaOn = current?.room === room && current?.config.qa === true;
 
   // Projected/console decks (and any `display` embed) are read-only: no ask box,
   // votes shown as static badges. Students ask + upvote from /live.
-  const readOnly = display || mode !== 'attendee';
+  const readOnly = display || mode !== 'attendee' || !qaOn;
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -70,9 +77,16 @@ function Queue({
       if (res.ok === false && res.reason === 'rate_limited') {
         // Refused, not dropped: keep the typed question and show when to retry.
         notify(res.retryAfterMs);
+      } else if (res.ok === false) {
+        // Any other refusal (Q&A toggled off mid-type): say so, keep the text —
+        // a cleared input reads as success.
+        setRefused('Q&A is closed for this session.');
       } else {
         setText('');
+        setRefused(null);
       }
+    } catch {
+      setRefused('Could not send your question — try again.');
     } finally {
       setSending(false);
     }
@@ -110,7 +124,20 @@ function Queue({
       {!readOnly && (
         <div className="mt-3 empty:hidden">
           <RateLimitNotice secondsLeft={secondsLeft} />
+          {refused && (
+            <p className="border-2 border-brutalist-pink bg-black p-3 font-mono text-sm text-brutalist-pink">
+              {refused}
+            </p>
+          )}
         </div>
+      )}
+
+      {/* Mid-type toggle-off: the form vanishes (readOnly flips) — leave a
+          breadcrumb so an attendee who was about to ask isn't just confused. */}
+      {!display && mode === 'attendee' && !qaOn && (
+        <p className="font-mono text-xs uppercase text-zinc-500">
+          Q&A is closed for this session.
+        </p>
       )}
 
       <div className={`${readOnly ? '' : 'mt-5'} space-y-2`}>

--- a/convex/questions.ts
+++ b/convex/questions.ts
@@ -103,6 +103,12 @@ export const upvote = mutation({
     }
     const talk = await liveTalkForRoom(ctx, q.room);
     if (!talk) return { ok: false as const, reason: 'not_counted' as const };
+    // Q&A toggled off mid-talk: writes drop, matching `ask` — the "disabled
+    // means closed" contract. (`list` deliberately stays visible: read-only
+    // history is harmless and yanking the queue mid-talk would be jarring.)
+    if (!resolveConfig(talk).qa) {
+      return { ok: false as const, reason: 'not_counted' as const };
+    }
 
     const already = await ctx.db
       .query('questionVotes')


### PR DESCRIPTION
Step 4 of the whole-system evaluation (#54, #55, #56).

## Why
The "disabled means writes dropped" contract (ADR-0001) had holes: `questions.upvote` ignored the `qa` toggle entirely (upvotes still landed after you switched Q&A off mid-talk), /live rendered the ask box unconditionally (dead form when Q&A is off), and both `QuestionQueue.submit` and `OrderedActions.send` treated **any** non-rate-limit refusal as success — input cleared, "✓ Submitted!", nothing stored.

## What
- **Server:** `upvote` drops when `config.qa` is off, matching `ask`. `list` deliberately stays visible — read-only history is harmless and yanking the queue mid-talk would be jarring (noted in code).
- **QuestionQueue:** derives `qaOn` from the live session config; Q&A off → read-only queue (static vote badges, no ask box) + a small "Q&A is closed" note. Refusals surface inline and keep the typed question.
- **OrderedActions:** non-rate-limit refusals and thrown errors (activity closed mid-type — previously an unhandled rejection) surface inline and keep the typed steps.
- **LivePoll** already handled every refusal shape — untouched.

Verified: lint / typecheck / unit (100/100) / full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)