### PR TITLE
feat(talks): archive four pre-blog slides.com decks as themed talks

### DIFF
--- a/data/talks/aws-batch-mapreduce.mdx
+++ b/data/talks/aws-batch-mapreduce.mdx
@@ -1,0 +1,127 @@
+---
+title: Map/Reduce with AWS Batch
+date: '2022-09-10'
+event: Tech Talk
+audience: Developers
+summary: Batch compute without babysitting servers. Where AWS Batch sits on the serverless spectrum, how compute environments and task definitions fit together, and how to shape a classic map/reduce job — fanning out over NYC taxi data to build a visualisation. Recreated in the talks format from the original 2022 slides.com deck.
+tags: ['aws', 'aws-batch', 'mapreduce', 'cloud', 'talks']
+durationMins: 20
+draft: true
+---
+
+<div style={{ fontFamily: '"IBM Plex Mono", monospace', fontSize: '0.8rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#39ff14' }}>● AWS Batch Map/Reduce · 2022</div>
+
+# {'{'}AWS Batch{'}'}
+
+### Implementing Map/Reduce with AWS Batch
+
+**Ryan Kelly**
+
+> Fan a big job out over a fleet you never have to manage.
+
+???
+
+[⏱ 0–2 · INTRO] The idea: AWS Batch runs containerised jobs at scale without you
+running the cluster. We'll use it to do map/reduce over a real dataset.
+
+---
+
+# WHERE DOES BATCH FIT?
+
+AWS gives you a **spectrum** of compute, trading control for convenience.
+
+<Diagram type="mermaid" caption="The serverless spectrum">
+{`flowchart LR
+  A["EC2<br/>you manage it all"] --> B["AWS Batch<br/>managed job queue"]
+  B --> C["Fargate<br/>serverless containers"]
+  C --> D["Lambda<br/>serverless functions"]`}
+</Diagram>
+
+Batch sits in the sweet spot for **large, parallel, batch** workloads.
+
+???
+
+[⏱ 2–5] Frame Batch against Lambda and raw EC2. Lambda is great until the job is
+too big or too long; EC2 means running your own cluster. Batch queues and schedules
+container jobs for you.
+
+---
+
+# TWO BUILDING BLOCKS
+
+**Compute Environments** — the *where*:
+
+- EC2 Spot, EC2 On-Demand, or **Fargate**
+- Batch scales the fleet up and down to match the queue
+
+**Task (Job) Definitions** — the *what*:
+
+- Container spec: image, vCPU, memory, command
+
+???
+
+[⏱ 5–9] Two concepts do most of the work. Compute environment = the pool of
+capacity (Spot to save money); job definition = the container blueprint. A job
+queue ties them together.
+
+---
+
+# WHAT IS MAP/REDUCE?
+
+> MapReduce is a programming model… for processing and generating big data sets
+> with a parallel, distributed algorithm on a cluster. — *Wikipedia*
+
+<Diagram type="mermaid" caption="Map, then reduce">
+{`flowchart LR
+  I["Input<br/>split into chunks"] --> M1["map"]
+  I --> M2["map"]
+  I --> M3["map"]
+  M1 --> R["reduce<br/>combine results"]
+  M2 --> R
+  M3 --> R
+  R --> O["Output"]`}
+</Diagram>
+
+**Map** each chunk in parallel, then **reduce** the partial results into one answer.
+
+???
+
+[⏱ 9–12] Classic pattern. On Batch: each map is a job over a slice of the data;
+the reduce job depends on the maps finishing (job dependencies) and combines them.
+
+---
+
+# THE DEMO
+
+Load **NYC taxi data** and build a video visualisation.
+
+- **Map** — process trip data in parallel slices
+- **Reduce** — stitch frames into a visualisation
+- Batch fans the maps out across the compute environment, then runs the reduce
+
+<NoteBlock title="Code" color="green">
+github.com/rtkelly13/AWSBatch-MapReduce
+</NoteBlock>
+
+???
+
+[⏱ 12–18 · DEMO 🚀] Walk the repo: job definitions for map and reduce, the queue,
+and the dependency that makes reduce wait. Show the resulting visualisation if the
+render's ready.
+
+---
+
+# TO THE DEMO! 🚀
+
+<div style={{ fontFamily: '"IBM Plex Mono", monospace', fontWeight: 700, color: '#39ff14', marginTop: '0.5rem' }}>github.com/rtkelly13/AWSBatch-MapReduce</div>
+
+- Batch = managed, parallel, containerised jobs
+- Compute environment (the where) + job definition (the what)
+- Map/reduce falls out naturally with job dependencies
+
+**Thanks!** 👋
+
+???
+
+[⏱ 18–20 · CLOSE] Recap the two building blocks and point at the repo. Take
+questions.

--- a/data/talks/paket-and-its-perks.mdx
+++ b/data/talks/paket-and-its-perks.mdx
@@ -1,0 +1,183 @@
+---
+title: Paket and its Perks
+date: '2018-07-13'
+event: .NET Talk
+audience: Developers
+summary: A dependency manager built for reproducible builds. Why lock files matter, how transitive dependencies bite you, and what Paket adds on top of the NuGet ecosystem — global version resolution, a real CLI, groups, and a pile of extra features. Recreated in the talks format from the original 2018 slides.com deck.
+tags: ['dotnet', 'paket', 'nuget', 'build', 'talks']
+durationMins: 25
+draft: true
+---
+
+<div style={{ fontFamily: '"IBM Plex Mono", monospace', fontSize: '0.8rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#facc15' }}>● Paket and its Perks · 2018</div>
+
+# PAKET AND ITS PERKS
+
+### Dependency management for reproducible .NET builds
+
+**Ryan Kelly**
+
+> The build that works on your machine should work on every machine — forever.
+
+???
+
+[⏱ 0–2 · INTRO] The promise of Paket in one line: reproducible builds. Everything
+in this talk hangs off that goal.
+
+---
+
+# REPRODUCIBLE BUILDS
+
+The same source should produce the **same output** — today, next year, on CI, on a
+teammate's laptop.
+
+- No "works on my machine"
+- No silent dependency drift
+- A build you can trust a year from now
+
+???
+
+[⏱ 2–4] Define the enemy: dependency drift. A transitive package quietly bumps and
+your "unchanged" build behaves differently. Reproducibility is the fix.
+
+---
+
+# LOCK-BASED SOURCE CONTROL
+
+Other ecosystems solved this with a **lock file**:
+
+- **npm** — `package-lock.json`
+- **pip** — `requirements.txt` (pinned)
+- **Cargo, Bundler, Composer…** — same idea
+
+The lock file records the *exact* resolved graph, so everyone restores identical versions.
+
+???
+
+[⏱ 4–7] Paket brings the lock-file discipline that npm/pip/cargo already have to
+.NET. `paket.dependencies` = what you want; `paket.lock` = exactly what you got.
+
+---
+
+# THE PROBLEM WITH raw csproj
+
+Traditional package references leave gaps:
+
+- Versions pinned **per-project**, not solution-wide → the same package at
+  different versions across projects
+- **Unknown transitive dependencies** — you never explicitly see what your
+  packages dragged in
+- No single source of truth for the whole graph
+
+???
+
+[⏱ 7–10] The classic .NET pain: two projects in one solution resolve the same
+dependency to different versions. And the transitive graph is invisible.
+
+---
+
+# WHY IT MATTERS: SUPPLY CHAIN
+
+Loose dependency management is a **security** problem too.
+
+- **Malicious package attacks** — a compromised version slips in
+- Version **consolidation** — one version, reviewed, across the whole solution
+- **Unknown transitive dependencies** — you can't audit what you can't see
+
+<NoteBlock title="Reproducibility = auditability" color="yellow">
+If your build isn't reproducible, you can't be sure *what* you actually shipped.
+</NoteBlock>
+
+???
+
+[⏱ 10–13] Tie reproducibility to security. A pinned, visible, consolidated graph
+is one you can actually review. This landed harder over the years as supply-chain
+attacks grew.
+
+---
+
+# PAKET: YET ANOTHER PACKAGE MANAGER
+
+So what does Paket add?
+
+- Versions managed **globally** (solution-wide) vs per-project
+- A real **CLI** experience vs GUI-focused workflows
+- **Reproducible builds** by default (lock file)
+- **Compatible** with the existing NuGet ecosystem — same feeds, same packages
+
+???
+
+[⏱ 13–16] The elevator pitch. Crucially it's not a rival registry — it sits on top
+of NuGet. You lose nothing, you gain the lock file and global resolution.
+
+---
+
+# HOW DOES IT WORK?
+
+Three files tell the whole story:
+
+<Diagram type="mermaid" caption="Paket's three files">
+{`flowchart LR
+  A["paket.dependencies<br/>what you want"] --> B["paket.lock<br/>exactly what resolved"]
+  B --> C["paket.references<br/>per-project needs"]`}
+</Diagram>
+
+`dependencies` declares intent, `lock` pins the resolved graph, `references` says which project uses what.
+
+???
+
+[⏱ 16–19] Walk the three files. The lock file is the star — commit it, and every
+restore anywhere reproduces the exact graph.
+
+---
+
+# LET'S CONVERT A PROJECT
+
+Migration is straightforward:
+
+1. `paket init`
+2. Move your NuGet references into `paket.dependencies`
+3. `paket install` — generates the lock file and wires up projects
+4. Commit `paket.lock`
+
+From here, every restore is reproducible.
+
+???
+
+[⏱ 19–22 · DEMO] Live-convert a small project if there's a machine. Otherwise walk
+the four steps. The payoff is the committed lock file.
+
+---
+
+# EXTRA PERKS
+
+Once you're in, you get a lot for free:
+
+- Build **NuGet packages** automatically
+- **Source dependencies** right inside `paket.dependencies` (GitHub files, gists)
+- **Groups** — isolate build-only or test-only dependencies
+- **Build scripts** — generate CSX/FSX DLL includes
+- **Local builds** — clone and build repos locally
+- **Package caches**, **feed credentials**, **overridden packages**
+
+???
+
+[⏱ 22–24] The "perks" of the title. Groups and source dependencies are the
+sleepers — most people come for reproducibility and stay for these.
+
+---
+
+# TAKEAWAY
+
+<div style={{ fontFamily: '"IBM Plex Mono", monospace', fontWeight: 700, color: '#facc15', marginTop: '0.5rem' }}>Same NuGet ecosystem — plus a lock file you can trust.</div>
+
+- Reproducible builds by default
+- Global, auditable dependency graph
+- A pile of extras once you're in
+
+**Thanks!** 👋
+
+???
+
+[⏱ 24–25 · CLOSE] One line to remember: Paket = NuGet + a lock file + global
+resolution. Take questions.

--- a/data/talks/railway-oriented-programming.mdx
+++ b/data/talks/railway-oriented-programming.mdx
@@ -1,0 +1,315 @@
+---
+title: Railway Oriented Programming
+date: '2018-04-13'
+event: F# Talk
+audience: Developers
+summary: Error handling as a first-class value. Why exceptions, error-callbacks, null and ad-hoc result objects all fall short — and how F#'s Result type lets you model success and failure honestly, then compose them with map, bind and mapError. Recreated in the talks format from the original 2018 slides.com deck.
+tags: ['fsharp', 'functional-programming', 'error-handling', 'talks']
+durationMins: 30
+draft: true
+---
+
+<div style={{ fontFamily: '"IBM Plex Mono", monospace', fontSize: '0.8rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#ec4899' }}>● Railway Oriented Programming · 2018</div>
+
+# RAILWAY ORIENTED PROGRAMMING
+
+### Error handling you can actually see in the types
+
+**Ryan Kelly**
+
+> Success and failure as two tracks — and the points that switch between them.
+
+???
+
+[⏱ 0–2 · INTRO] Set the frame: we handle errors constantly, but most of the ways
+we do it hide the failure from the type system. Today: make failure explicit and
+composable.
+
+---
+
+# WHAT PROBLEM ARE WE SOLVING?
+
+Almost every useful function can **fail**:
+
+- Parse a string that isn't a number
+- Fetch a record that doesn't exist
+- Call a service that's down
+
+The question isn't *whether* things fail — it's whether the **type** tells you they can.
+
+???
+
+[⏱ 2–4] The thesis in one line: an honest signature admits it can fail. Everything
+that follows is about getting failure into the return type.
+
+---
+
+# THE USUAL SUSPECTS
+
+Four ways we already handle errors — each with a catch.
+
+<Diagram type="mermaid" caption="Ways to signal failure">
+{`flowchart TB
+  A["Exceptions"] --> E["something is hidden<br/>from the caller"]
+  B["callback(err, result)"] --> E
+  C["Default values / null"] --> E
+  D["Ad-hoc Result objects"] --> E`}
+</Diagram>
+
+Let's take them one at a time.
+
+???
+
+[⏱ 4–5] Preview the next four slides. The common thread: the compiler doesn't make
+you deal with the failure.
+
+---
+
+# EXCEPTIONS
+
+Basically a **goto** with nicer syntax.
+
+- Any line *could* be doing something you don't expect
+- Often the simplest thing to reach for
+
+<NoteBlock title="Main issue" color="red">
+**Magic code paths** — control can leave a function from anywhere, invisibly.
+</NoteBlock>
+
+???
+
+[⏱ 5–8] Exceptions aren't evil, but they're invisible in the signature. `int
+Parse(string)` doesn't tell you it throws. Control flow you can't see.
+
+---
+
+# callback(err, result)
+
+The Node.js classic.
+
+- You must check `err` **before** touching `result`
+- Every layer has to handle — or forward — the error
+
+<NoteBlock title="Main issue" color="red">
+**Too much boilerplate** — and nothing forces you to check `err` first.
+</NoteBlock>
+
+???
+
+[⏱ 8–10] Convention, not enforcement. Forget the check and you read a `result`
+that was never valid.
+
+---
+
+# DEFAULT VALUES & null
+
+"If in doubt, return `null`" — or `0`, or `1970-01-01`.
+
+- `Option<'a>` is better, but still only says *"nothing"*
+
+<NoteBlock title="Main issue" color="red">
+**No explanation of the error** — you know it failed, not *why*.
+</NoteBlock>
+
+???
+
+[⏱ 10–12] Option is a real step up (no null), but a bare `None` throws away the
+reason. Sometimes you need the why.
+
+---
+
+# AD-HOC RESULT OBJECTS
+
+Roll your own bag of fields:
+
+```csharp
+public class Result<T> {
+    public bool HasError { get; set; }
+    public T Value { get; set; }
+    public string Error { get; set; }
+}
+```
+
+<NoteBlock title="Main issue" color="red">
+**Nothing forces the caller to handle the error** — `Value` is readable even when `HasError` is true.
+</NoteBlock>
+
+???
+
+[⏱ 12–14] So close — but the two states aren't mutually exclusive in the type. You
+can read a value that isn't there. We want the compiler to stop that.
+
+---
+
+# WHAT ABOUT Either?
+
+Abstracts a **Left** and a **Right**:
+
+```fsharp
+type Either<'a, 'b> =
+  | Left of 'a
+  | Right of 'b
+```
+
+<NoteBlock title="Main issue" color="red">
+Which side is the error? By convention it's the **Left** — but you have to *know* that.
+</NoteBlock>
+
+???
+
+[⏱ 14–16] Either has the right shape — a union, two mutually exclusive cases — but
+Left/Right carry no meaning. We want the names to say what they mean.
+
+---
+
+# WHAT DO WE ACTUALLY WANT?
+
+- **Simple semantics** — easy to read at the call site
+- **Unambiguous** — no "which side is the error?"
+- **Defer errors** — carry failure along, handle it later
+- **Honest APIs** — the signature admits it can fail
+- **Explicit consumption** — you *must* deal with both cases
+
+???
+
+[⏱ 16–18] This is the checklist. Next slide is the type that ticks every box.
+
+---
+
+# THE RESULT TYPE
+
+A union of an **Ok** and an **Error** — named, unambiguous, exhaustive.
+
+```fsharp
+type Result<'T,'TError> =
+  | Ok of ResultValue:'T
+  | Error of ErrorValue:'TError
+```
+
+The names *are* the documentation. You can't read an `Ok` value out of an `Error`.
+
+???
+
+[⏱ 18–20] The payoff. Built into F#. Pattern matching forces you to handle both
+cases or the compiler complains. Now let's use it.
+
+---
+
+# THREE PHASES
+
+Working with `Result` breaks into three moves:
+
+<Diagram type="mermaid" caption="The shape of every Result workflow">
+{`flowchart LR
+  A["Construction<br/>get into Result"] --> B["Pipelining<br/>transform inside"]
+  B --> C["Consumption<br/>get back out"]`}
+</Diagram>
+
+???
+
+[⏱ 20–21] Map the rest of the talk: construct → pipeline → consume. Same three
+beats every time.
+
+---
+
+# CONSTRUCTION
+
+Get a raw value **into** a `Result`:
+
+```fsharp
+let construction value =
+    match System.Int32.TryParse(value) with
+    | (true, int) -> Ok int
+    | _ -> sprintf "Could not parse value %s" value |> Error
+```
+
+Signature: `string -> Result<int, string>` — honest about failing.
+
+???
+
+[⏱ 21–23] The boundary. Once a value is inside a Result, everything downstream
+composes. Note the signature tells the whole story.
+
+---
+
+# PIPELINING
+
+Transform the value **without** leaving the track:
+
+```fsharp
+let pipeline value =
+    value
+    |> parseInt
+    |> Result.bind (fun x ->
+        if x > 10 then Ok x
+        else Error "Value must be greater than 10")
+    |> Result.map (fun x -> x * 2)
+    |> Result.mapError (fun error -> sprintf "Error: %s" error)
+```
+
+Errors short-circuit; the happy path flows on.
+
+???
+
+[⏱ 23–26] This is the "railway": Ok stays on the main line, Error diverts to the
+error track and skips the rest. Three combinators do the switching — next three
+slides.
+
+---
+
+# map · bind · mapError
+
+The three combinators that keep you on the rails:
+
+| Combinator | When it runs | What it takes |
+| --- | --- | --- |
+| `Result.map` | on **Ok** | `'a -> 'b` |
+| `Result.bind` | on **Ok** | `'a -> Result<'b,'e>` |
+| `Result.mapError` | on **Error** | `'e -> 'f` |
+
+`map` transforms a value; `bind` chains another failable step; `mapError` reshapes the failure.
+
+???
+
+[⏱ 26–28] The whole algebra on one slide. bind is the important one — it's how you
+compose two things that can each fail without nesting.
+
+---
+
+# CONSUMPTION
+
+Finally, get a value back **out** — and you must handle both cases:
+
+```fsharp
+let consumption value =
+    match value |> pipeline with
+    | Ok ok -> ok
+    | Error error -> failwith error
+```
+
+Same pattern match as any other union — the compiler makes sure you cover both.
+
+???
+
+[⏱ 28–29] At the edge of the system you collapse the Result — log it, return an
+HTTP code, throw. But you decide, explicitly, and the compiler holds you to it.
+
+---
+
+# THERE'S MUCH MORE
+
+This is just a glimpse. Where it goes next:
+
+- **Computation expressions** — `result { ... }` to hide the plumbing
+- **Result aggregation** — collect many results into one
+- **Tee** — run side effects without leaving the track
+- **Kleisli composition** — glue failable functions together
+
+<div style={{ fontFamily: '"IBM Plex Mono", monospace', fontWeight: 700, color: '#ec4899', marginTop: '1rem' }}>Model failure in the type — then let composition do the work.</div>
+
+**Thanks!** 👋
+
+???
+
+[⏱ 29–30 · CLOSE] Leave them with the one idea: put failure in the return type and
+everything else composes. Take questions.

--- a/data/talks/the-safe-stack.mdx
+++ b/data/talks/the-safe-stack.mdx
@@ -1,0 +1,142 @@
+---
+title: What is the SAFE Stack?
+date: '2019-01-24'
+event: F# Talk
+audience: Developers
+summary: An end-to-end F# web stack. Saturn and Giraffe on the server, Fable compiling F# to JavaScript on the client, and Elmish bringing the Elm Model-View-Update pattern to the browser — one language from the database to the DOM. Recreated in the talks format from the original 2019 slides.com deck.
+tags: ['fsharp', 'safe-stack', 'fable', 'web', 'talks']
+durationMins: 20
+draft: true
+---
+
+<div style={{ fontFamily: '"IBM Plex Mono", monospace', fontSize: '0.8rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#22d3ee' }}>● The SAFE Stack · 2019</div>
+
+# WHAT IS THE SAFE STACK?
+
+### F# from the database to the DOM
+
+**Ryan Kelly**
+
+> One language, one type system, all the way through the web app.
+
+???
+
+[⏱ 0–2 · INTRO] The pitch: full-stack web development where server and client are
+both F#, sharing types across the wire. No context-switching between languages.
+
+---
+
+# SAFE = SATURN · AZURE · FABLE · ELMISH
+
+Four pieces, one acronym:
+
+<Diagram type="mermaid" caption="The SAFE stack, end to end">
+{`flowchart LR
+  DB[("Data")] --> S["Saturn + Giraffe<br/>(server)"]
+  S -->|"shared F# types"| F["Fable<br/>(F# → JS)"]
+  F --> E["Elmish<br/>(MVU in the browser)"]
+  E --> U["UI"]
+  A["Azure<br/>(hosting)"] -.-> S`}
+</Diagram>
+
+The magic: the **same F# types** describe your API on both sides of the wire.
+
+???
+
+[⏱ 2–4] Walk the pipeline. The standout property is shared types — define a record
+once, use it on server and client, and the compiler catches a mismatch.
+
+---
+
+# SATURN + GIRAFFE
+
+The server layer.
+
+- **Giraffe** — functional wrappers over ASP.NET Core
+- **Saturn** — an opinionated, MVC-flavoured layer on top of Giraffe
+
+You get ASP.NET Core's performance with a composable, functional routing model.
+
+<NoteBlock title="Docs" color="blue">
+saturnframework.org · giraffe-fsharp Giraffe docs
+</NoteBlock>
+
+???
+
+[⏱ 4–7] Giraffe is the low-level HttpHandler pipeline; Saturn is the batteries-
+included layer if you want structure. Both are just ASP.NET Core underneath.
+
+---
+
+# FABLE
+
+The client layer: **F# |> Babel**.
+
+- Compiles **F# to JavaScript** using Babel as the transpiler
+- Ties in heavily with the JS ecosystem — npm packages, React, the lot
+- Designed to be highly compatible with existing JS tooling
+
+<NoteBlock title="Docs" color="blue">
+fable.io
+</NoteBlock>
+
+???
+
+[⏱ 7–10] This is what makes the "F# in the browser" claim real. You still reach
+into the npm ecosystem, but you write F#. Interop is first-class.
+
+---
+
+# ELMISH
+
+MVU for the browser.
+
+- A Fable library that, with React/Redux, gives you the **Elm architecture**
+- **Model → View → Update** — a single state, pure update function, rendered view
+- Hot Module Reload via Redux/Webpack
+
+<Diagram type="mermaid" caption="Model-View-Update loop">
+{`flowchart LR
+  M["Model"] --> V["View"]
+  V -->|"message"| U["Update"]
+  U --> M`}
+</Diagram>
+
+???
+
+[⏱ 10–14] MVU is the heart of the client. One immutable model, messages describe
+what happened, update produces the next model. Predictable, testable, time-travel
+debuggable.
+
+---
+
+# FULMA
+
+Styling, the F# way.
+
+- **F# + Bulma** — typed wrappers over the Bulma CSS framework
+- Build your UI with F# functions instead of hand-written class strings
+
+The whole front end — layout, components, styles — stays in F#.
+
+???
+
+[⏱ 14–16] Optional but lovely: Fulma means even your CSS framework is typed. No
+stringly-typed class names.
+
+---
+
+# ONE LANGUAGE, END TO END
+
+<div style={{ fontFamily: '"IBM Plex Mono", monospace', fontWeight: 700, color: '#22d3ee', marginTop: '0.5rem' }}>Saturn ⟶ shared types ⟶ Fable ⟶ Elmish</div>
+
+- Server and client both F#
+- Types shared across the wire — refactor once, both sides update
+- The Elm architecture in the browser, ASP.NET Core on the server
+
+**Thanks!** 👋
+
+???
+
+[⏱ 16–20 · CLOSE] Recap the through-line: it's the shared type system that makes
+SAFE more than "F# on both ends." Take questions.


### PR DESCRIPTION
Recreates the general arc of four pre-blog [slides.com/ryankelly](https://slides.com/ryankelly) decks in the blog's talks MDX format. Each preserves its **original creation date** and gets a **distinct signature accent** for differentiation.

## The four talks

| Talk | Original date | Accent |
| --- | --- | --- |
| Railway Oriented Programming | 2018-04-13 | magenta `#ec4899` |
| Paket and its Perks | 2018-07-13 | amber `#facc15` |
| The SAFE Stack | 2019-01-24 | cyan `#22d3ee` |
| Map/Reduce with AWS Batch | 2022-09-10 | terminal green `#39ff14` |

## Preview URLs (once Vercel builds)

Talks ship as `draft: true`, so they're admin-only in the listing but the pages still build — reach them directly on the preview deployment:

- `/talks/railway-oriented-programming/present`
- `/talks/paket-and-its-perks/present`
- `/talks/the-safe-stack/present`
- `/talks/aws-batch-mapreduce/present`

(Drop the `/present` for the landing page. Signed in as admin, they also appear in `/talks` behind a DRAFT badge.)

## Notes / decisions

- **Emulation, not copies** — general structure of each original deck, not slide-for-slide. Code samples rebuilt as real F#/C# fences (Prism-highlighted); diagrams as mermaid. No external image assets — fully self-contained.
- **Theming** — the deck theme is globally fixed (brutalist black), so differentiation lives in-content: a monospace kicker badge, closing accent line, and matching `NoteBlock` colors per talk, echoing each original deck's identity.
- **`draft: true`** — pending review before publishing. Flip to `false` to go live.
- **`event` field** — actual venues unknown, so honest topic-based placeholders (`F# Talk`, `.NET Talk`, `Tech Talk`); each summary notes it's recreated from the original slides.com deck. Update if you recall the real meetups/conferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)