### PR TITLE
feat(sessions): admin JSON export — archive a session before clear-down

### DIFF
--- a/components/admin/SessionManager.tsx
+++ b/components/admin/SessionManager.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from 'convex/react';
+import { useConvex, useMutation, useQuery } from 'convex/react';
 import { useState } from 'react';
 import { api } from '@/convex/_generated/api';
 import { useRunAction } from './useRunAction';
@@ -11,6 +11,63 @@ function when(ts: number): string {
     hour: '2-digit',
     minute: '2-digit',
   });
+}
+
+/** yyyy-mm-dd for a filesystem-safe archive filename. */
+function ymd(ts: number): string {
+  return new Date(ts).toISOString().slice(0, 10);
+}
+
+/**
+ * Download one session's full data as a JSON archive — the "afterlife" before
+ * clear-down/auto-expiry destroy it (Convex isn't long-term storage; the
+ * presenter files this in their own Drive). The bundle carries the raw
+ * documents, including presenter-only pre-mask originals, so it's admin-gated
+ * server-side; offered on every session so archiving-before-purge is one click.
+ */
+function ExportButton({ room, slug }: { room: string; slug: string }) {
+  const convex = useConvex();
+  const { run, error, busy } = useRunAction();
+
+  const download = () =>
+    run(async () => {
+      const res = await convex.query(api.sessions.exportSession, { room });
+      if (!res.authorized) throw new Error('Not authorized to export.');
+      if (!res.session) throw new Error('Session no longer exists.');
+      const bundle = {
+        exportedAt: new Date().toISOString(),
+        session: res.session,
+        data: res.data,
+      };
+      const blob = new Blob([JSON.stringify(bundle, null, 2)], {
+        type: 'application/json',
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `session-${slug}-${ymd(res.session.startedAt)}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+    });
+
+  return (
+    <span className="flex items-center gap-2">
+      {error && (
+        <span className="font-mono text-xs uppercase text-brutalist-pink">
+          {error}
+        </span>
+      )}
+      <button
+        type="button"
+        disabled={busy}
+        onClick={download}
+        title="Download this session's data as JSON (to archive before clearing)"
+        className="border-2 border-brutalist-cyan px-3 py-1.5 font-mono text-xs font-bold uppercase text-brutalist-cyan hover:bg-brutalist-cyan hover:text-black disabled:opacity-40"
+      >
+        {busy ? '…' : 'Export'}
+      </button>
+    </span>
+  );
 }
 
 function ClearDownButton({
@@ -173,6 +230,7 @@ export default function SessionManager() {
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-2">
+            {s.hasData && <ExportButton room={s.room} slug={s.slug} />}
             <ClearDownButton
               room={s.room}
               live={s.status === 'live'}

--- a/convex/export.test.ts
+++ b/convex/export.test.ts
@@ -1,0 +1,126 @@
+/// <reference types="vite/client" />
+import { describe, expect, test } from 'vitest';
+import { api } from './_generated/api';
+import type { Id } from './_generated/dataModel';
+import { asAdmin, asNonAdmin, harness } from './test.helpers';
+
+/**
+ * The session export is the archive-before-purge escape hatch (F4): it returns
+ * the raw documents — including presenter-only pre-mask originals — so it must
+ * be admin-gated, and it must actually gather every table's rows for the room.
+ */
+
+async function seedSession(
+  t: ReturnType<typeof harness>,
+): Promise<Id<'talks'>> {
+  const room = (await t.run((ctx) =>
+    ctx.db.insert('talks', {
+      slug: 'export-deck',
+      title: 'Export',
+      status: 'ended',
+      startedAt: 1,
+      endedAt: 2,
+    }),
+  )) as Id<'talks'>;
+  await t.run(async (ctx) => {
+    await ctx.db.insert('attendees', { room, machineId: 'm', firstSeen: 1 });
+    await ctx.db.insert('reactionTotals', { room, emoji: '🔥', total: 4 });
+    const questionId = await ctx.db.insert('questions', {
+      room,
+      text: 'q',
+      votes: 2,
+      answered: false,
+      hidden: false,
+      createdAt: 1,
+    });
+    await ctx.db.insert('questionVotes', { questionId, machineId: 'm' });
+    const pollId = await ctx.db.insert('polls', {
+      room,
+      prompt: 'p',
+      status: 'closed',
+      createdAt: 1,
+    });
+    await ctx.db.insert('pollWords', { pollId, word: 'w', count: 3 });
+    await ctx.db.insert('pollSubmitters', { pollId, machineId: 'm', count: 1 });
+    const activityId = await ctx.db.insert('activities', {
+      room,
+      prompt: 'a',
+      options: ['x'],
+      revealAt: null,
+      revealed: true,
+      status: 'closed',
+      createdAt: 1,
+    });
+    await ctx.db.insert('activitySubmissions', {
+      activityId,
+      room,
+      steps: ['s'],
+      hidden: false,
+      createdAt: 1,
+    });
+  });
+  return room;
+}
+
+describe('sessions.exportSession', () => {
+  test('refuses a non-admin (no data leaks)', async () => {
+    const t = harness();
+    const room = await seedSession(t);
+    expect(await t.query(api.sessions.exportSession, { room })).toMatchObject({
+      authorized: false,
+    });
+    const nonAdmin = await asNonAdmin(t);
+    expect(
+      await nonAdmin.query(api.sessions.exportSession, { room }),
+    ).toMatchObject({ authorized: false });
+  });
+
+  test('admin gets the session row plus every table populated', async () => {
+    const t = harness();
+    const room = await seedSession(t);
+    const admin = await asAdmin(t);
+    const res = await admin.query(api.sessions.exportSession, { room });
+
+    expect(res.authorized).toBe(true);
+    if (!res.authorized || !res.session) throw new Error('expected a bundle');
+    expect(res.session.slug).toBe('export-deck');
+    expect(res.data.attendees).toHaveLength(1);
+    expect(res.data.reactionTotals).toHaveLength(1);
+    expect(res.data.questions).toHaveLength(1);
+    expect(res.data.questionVotes).toHaveLength(1);
+    expect(res.data.polls).toHaveLength(1);
+    expect(res.data.pollWords).toHaveLength(1);
+    expect(res.data.pollSubmitters).toHaveLength(1);
+    expect(res.data.activities).toHaveLength(1);
+    expect(res.data.activitySubmissions).toHaveLength(1);
+  });
+
+  test('a second session is not mixed into the export', async () => {
+    const t = harness();
+    const room = await seedSession(t);
+    await seedSession(t); // a second, unrelated session
+    const admin = await asAdmin(t);
+    const res = await admin.query(api.sessions.exportSession, { room });
+    if (!res.authorized || !res.session) throw new Error('expected a bundle');
+    // Only the target room's single row per table — not the other session's.
+    expect(res.data.attendees).toHaveLength(1);
+    expect(res.data.questionVotes).toHaveLength(1);
+    expect(res.data.pollWords).toHaveLength(1);
+  });
+
+  test('returns session: null for an unknown room', async () => {
+    const t = harness();
+    const admin = await asAdmin(t);
+    const ghost = (await t.run((ctx) =>
+      ctx.db.insert('talks', {
+        slug: 'ghost',
+        title: 'G',
+        status: 'ended',
+        startedAt: 1,
+      }),
+    )) as Id<'talks'>;
+    await t.run((ctx) => ctx.db.delete(ghost));
+    const res = await admin.query(api.sessions.exportSession, { room: ghost });
+    expect(res).toMatchObject({ authorized: true, session: null });
+  });
+});

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -89,6 +89,111 @@ export const list = query({
 });
 
 /**
+ * Admin: full JSON archive of one session's data — the escape hatch before
+ * clear-down / auto-expiry destroy it (Convex is not long-term storage; the
+ * presenter archives this to their own Google Drive). Returns the raw
+ * documents (not a projection) so the bundle stays complete as the schema
+ * grows — including the presenter-only pre-mask originals (ADR-0002), which is
+ * exactly why this is admin-gated. Bounded by one session's data (same scope
+ * `purgeSessionData` walks).
+ */
+export const exportSession = query({
+  args: { room: v.string() },
+  handler: async (ctx, { room }) => {
+    if (!(await isAdminUser(ctx))) return { authorized: false as const };
+
+    const session = await ctx.db.get(room as Id<'talks'>);
+    if (!session) return { authorized: true as const, session: null };
+
+    // Query each table with its literal index so row types stay precise (a
+    // generic helper would widen them into a union and lose the child ids).
+    const [
+      attendees,
+      reactionTotals,
+      questions,
+      polls,
+      activities,
+      activitySubmissions,
+    ] = await Promise.all([
+      ctx.db
+        .query('attendees')
+        .withIndex('by_room_firstSeen', (q) => q.eq('room', room))
+        .collect(),
+      ctx.db
+        .query('reactionTotals')
+        .withIndex('by_room', (q) => q.eq('room', room))
+        .collect(),
+      ctx.db
+        .query('questions')
+        .withIndex('by_room_created', (q) => q.eq('room', room))
+        .collect(),
+      ctx.db
+        .query('polls')
+        .withIndex('by_room_created', (q) => q.eq('room', room))
+        .collect(),
+      ctx.db
+        .query('activities')
+        .withIndex('by_room_created', (q) => q.eq('room', room))
+        .collect(),
+      ctx.db
+        .query('activitySubmissions')
+        .withIndex('by_room_created', (q) => q.eq('room', room))
+        .collect(),
+    ]);
+
+    // Child rows are keyed by parent, not room — gather them per parent.
+    const questionVotes = (
+      await Promise.all(
+        questions.map((q) =>
+          ctx.db
+            .query('questionVotes')
+            .withIndex('by_question_machine', (row) =>
+              row.eq('questionId', q._id),
+            )
+            .collect(),
+        ),
+      )
+    ).flat();
+    const pollWords = (
+      await Promise.all(
+        polls.map((p) =>
+          ctx.db
+            .query('pollWords')
+            .withIndex('by_poll', (row) => row.eq('pollId', p._id))
+            .collect(),
+        ),
+      )
+    ).flat();
+    const pollSubmitters = (
+      await Promise.all(
+        polls.map((p) =>
+          ctx.db
+            .query('pollSubmitters')
+            .withIndex('by_poll_machine', (row) => row.eq('pollId', p._id))
+            .collect(),
+        ),
+      )
+    ).flat();
+
+    return {
+      authorized: true as const,
+      session,
+      data: {
+        attendees,
+        reactionTotals,
+        questions,
+        questionVotes,
+        polls,
+        pollWords,
+        pollSubmitters,
+        activities,
+        activitySubmissions,
+      },
+    };
+  },
+});
+
+/**
  * Each room-scoped table paired with its room index. This single map is the
  * source of truth for `purgeByRoom`, so a table can only ever be purged through
  * its correct room-keyed index — a mismatched pairing is impossible to express


### PR DESCRIPTION
Step 7 of the whole-system evaluation — **the export system you asked for** (F4). Session data is destroy-by-design (clear-down + the 30-day reaper), so this gives it an afterlife: a one-click JSON archive to file in your own Drive.

> **Base:** targets `eval/convex-authz-purge-tests` (#58), not `main` — the export test reuses that PR's `test.helpers.ts`. Merge #58 first, then this retargets to `main` cleanly. The product code (query + button) is independent of #58.

## What
- **`sessions.exportSession`** (admin query): the full session row + every per-Session table's rows for the room (attendees, reaction totals, questions + votes, polls + words + submitters, activities + submissions). Returns **raw documents**, not a projection — so the bundle stays complete as the schema grows, and automatically includes the presenter-only pre-mask originals (ADR-0002) once #56 lands. That retained text is exactly why it's `isAdminUser`-gated.
- **SessionManager "Export" button**, left of Clear down (archive-then-purge reads left-to-right). Downloads `session-<slug>-<date>.json` client-side via `useConvex().query`; errors surface through `useRunAction`.
- **export.test.ts:** non-admin refusal (no leak), admin bundle completeness, no cross-session bleed, `session: null` for a deleted room.

Drive upload stays manual (you file the download) unless you want that automated later.

Verified: convex suite (18 incl. 4 new) / typecheck / lint / build.

## ⚠️ Heads-up (not part of this PR)
While branching I found two **untracked** files in the working tree I didn't create — `convex/talks.test.ts` (a "follow in-slide build step" feature, importing my `test.helpers.ts`) and `data/talks/zz-step-probe.mdx`. Looks like **another agent session is working in this same repo concurrently**. I left both untouched and excluded them from every commit. Worth confirming that other session is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)