### PR TITLE
feat(graphics): seed-driven SVG background/graphic generators + talk backgrounds

### DIFF
--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -67,7 +67,9 @@ Actions registered via `kbar` API. Add new commands in SearchProvider.
 ## TALKS
 
 The live-talk UI, backed by Convex (see convex/AGENTS.md). Split into the deck
-itself and the embeddable audience widgets.
+itself and the embeddable audience widgets. Deck theming, the SVG **graphics
+generators** (`components/graphics/`), and **named per-slide backgrounds** are
+documented in [docs/talks-graphics.md](../docs/talks-graphics.md).
 
 | Component          | Purpose                                                       |
 | ------------------ | ------------------------------------------------------------ |

--- a/components/graphics/GeneratedBackground.tsx
+++ b/components/graphics/GeneratedBackground.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+import { renderGraphic } from './registry';
+import type { GraphicParams } from './types';
+
+interface GeneratedBackgroundProps extends Partial<GraphicParams> {
+  /** Generator id from the registry (e.g. `node-network`). */
+  generator: string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/**
+ * Renders a graphic generator inline as a full-bleed SVG layer. Decorative, so
+ * it's marked aria-hidden. For CSS/Spectacle backgrounds prefer `graphicDataUri`
+ * (registry) — this component is for the gallery and in-flow decoration.
+ */
+export default function GeneratedBackground({
+  generator,
+  className,
+  style,
+  seed,
+  accent,
+  background,
+  density,
+  opacity,
+  strokeWidth,
+  width,
+  height,
+}: GeneratedBackgroundProps) {
+  // Memoise on the individual primitive params (not the rest object, which is a
+  // fresh reference each render) so the SVG is only rebuilt when a value changes.
+  const svg = useMemo(
+    () =>
+      renderGraphic(generator, {
+        seed,
+        accent,
+        background,
+        density,
+        opacity,
+        strokeWidth,
+        width,
+        height,
+      }),
+    [
+      generator,
+      seed,
+      accent,
+      background,
+      density,
+      opacity,
+      strokeWidth,
+      width,
+      height,
+    ],
+  );
+
+  if (!svg) return null;
+
+  return (
+    <div
+      aria-hidden
+      className={className}
+      style={{ lineHeight: 0, ...style }}
+      // SVG is generated from a fixed template + numeric params — no user input.
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}

--- a/components/graphics/generators.ts
+++ b/components/graphics/generators.ts
@@ -20,8 +20,8 @@ function frame(params: GraphicParams, inner: string): string {
 const dotGrid: RenderFn = (p) => {
   const rng = mulberry32(p.seed);
   const spacing = lerp(96, 34, p.density);
-  const faint = withAlpha(p.accent, 0.12);
-  const bright = withAlpha(p.accent, 0.85);
+  const faint = withAlpha(p.accent, 0.4);
+  const bright = withAlpha(p.accent, 0.95);
   let out = '';
   for (let y = spacing / 2; y < p.height; y += spacing) {
     for (let x = spacing / 2; x < p.width; x += spacing) {
@@ -38,8 +38,8 @@ const dotGrid: RenderFn = (p) => {
 const diagonalHatch: RenderFn = (p) => {
   const rng = mulberry32(p.seed);
   const gap = lerp(70, 20, p.density);
-  const faint = withAlpha(p.accent, 0.1);
-  const bright = withAlpha(p.accent, 0.7);
+  const faint = withAlpha(p.accent, 0.32);
+  const bright = withAlpha(p.accent, 0.9);
   let out = '';
   for (let o = -p.height; o < p.width; o += gap) {
     const hot = chance(rng, 0.12);
@@ -57,8 +57,8 @@ const nodeNetwork: RenderFn = (p) => {
     x: range(rng, 0, p.width),
     y: range(rng, 0, p.height),
   }));
-  const edge = withAlpha(p.accent, 0.18);
-  const dot = withAlpha(p.accent, 0.9);
+  const edge = withAlpha(p.accent, 0.35);
+  const dot = withAlpha(p.accent, 0.95);
   let lines = '';
   for (let i = 0; i < nodes.length; i++) {
     const dists = nodes
@@ -95,7 +95,7 @@ const contourLines: RenderFn = (p) => {
     const freq = range(rng, 1.2, 3.2);
     const phase = range(rng, 0, Math.PI * 2);
     const hot = chance(rng, 0.15);
-    const stroke = hot ? withAlpha(p.accent, 0.8) : withAlpha(p.accent, 0.14);
+    const stroke = hot ? withAlpha(p.accent, 0.9) : withAlpha(p.accent, 0.32);
     let d = '';
     for (let x = 0; x <= p.width; x += step) {
       const y =
@@ -112,9 +112,9 @@ const isoGrid: RenderFn = (p) => {
   const rng = mulberry32(p.seed);
   const cw = lerp(120, 52, p.density);
   const ch = cw * 0.58;
-  const line = withAlpha(p.accent, 0.16);
-  const fill = withAlpha(p.accent, 0.1);
-  const hot = withAlpha(p.accent, 0.55);
+  const line = withAlpha(p.accent, 0.36);
+  const fill = withAlpha(p.accent, 0.22);
+  const hot = withAlpha(p.accent, 0.85);
   let out = '';
   for (let row = -1; row * ch * 0.5 < p.height + ch; row++) {
     for (let col = -1; col * cw < p.width + cw; col++) {
@@ -132,9 +132,9 @@ const isoGrid: RenderFn = (p) => {
 const scatterBlocks: RenderFn = (p) => {
   const rng = mulberry32(p.seed);
   const count = Math.round(lerp(14, 76, p.density));
-  const outline = withAlpha(p.accent, 0.3);
-  const faint = withAlpha(p.accent, 0.08);
-  const solid = withAlpha(p.accent, 0.85);
+  const outline = withAlpha(p.accent, 0.5);
+  const faint = withAlpha(p.accent, 0.22);
+  const solid = withAlpha(p.accent, 0.95);
   let out = '';
   for (let i = 0; i < count; i++) {
     const x = range(rng, 0, p.width);

--- a/components/graphics/generators.ts
+++ b/components/graphics/generators.ts
@@ -1,0 +1,165 @@
+import { withAlpha } from './palette';
+import { chance, intRange, mulberry32, type Rng, range } from './rng';
+import type { GraphicParams, RenderFn } from './types';
+
+/** Linear interpolate — used to map density (0..1) onto per-generator ranges. */
+const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+const r2 = (n: number) => Math.round(n * 100) / 100;
+
+/** Wrap generator marks in a themed <svg> with optional backdrop + opacity. */
+function frame(params: GraphicParams, inner: string): string {
+  const { width, height, opacity, background } = params;
+  const bg =
+    background && background !== 'transparent'
+      ? `<rect width="${width}" height="${height}" fill="${background}"/>`
+      : '';
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="100%" height="100%" preserveAspectRatio="xMidYMid slice" role="img">${bg}<g opacity="${opacity}">${inner}</g></svg>`;
+}
+
+/** Grid of dots with jittered radius; a scatter of them flare to full accent. */
+const dotGrid: RenderFn = (p) => {
+  const rng = mulberry32(p.seed);
+  const spacing = lerp(96, 34, p.density);
+  const faint = withAlpha(p.accent, 0.12);
+  const bright = withAlpha(p.accent, 0.85);
+  let out = '';
+  for (let y = spacing / 2; y < p.height; y += spacing) {
+    for (let x = spacing / 2; x < p.width; x += spacing) {
+      const hot = chance(rng, 0.06 + p.density * 0.14);
+      const rad =
+        (hot ? range(rng, 2.5, 4.5) : range(rng, 1, 2.4)) * (spacing / 40);
+      out += `<circle cx="${r2(x)}" cy="${r2(y)}" r="${r2(rad)}" fill="${hot ? bright : faint}"/>`;
+    }
+  }
+  return frame(p, out);
+};
+
+/** Parallel 45° rules; a few lines pop to accent, the rest stay ghostly. */
+const diagonalHatch: RenderFn = (p) => {
+  const rng = mulberry32(p.seed);
+  const gap = lerp(70, 20, p.density);
+  const faint = withAlpha(p.accent, 0.1);
+  const bright = withAlpha(p.accent, 0.7);
+  let out = '';
+  for (let o = -p.height; o < p.width; o += gap) {
+    const hot = chance(rng, 0.12);
+    const w = hot ? p.strokeWidth * 2.5 : p.strokeWidth * range(rng, 0.5, 1.1);
+    out += `<line x1="${r2(o)}" y1="0" x2="${r2(o + p.height)}" y2="${p.height}" stroke="${hot ? bright : faint}" stroke-width="${r2(w)}"/>`;
+  }
+  return frame(p, out);
+};
+
+/** Constellation / circuit: scattered nodes wired to their nearest neighbours. */
+const nodeNetwork: RenderFn = (p) => {
+  const rng = mulberry32(p.seed);
+  const count = Math.round(lerp(12, 64, p.density));
+  const nodes = Array.from({ length: count }, () => ({
+    x: range(rng, 0, p.width),
+    y: range(rng, 0, p.height),
+  }));
+  const edge = withAlpha(p.accent, 0.18);
+  const dot = withAlpha(p.accent, 0.9);
+  let lines = '';
+  for (let i = 0; i < nodes.length; i++) {
+    const dists = nodes
+      .map((n, j) => ({
+        j,
+        d: (n.x - nodes[i].x) ** 2 + (n.y - nodes[i].y) ** 2,
+      }))
+      .filter((n) => n.j !== i)
+      .sort((a, b) => a.d - b.d)
+      .slice(0, 2);
+    for (const { j } of dists) {
+      if (j > i) {
+        lines += `<line x1="${r2(nodes[i].x)}" y1="${r2(nodes[i].y)}" x2="${r2(nodes[j].x)}" y2="${r2(nodes[j].y)}" stroke="${edge}" stroke-width="${p.strokeWidth}"/>`;
+      }
+    }
+  }
+  let dots = '';
+  for (const n of nodes) {
+    const rad = chance(rng, 0.2) ? range(rng, 4, 7) : range(rng, 2, 3.5);
+    dots += `<circle cx="${r2(n.x)}" cy="${r2(n.y)}" r="${r2(rad)}" fill="${dot}"/>`;
+  }
+  return frame(p, lines + dots);
+};
+
+/** Stacked topographic waves; a couple of bands rise to full accent. */
+const contourLines: RenderFn = (p) => {
+  const rng = mulberry32(p.seed);
+  const count = Math.round(lerp(6, 26, p.density));
+  const step = p.width / 48;
+  let out = '';
+  for (let i = 0; i < count; i++) {
+    const base = ((i + 0.5) * p.height) / count;
+    const amp = range(rng, 6, 30);
+    const freq = range(rng, 1.2, 3.2);
+    const phase = range(rng, 0, Math.PI * 2);
+    const hot = chance(rng, 0.15);
+    const stroke = hot ? withAlpha(p.accent, 0.8) : withAlpha(p.accent, 0.14);
+    let d = '';
+    for (let x = 0; x <= p.width; x += step) {
+      const y =
+        base + Math.sin((x / p.width) * Math.PI * 2 * freq + phase) * amp;
+      d += `${x === 0 ? 'M' : 'L'}${r2(x)} ${r2(y)} `;
+    }
+    out += `<path d="${d.trim()}" fill="none" stroke="${stroke}" stroke-width="${hot ? p.strokeWidth * 1.8 : p.strokeWidth}"/>`;
+  }
+  return frame(p, out);
+};
+
+/** Isometric lattice of diamonds; some cells fill with faint accent. */
+const isoGrid: RenderFn = (p) => {
+  const rng = mulberry32(p.seed);
+  const cw = lerp(120, 52, p.density);
+  const ch = cw * 0.58;
+  const line = withAlpha(p.accent, 0.16);
+  const fill = withAlpha(p.accent, 0.1);
+  const hot = withAlpha(p.accent, 0.55);
+  let out = '';
+  for (let row = -1; row * ch * 0.5 < p.height + ch; row++) {
+    for (let col = -1; col * cw < p.width + cw; col++) {
+      const cx = col * cw + (row % 2 ? cw / 2 : 0);
+      const cy = (row * ch) / 2;
+      const path = `M${r2(cx)} ${r2(cy - ch / 2)} L${r2(cx + cw / 2)} ${r2(cy)} L${r2(cx)} ${r2(cy + ch / 2)} L${r2(cx - cw / 2)} ${r2(cy)} Z`;
+      const flare = chance(rng, 0.05 + p.density * 0.1);
+      out += `<path d="${path}" fill="${flare ? hot : chance(rng, 0.12) ? fill : 'none'}" stroke="${line}" stroke-width="${p.strokeWidth}"/>`;
+    }
+  }
+  return frame(p, out);
+};
+
+/** Brutalist confetti: scattered rotated squares — outlined, faint, or solid. */
+const scatterBlocks: RenderFn = (p) => {
+  const rng = mulberry32(p.seed);
+  const count = Math.round(lerp(14, 76, p.density));
+  const outline = withAlpha(p.accent, 0.3);
+  const faint = withAlpha(p.accent, 0.08);
+  const solid = withAlpha(p.accent, 0.85);
+  let out = '';
+  for (let i = 0; i < count; i++) {
+    const x = range(rng, 0, p.width);
+    const y = range(rng, 0, p.height);
+    const size = range(rng, 8, 46);
+    const rot = intRange(rng, 0, 45);
+    const roll = rng();
+    const style =
+      roll < 0.18
+        ? `fill="${solid}"`
+        : roll < 0.5
+          ? `fill="${faint}"`
+          : `fill="none" stroke="${outline}" stroke-width="${p.strokeWidth}"`;
+    out += `<rect x="${r2(x)}" y="${r2(y)}" width="${r2(size)}" height="${r2(size)}" transform="rotate(${rot} ${r2(x + size / 2)} ${r2(y + size / 2)})" ${style}/>`;
+  }
+  return frame(p, out);
+};
+
+export const GENERATORS: Record<string, RenderFn> = {
+  'dot-grid': dotGrid,
+  'diagonal-hatch': diagonalHatch,
+  'node-network': nodeNetwork,
+  contour: contourLines,
+  'iso-grid': isoGrid,
+  'scatter-blocks': scatterBlocks,
+};
+
+export type { Rng };

--- a/components/graphics/index.ts
+++ b/components/graphics/index.ts
@@ -1,0 +1,11 @@
+export { default as GeneratedBackground } from './GeneratedBackground';
+export { ACCENT_SWATCHES, BRUTALIST_ACCENTS, withAlpha } from './palette';
+export {
+  GENERATOR_LIST,
+  getGenerator,
+  graphicDataUri,
+  renderGraphic,
+  resolveParams,
+} from './registry';
+export type { Generator, GraphicParams, RenderFn } from './types';
+export { BASE_PARAMS } from './types';

--- a/components/graphics/palette.ts
+++ b/components/graphics/palette.ts
@@ -1,0 +1,33 @@
+/**
+ * The brutalist accent palette, mirrored from tailwind.config.js so generators
+ * and the gallery share one source of swatches. Keep in sync with the Tailwind
+ * `brutalist` colours.
+ */
+export const BRUTALIST_ACCENTS = {
+  cyan: '#22d3ee',
+  pink: '#ec4899',
+  yellow: '#facc15',
+  neonGreen: '#39ff14',
+  neonCyan: '#00ffff',
+  white: '#ffffff',
+} as const;
+
+export type AccentName = keyof typeof BRUTALIST_ACCENTS;
+
+/** Ordered swatch list for the gallery's colour picker. */
+export const ACCENT_SWATCHES: { name: AccentName; value: string }[] = (
+  Object.keys(BRUTALIST_ACCENTS) as AccentName[]
+).map((name) => ({ name, value: BRUTALIST_ACCENTS[name] }));
+
+/**
+ * Convert `#rrggbb` to an `rgba()` string at the given alpha. Generators use
+ * this for the many faint background marks that sit under the bright accent.
+ */
+export function withAlpha(hex: string, alpha: number): string {
+  const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex.trim());
+  if (!m) return hex;
+  const r = Number.parseInt(m[1], 16);
+  const g = Number.parseInt(m[2], 16);
+  const b = Number.parseInt(m[3], 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}

--- a/components/graphics/registry.ts
+++ b/components/graphics/registry.ts
@@ -1,0 +1,84 @@
+import { GENERATORS } from './generators';
+import { BASE_PARAMS, type Generator, type GraphicParams } from './types';
+
+/** Per-generator metadata + default params (merged over BASE_PARAMS). */
+const META: Record<
+  string,
+  { label: string; description: string; defaults?: Partial<GraphicParams> }
+> = {
+  'dot-grid': {
+    label: 'Dot Grid',
+    description: 'Regular grid of dots with a scatter flaring to full accent.',
+    defaults: { density: 0.5 },
+  },
+  'diagonal-hatch': {
+    label: 'Diagonal Hatch',
+    description: 'Parallel 45° rules — a few pop, the rest stay ghostly.',
+    defaults: { density: 0.55, strokeWidth: 2 },
+  },
+  'node-network': {
+    label: 'Node Network',
+    description: 'Constellation of nodes wired to their nearest neighbours.',
+    defaults: { density: 0.5 },
+  },
+  contour: {
+    label: 'Contour',
+    description: 'Stacked topographic waves with occasional bright bands.',
+    defaults: { density: 0.6, strokeWidth: 2 },
+  },
+  'iso-grid': {
+    label: 'Iso Grid',
+    description: 'Isometric lattice of diamonds; some cells fill with accent.',
+    defaults: { density: 0.5 },
+  },
+  'scatter-blocks': {
+    label: 'Scatter Blocks',
+    description: 'Brutalist confetti of rotated squares — outlined to solid.',
+    defaults: { density: 0.5 },
+  },
+};
+
+export const GENERATOR_LIST: Generator[] = Object.entries(GENERATORS).map(
+  ([name, render]) => ({
+    name,
+    label: META[name]?.label ?? name,
+    description: META[name]?.description ?? '',
+    defaults: { ...BASE_PARAMS, ...META[name]?.defaults },
+    render,
+  }),
+);
+
+const BY_NAME = new Map(GENERATOR_LIST.map((g) => [g.name, g]));
+
+export function getGenerator(name: string): Generator | undefined {
+  return BY_NAME.get(name);
+}
+
+/** Merge caller params over a generator's defaults into a full param set. */
+export function resolveParams(
+  name: string,
+  overrides: Partial<GraphicParams> = {},
+): GraphicParams {
+  const gen = getGenerator(name);
+  return { ...BASE_PARAMS, ...gen?.defaults, ...overrides };
+}
+
+/** Render a generator to a raw SVG string. Empty string for unknown names. */
+export function renderGraphic(
+  name: string,
+  overrides: Partial<GraphicParams> = {},
+): string {
+  const gen = getGenerator(name);
+  if (!gen) return '';
+  return gen.render(resolveParams(name, overrides));
+}
+
+/** SVG string → data URI suitable for a CSS `url(...)` background. */
+export function graphicDataUri(
+  name: string,
+  overrides: Partial<GraphicParams> = {},
+): string {
+  const svg = renderGraphic(name, overrides);
+  if (!svg) return '';
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}

--- a/components/graphics/registry.ts
+++ b/components/graphics/registry.ts
@@ -54,13 +54,18 @@ export function getGenerator(name: string): Generator | undefined {
   return BY_NAME.get(name);
 }
 
-/** Merge caller params over a generator's defaults into a full param set. */
+/** Merge caller params over a generator's defaults into a full param set.
+ * `undefined` overrides are dropped so a missing prop (e.g. width) falls back
+ * to the default instead of clobbering it with undefined. */
 export function resolveParams(
   name: string,
   overrides: Partial<GraphicParams> = {},
 ): GraphicParams {
   const gen = getGenerator(name);
-  return { ...BASE_PARAMS, ...gen?.defaults, ...overrides };
+  const defined = Object.fromEntries(
+    Object.entries(overrides).filter(([, v]) => v !== undefined),
+  );
+  return { ...BASE_PARAMS, ...gen?.defaults, ...defined };
 }
 
 /** Render a generator to a raw SVG string. Empty string for unknown names. */

--- a/components/graphics/rng.ts
+++ b/components/graphics/rng.ts
@@ -1,0 +1,37 @@
+/**
+ * Tiny deterministic PRNG (mulberry32) plus range helpers. Every generator
+ * derives all its randomness from a seed so the same params always produce the
+ * exact same SVG — safe for SSR, snapshotable, and shareable via a seed number.
+ */
+export type Rng = () => number;
+
+export function mulberry32(seed: number): Rng {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Float in [min, max). */
+export function range(rng: Rng, min: number, max: number): number {
+  return min + rng() * (max - min);
+}
+
+/** Integer in [min, max]. */
+export function intRange(rng: Rng, min: number, max: number): number {
+  return Math.floor(range(rng, min, max + 1));
+}
+
+/** True with probability p (0..1). */
+export function chance(rng: Rng, p: number): boolean {
+  return rng() < p;
+}
+
+/** Pick one element deterministically. */
+export function pick<T>(rng: Rng, items: readonly T[]): T {
+  return items[Math.min(items.length - 1, Math.floor(rng() * items.length))];
+}

--- a/components/graphics/types.ts
+++ b/components/graphics/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared contract for every graphic/background generator. A generator is a pure
+ * function from `GraphicParams` to an SVG string — no React, no DOM — so the
+ * same output can be rendered inline, turned into a data URI for a CSS
+ * background, or written to a file.
+ */
+export interface GraphicParams {
+  /** viewBox width (aspect ratio only — the SVG scales to its container). */
+  width: number;
+  /** viewBox height. */
+  height: number;
+  /** Deterministic seed — same seed + params ⇒ identical SVG. */
+  seed: number;
+  /** Foreground "ink" colour (the themeable accent). */
+  accent: string;
+  /** Backdrop fill, or `'transparent'` to let a parent background show through. */
+  background: string;
+  /** How busy the graphic is, 0..1. Meaning is per-generator but monotonic. */
+  density: number;
+  /** Overall opacity applied to the whole graphic, 0..1. */
+  opacity: number;
+  /** Base stroke width in viewBox units. */
+  strokeWidth: number;
+}
+
+export type RenderFn = (params: GraphicParams) => string;
+
+export type ControlType = 'seed' | 'density' | 'strokeWidth' | 'opacity';
+
+/** Metadata that lets the gallery build live controls generically. */
+export interface Generator {
+  /** Stable id used in frontmatter and the registry (kebab-case). */
+  name: string;
+  /** Human label for the gallery. */
+  label: string;
+  /** One-line description of the look. */
+  description: string;
+  /** Per-generator default params (merged over the global defaults). */
+  defaults: GraphicParams;
+  render: RenderFn;
+}
+
+/** Global fallbacks; individual generators override via `defaults`. */
+export const BASE_PARAMS: GraphicParams = {
+  width: 1280,
+  height: 720,
+  seed: 1,
+  accent: '#22d3ee',
+  background: 'transparent',
+  density: 0.5,
+  opacity: 1,
+  strokeWidth: 2,
+};

--- a/components/talks/SpectacleDeck.tsx
+++ b/components/talks/SpectacleDeck.tsx
@@ -1,6 +1,6 @@
 import { useConvexAuth, useMutation, useQuery } from 'convex/react';
 import { useRouter } from 'next/router';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Box,
   Deck,
@@ -31,6 +31,8 @@ export interface DeckSlide {
   notesCode: string | null;
   /** Per-slide `[⏱ a–b …]` timing window (minutes from talk start), if any. */
   window?: SlideWindow | null;
+  /** Name of the background this slide selects (frontmatter `backgrounds`). */
+  background?: string | null;
 }
 
 interface SpectacleDeckProps {
@@ -38,8 +40,10 @@ interface SpectacleDeckProps {
   slug: string;
   /** Target length (frontmatter durationMins) — drives the console pacing timer. */
   durationMins?: number;
-  /** Optional generated deck background (frontmatter `background`). */
-  background?: TalkBackground;
+  /** Named background definitions (frontmatter `backgrounds`). */
+  backgrounds?: Record<string, TalkBackground>;
+  /** Deck-wide default background name (frontmatter `background`). */
+  defaultBackground?: string;
 }
 
 type Mode = 'attendee' | 'presenter' | 'console';
@@ -80,28 +84,98 @@ function Chrome({
   );
 }
 
-// A generated background is baked into a single data-URI SVG (opacity folded in)
-// and applied to every slide via Spectacle's native full-bleed backgroundImage.
-function backgroundImage(background?: TalkBackground): string | undefined {
-  if (!background?.generator) return undefined;
-  const uri = graphicDataUri(background.generator, {
-    seed: background.seed,
-    accent: background.accent,
-    density: background.density,
-    opacity: background.opacity ?? 0.18,
+// A generated background is baked into a single data-URI SVG (opacity folded in).
+function backgroundUri(bg?: TalkBackground): string | undefined {
+  if (!bg?.generator) return undefined;
+  const uri = graphicDataUri(bg.generator, {
+    seed: bg.seed,
+    accent: bg.accent,
+    density: bg.density,
+    opacity: bg.opacity ?? 0.18,
   });
   return uri ? `url("${uri}")` : undefined;
 }
 
-function renderSlides(slides: DeckSlide[], background?: TalkBackground) {
-  const bgImage = backgroundImage(background);
-  return slides.map((slide, i) => (
-    <Slide
-      key={i}
-      backgroundColor="#000000"
-      backgroundImage={bgImage}
-      backgroundSize="cover"
+/** Resolve each named background to a CSS `url(...)` once. */
+function buildBackgroundUris(
+  backgrounds?: Record<string, TalkBackground>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [name, bg] of Object.entries(backgrounds ?? {})) {
+    const uri = backgroundUri(bg);
+    if (uri) out[name] = uri;
+  }
+  return out;
+}
+
+/**
+ * Fixed backdrop behind the whole deck: one layer per named background, shown
+ * via opacity. Only the active slide's background is opaque, so the backdrop
+ * stays put between slides that share a name and cross-fades only when the name
+ * actually changes — the content transitions, the backdrop mostly doesn't.
+ */
+function DeckBackground({
+  uris,
+  activeName,
+}: {
+  uris: Record<string, string>;
+  activeName: string | null;
+}) {
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 0,
+        backgroundColor: '#000000',
+      }}
     >
+      {Object.entries(uris).map(([name, uri]) => (
+        <div
+          key={name}
+          style={{
+            position: 'absolute',
+            inset: 0,
+            backgroundImage: uri,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            opacity: name === activeName ? 1 : 0,
+            transition: 'opacity 500ms ease',
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Reports the active slide index up from inside the persistent template. */
+function ActiveSlideReporter({
+  index,
+  onChange,
+}: {
+  index: number;
+  onChange: (i: number) => void;
+}) {
+  useEffect(() => {
+    onChange(index);
+  }, [index, onChange]);
+  return null;
+}
+
+// With backgrounds present the slides + deck backdrop go transparent so the
+// fixed DeckBackground shows through and stays put across transitions.
+function deckTheme(hasBackground: boolean): typeof brutalistTheme {
+  if (!hasBackground) return brutalistTheme;
+  return {
+    ...brutalistTheme,
+    backdropStyle: { backgroundColor: 'transparent' },
+  };
+}
+
+function renderSlides(slides: DeckSlide[], hasBackground: boolean) {
+  return slides.map((slide, i) => (
+    <Slide key={i} backgroundColor={hasBackground ? 'transparent' : '#000000'}>
       <SlideBody code={slide.code} />
       {slide.notesCode ? (
         <Notes>
@@ -112,18 +186,50 @@ function renderSlides(slides: DeckSlide[], background?: TalkBackground) {
   ));
 }
 
+/** The active slide's background name, or the deck default, or null. */
+function activeBackgroundName(
+  slides: DeckSlide[],
+  active: number,
+  defaultBackground?: string,
+): string | null {
+  return slides[active]?.background ?? defaultBackground ?? null;
+}
+
 /** Deck with no live layer — used when Convex isn't configured. */
 function BaseDeck({
   slides,
-  background,
+  backgrounds,
+  defaultBackground,
 }: {
   slides: DeckSlide[];
-  background?: TalkBackground;
+  backgrounds?: Record<string, TalkBackground>;
+  defaultBackground?: string;
 }) {
+  const uris = useMemo(() => buildBackgroundUris(backgrounds), [backgrounds]);
+  const hasBg = Object.keys(uris).length > 0;
+  const [active, setActive] = useState(0);
+  const activeName = activeBackgroundName(slides, active, defaultBackground);
+
+  const template = ({
+    slideNumber,
+    numberOfSlides,
+  }: {
+    slideNumber: number;
+    numberOfSlides: number;
+  }) => (
+    <>
+      <Chrome slideNumber={slideNumber} numberOfSlides={numberOfSlides} />
+      <ActiveSlideReporter index={slideNumber - 1} onChange={setActive} />
+    </>
+  );
+
   return (
-    <Deck theme={brutalistTheme} template={Chrome}>
-      {renderSlides(slides, background)}
-    </Deck>
+    <>
+      {hasBg && <DeckBackground uris={uris} activeName={activeName} />}
+      <Deck theme={deckTheme(hasBg)} template={template}>
+        {renderSlides(slides, hasBg)}
+      </Deck>
+    </>
   );
 }
 
@@ -150,7 +256,8 @@ function LiveDeck({
   slides,
   slug,
   durationMins,
-  background,
+  backgrounds,
+  defaultBackground,
 }: SpectacleDeckProps) {
   const router = useRouter();
   const current = useQuery(api.talks.current);
@@ -161,6 +268,14 @@ function LiveDeck({
 
   const sessionIdRef = useRef('');
   if (!sessionIdRef.current) sessionIdRef.current = crypto.randomUUID();
+
+  // Named-background backdrop state (see BaseDeck for the model). `bgActive` is
+  // the visible slide reported by the template, independent of the live/console
+  // driving index so the backdrop tracks correctly in every mode.
+  const bgUris = useMemo(() => buildBackgroundUris(backgrounds), [backgrounds]);
+  const hasBg = Object.keys(bgUris).length > 0;
+  const [bgActive, setBgActive] = useState(0);
+  const bgName = activeBackgroundName(slides, bgActive, defaultBackground);
 
   // The console's Prev/Next drive the embedded deck (which then broadcasts),
   // and the deck reports its slide index up for the console's notes/preview.
@@ -307,6 +422,7 @@ function LiveDeck({
   }) => (
     <>
       <Chrome slideNumber={slideNumber} numberOfSlides={numberOfSlides} />
+      <ActiveSlideReporter index={slideNumber - 1} onChange={setBgActive} />
       {drivingDeck ? (
         <DeckDriver
           room={room}
@@ -329,8 +445,8 @@ function LiveDeck({
 
   const deckEl = (
     <DeckModeProvider value={mode}>
-      <Deck theme={brutalistTheme} template={template}>
-        {renderSlides(slides, background)}
+      <Deck theme={deckTheme(hasBg)} template={template}>
+        {renderSlides(slides, hasBg)}
       </Deck>
     </DeckModeProvider>
   );
@@ -446,40 +562,44 @@ function LiveDeck({
 
   if (sidebar) {
     return (
-      <div
-        style={{
-          display: 'flex',
-          width: '100vw',
-          height: '100dvh',
-          overflow: 'hidden',
-        }}
-      >
+      <>
+        {hasBg && <DeckBackground uris={bgUris} activeName={bgName} />}
         <div
           style={{
-            position: 'relative',
+            display: 'flex',
+            width: '100vw',
             height: '100dvh',
-            flex: '1 1 0%',
-            minWidth: 0,
+            overflow: 'hidden',
           }}
         >
-          {deckEl}
-          {hud}
+          <div
+            style={{
+              position: 'relative',
+              height: '100dvh',
+              flex: '1 1 0%',
+              minWidth: 0,
+            }}
+          >
+            {deckEl}
+            {hud}
+          </div>
+          <div
+            style={{
+              height: '100dvh',
+              flex: `0 0 ${sidebarWidth}`,
+              width: sidebarWidth,
+            }}
+          >
+            {sidebar}
+          </div>
         </div>
-        <div
-          style={{
-            height: '100dvh',
-            flex: `0 0 ${sidebarWidth}`,
-            width: sidebarWidth,
-          }}
-        >
-          {sidebar}
-        </div>
-      </div>
+      </>
     );
   }
 
   return (
     <>
+      {hasBg && <DeckBackground uris={bgUris} activeName={bgName} />}
       {deckEl}
       {hud}
     </>
@@ -498,16 +618,24 @@ export default function SpectacleDeck({
   slides,
   slug,
   durationMins,
-  background,
+  backgrounds,
+  defaultBackground,
 }: SpectacleDeckProps) {
   if (!isConvexConfigured)
-    return <BaseDeck slides={slides} background={background} />;
+    return (
+      <BaseDeck
+        slides={slides}
+        backgrounds={backgrounds}
+        defaultBackground={defaultBackground}
+      />
+    );
   return (
     <LiveDeck
       slides={slides}
       slug={slug}
       durationMins={durationMins}
-      background={background}
+      backgrounds={backgrounds}
+      defaultBackground={defaultBackground}
     />
   );
 }

--- a/components/talks/SpectacleDeck.tsx
+++ b/components/talks/SpectacleDeck.tsx
@@ -10,6 +10,8 @@ import {
   Progress,
   Slide,
 } from 'spectacle';
+import type { TalkBackground } from 'types/TalkFrontMatter';
+import { graphicDataUri } from '@/components/graphics';
 import { api } from '@/convex/_generated/api';
 import { isConvexConfigured } from '@/lib/convexClient';
 import type { SlideWindow } from '@/lib/slideTiming';
@@ -36,6 +38,8 @@ interface SpectacleDeckProps {
   slug: string;
   /** Target length (frontmatter durationMins) — drives the console pacing timer. */
   durationMins?: number;
+  /** Optional generated deck background (frontmatter `background`). */
+  background?: TalkBackground;
 }
 
 type Mode = 'attendee' | 'presenter' | 'console';
@@ -76,9 +80,28 @@ function Chrome({
   );
 }
 
-function renderSlides(slides: DeckSlide[]) {
+// A generated background is baked into a single data-URI SVG (opacity folded in)
+// and applied to every slide via Spectacle's native full-bleed backgroundImage.
+function backgroundImage(background?: TalkBackground): string | undefined {
+  if (!background?.generator) return undefined;
+  const uri = graphicDataUri(background.generator, {
+    seed: background.seed,
+    accent: background.accent,
+    density: background.density,
+    opacity: background.opacity ?? 0.18,
+  });
+  return uri ? `url("${uri}")` : undefined;
+}
+
+function renderSlides(slides: DeckSlide[], background?: TalkBackground) {
+  const bgImage = backgroundImage(background);
   return slides.map((slide, i) => (
-    <Slide key={i} backgroundColor="#000000">
+    <Slide
+      key={i}
+      backgroundColor="#000000"
+      backgroundImage={bgImage}
+      backgroundSize="cover"
+    >
       <SlideBody code={slide.code} />
       {slide.notesCode ? (
         <Notes>
@@ -90,10 +113,16 @@ function renderSlides(slides: DeckSlide[]) {
 }
 
 /** Deck with no live layer — used when Convex isn't configured. */
-function BaseDeck({ slides }: { slides: DeckSlide[] }) {
+function BaseDeck({
+  slides,
+  background,
+}: {
+  slides: DeckSlide[];
+  background?: TalkBackground;
+}) {
   return (
     <Deck theme={brutalistTheme} template={Chrome}>
-      {renderSlides(slides)}
+      {renderSlides(slides, background)}
     </Deck>
   );
 }
@@ -117,7 +146,12 @@ function resolveMode(raw: unknown): Mode {
  * - `console` (admin) → follows + a presenter console sidebar (connection status,
  *   presence, reactions, live numbers, End talk) — the presenter's second screen.
  */
-function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
+function LiveDeck({
+  slides,
+  slug,
+  durationMins,
+  background,
+}: SpectacleDeckProps) {
   const router = useRouter();
   const current = useQuery(api.talks.current);
   const setSlide = useMutation(api.talks.setSlide);
@@ -296,7 +330,7 @@ function LiveDeck({ slides, slug, durationMins }: SpectacleDeckProps) {
   const deckEl = (
     <DeckModeProvider value={mode}>
       <Deck theme={brutalistTheme} template={template}>
-        {renderSlides(slides)}
+        {renderSlides(slides, background)}
       </Deck>
     </DeckModeProvider>
   );
@@ -464,7 +498,16 @@ export default function SpectacleDeck({
   slides,
   slug,
   durationMins,
+  background,
 }: SpectacleDeckProps) {
-  if (!isConvexConfigured) return <BaseDeck slides={slides} />;
-  return <LiveDeck slides={slides} slug={slug} durationMins={durationMins} />;
+  if (!isConvexConfigured)
+    return <BaseDeck slides={slides} background={background} />;
+  return (
+    <LiveDeck
+      slides={slides}
+      slug={slug}
+      durationMins={durationMins}
+      background={background}
+    />
+  );
 }

--- a/components/talks/SpectacleDeck.tsx
+++ b/components/talks/SpectacleDeck.tsx
@@ -6,6 +6,7 @@ import {
   Deck,
   FlexBox,
   FullScreen,
+  fadeTransition,
   Notes,
   Progress,
   Slide,
@@ -226,7 +227,11 @@ function BaseDeck({
   return (
     <>
       {hasBg && <DeckBackground uris={uris} activeName={activeName} />}
-      <Deck theme={deckTheme(hasBg)} template={template}>
+      <Deck
+        theme={deckTheme(hasBg)}
+        template={template}
+        transition={hasBg ? fadeTransition : undefined}
+      >
         {renderSlides(slides, hasBg)}
       </Deck>
     </>
@@ -445,7 +450,11 @@ function LiveDeck({
 
   const deckEl = (
     <DeckModeProvider value={mode}>
-      <Deck theme={deckTheme(hasBg)} template={template}>
+      <Deck
+        theme={deckTheme(hasBg)}
+        template={template}
+        transition={hasBg ? fadeTransition : undefined}
+      >
         {renderSlides(slides, hasBg)}
       </Deck>
     </DeckModeProvider>

--- a/data/talks/aws-batch-mapreduce.mdx
+++ b/data/talks/aws-batch-mapreduce.mdx
@@ -7,12 +7,14 @@ summary: Batch compute without babysitting servers. Where AWS Batch sits on the 
 tags: ['aws', 'aws-batch', 'mapreduce', 'cloud', 'talks']
 durationMins: 20
 draft: true
-background:
-  generator: node-network
-  seed: 42
-  accent: '#39ff14'
-  opacity: 0.16
-  density: 0.55
+backgrounds:
+  main:
+    generator: node-network
+    seed: 42
+    accent: '#39ff14'
+    opacity: 0.16
+    density: 0.55
+background: main
 ---
 
 <div style={{ fontFamily: '"IBM Plex Mono", monospace', fontSize: '0.8rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#39ff14' }}>● AWS Batch Map/Reduce · 2022</div>

--- a/data/talks/aws-batch-mapreduce.mdx
+++ b/data/talks/aws-batch-mapreduce.mdx
@@ -7,6 +7,12 @@ summary: Batch compute without babysitting servers. Where AWS Batch sits on the 
 tags: ['aws', 'aws-batch', 'mapreduce', 'cloud', 'talks']
 durationMins: 20
 draft: true
+background:
+  generator: node-network
+  seed: 42
+  accent: '#39ff14'
+  opacity: 0.16
+  density: 0.55
 ---
 
 <div style={{ fontFamily: '"IBM Plex Mono", monospace', fontSize: '0.8rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#39ff14' }}>● AWS Batch Map/Reduce · 2022</div>

--- a/data/talks/paket-and-its-perks.mdx
+++ b/data/talks/paket-and-its-perks.mdx
@@ -7,6 +7,12 @@ summary: A dependency manager built for reproducible builds. Why lock files matt
 tags: ['dotnet', 'paket', 'nuget', 'build', 'talks']
 durationMins: 25
 draft: true
+background:
+  generator: scatter-blocks
+  seed: 71
+  accent: '#facc15'
+  opacity: 0.16
+  density: 0.5
 ---
 
 <div style={{ fontFamily: '"IBM Plex Mono", monospace', fontSize: '0.8rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#facc15' }}>● Paket and its Perks · 2018</div>

--- a/data/talks/paket-and-its-perks.mdx
+++ b/data/talks/paket-and-its-perks.mdx
@@ -7,12 +7,14 @@ summary: A dependency manager built for reproducible builds. Why lock files matt
 tags: ['dotnet', 'paket', 'nuget', 'build', 'talks']
 durationMins: 25
 draft: true
-background:
-  generator: scatter-blocks
-  seed: 71
-  accent: '#facc15'
-  opacity: 0.16
-  density: 0.5
+backgrounds:
+  main:
+    generator: scatter-blocks
+    seed: 71
+    accent: '#facc15'
+    opacity: 0.16
+    density: 0.5
+background: main
 ---
 
 <div style={{ fontFamily: '"IBM Plex Mono", monospace', fontSize: '0.8rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#facc15' }}>● Paket and its Perks · 2018</div>

--- a/data/talks/railway-oriented-programming.mdx
+++ b/data/talks/railway-oriented-programming.mdx
@@ -7,12 +7,14 @@ summary: Error handling as a first-class value. Why exceptions, error-callbacks,
 tags: ['fsharp', 'functional-programming', 'error-handling', 'talks']
 durationMins: 30
 draft: true
-background:
-  generator: contour
-  seed: 13
-  accent: '#ec4899'
-  opacity: 0.18
-  density: 0.6
+backgrounds:
+  main:
+    generator: contour
+    seed: 13
+    accent: '#ec4899'
+    opacity: 0.18
+    density: 0.6
+background: main
 ---
 
 <div style={{ fontFamily: '"IBM Plex Mono", monospace', fontSize: '0.8rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#ec4899' }}>● Railway Oriented Programming · 2018</div>

--- a/data/talks/railway-oriented-programming.mdx
+++ b/data/talks/railway-oriented-programming.mdx
@@ -7,6 +7,12 @@ summary: Error handling as a first-class value. Why exceptions, error-callbacks,
 tags: ['fsharp', 'functional-programming', 'error-handling', 'talks']
 durationMins: 30
 draft: true
+background:
+  generator: contour
+  seed: 13
+  accent: '#ec4899'
+  opacity: 0.18
+  density: 0.6
 ---
 
 <div style={{ fontFamily: '"IBM Plex Mono", monospace', fontSize: '0.8rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#ec4899' }}>● Railway Oriented Programming · 2018</div>

--- a/data/talks/so-you-want-to-build-software.mdx
+++ b/data/talks/so-you-want-to-build-software.mdx
@@ -8,6 +8,12 @@ summary: What a professional software engineer actually does all day — and how
 tags: ['careers', 'software-engineering', 'talks']
 durationMins: 100
 draft: false
+background:
+  generator: dot-grid
+  seed: 7
+  accent: '#22d3ee'
+  density: 0.4
+  opacity: 0.12
 ---
 
 # SO YOU WANT TO BUILD SOFTWARE?

--- a/data/talks/so-you-want-to-build-software.mdx
+++ b/data/talks/so-you-want-to-build-software.mdx
@@ -8,12 +8,20 @@ summary: What a professional software engineer actually does all day — and how
 tags: ['careers', 'software-engineering', 'talks']
 durationMins: 100
 draft: false
-background:
-  generator: dot-grid
-  seed: 7
-  accent: '#22d3ee'
-  density: 0.4
-  opacity: 0.12
+backgrounds:
+  main:
+    generator: dot-grid
+    seed: 7
+    accent: '#22d3ee'
+    density: 0.4
+    opacity: 0.28
+  activity:
+    generator: scatter-blocks
+    seed: 3
+    accent: '#facc15'
+    density: 0.5
+    opacity: 0.24
+background: main
 ---
 
 # SO YOU WANT TO BUILD SOFTWARE?
@@ -160,6 +168,8 @@ the sat-nav, the hospital screens — all software."
   **precise**. Let me show you what I mean — let's make some toast."
 
 ---
+
+{/* bg: activity */}
 
 # 🍞 TRY IT: MAKING TOAST
 
@@ -374,6 +384,8 @@ small project.
 - Segue: "small projects are exactly how you'd start — here's one you could do."
 
 ---
+
+{/* bg: activity */}
 
 # SOMETHING YOU COULD BUILD
 

--- a/data/talks/the-safe-stack.mdx
+++ b/data/talks/the-safe-stack.mdx
@@ -7,12 +7,14 @@ summary: An end-to-end F# web stack. Saturn and Giraffe on the server, Fable com
 tags: ['fsharp', 'safe-stack', 'fable', 'web', 'talks']
 durationMins: 20
 draft: true
-background:
-  generator: iso-grid
-  seed: 24
-  accent: '#22d3ee'
-  opacity: 0.16
-  density: 0.5
+backgrounds:
+  main:
+    generator: iso-grid
+    seed: 24
+    accent: '#22d3ee'
+    opacity: 0.16
+    density: 0.5
+background: main
 ---
 
 <div style={{ fontFamily: '"IBM Plex Mono", monospace', fontSize: '0.8rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#22d3ee' }}>● The SAFE Stack · 2019</div>

--- a/data/talks/the-safe-stack.mdx
+++ b/data/talks/the-safe-stack.mdx
@@ -7,6 +7,12 @@ summary: An end-to-end F# web stack. Saturn and Giraffe on the server, Fable com
 tags: ['fsharp', 'safe-stack', 'fable', 'web', 'talks']
 durationMins: 20
 draft: true
+background:
+  generator: iso-grid
+  seed: 24
+  accent: '#22d3ee'
+  opacity: 0.16
+  density: 0.5
 ---
 
 <div style={{ fontFamily: '"IBM Plex Mono", monospace', fontSize: '0.8rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.1em', color: '#22d3ee' }}>● The SAFE Stack · 2019</div>

--- a/docs/talks-graphics.md
+++ b/docs/talks-graphics.md
@@ -1,0 +1,190 @@
+# Talk decks, generated graphics & backgrounds
+
+Everything added while archiving four pre-blog slides.com decks and turning the
+talk decks into a themeable system: the recreated talks, the slide-rendering
+improvements, a standardised SVG **graphics generator** mechanism, **named
+per-slide backgrounds**, the experiments gallery, and the accessibility pass.
+
+Shipped across three PRs: **#60** (archived talks, merged), **#61** (slide
+sizing), **#62** (graphics + backgrounds).
+
+---
+
+## 1. The recreated talks
+
+Four pre-blog decks from [slides.com/ryankelly](https://slides.com/ryankelly)
+were recreated in the talks MDX format under `data/talks/`, emulating the
+general arc of each original (not slide-for-slide). Each preserves its original
+publish date in frontmatter and carries a signature accent for differentiation:
+
+| Talk | File | Original date | Accent |
+| --- | --- | --- | --- |
+| Railway Oriented Programming | `railway-oriented-programming.mdx` | 2018-04-13 | magenta `#ec4899` |
+| Paket and its Perks | `paket-and-its-perks.mdx` | 2018-07-13 | amber `#facc15` |
+| The SAFE Stack | `the-safe-stack.mdx` | 2019-01-24 | cyan `#22d3ee` |
+| Map/Reduce with AWS Batch | `aws-batch-mapreduce.mdx` | 2022-09-10 | terminal green `#39ff14` |
+
+Code samples are real F#/C# fences (Prism-highlighted) and diagrams are mermaid,
+so the talks are self-contained (no external image assets). They ship
+`draft: true` — visible behind a DRAFT badge, admin-only — pending review of the
+placeholder `event` names, which are honest topic-based stand-ins because the
+original venues are unknown.
+
+The original decks are preserved verbatim too — see [Provenance](#6-provenance--archive).
+
+## 2. Slide rendering
+
+Two presentation fixes in `components/talks/SlideBody.tsx` and `SpectacleDeck.tsx`:
+
+- **Sizing & fill (#61):** slide bodies rendered top-aligned in a `prose-lg`
+  box, so sparse slides clustered content in the top third. `SlideBody` now
+  fills the slide height, vertically centres its content, and steps the base
+  type to `prose-xl`. Verified across every deck — the densest slide is 604/768px,
+  so nothing clips.
+- **Transitions:** when a talk has a background, the deck uses Spectacle's
+  `fadeTransition` so content **dissolves** over the stationary backdrop instead
+  of swiping — one consistent motion. Decks without a background keep the default
+  swipe.
+
+## 3. Graphics generator mechanism
+
+`components/graphics/` — a standardised, framework-agnostic way to produce
+deterministic SVG graphics. A generator is a pure function
+**`(params) => svgString`**; the same seed + params always yield identical
+output (SSR-safe, snapshotable, shareable by a seed number).
+
+```
+components/graphics/
+├── rng.ts          # mulberry32 seeded PRNG + range/pick helpers
+├── types.ts        # GraphicParams contract + BASE_PARAMS defaults
+├── palette.ts      # brutalist accent swatches (mirror tailwind) + withAlpha
+├── generators.ts   # the six render functions
+├── registry.ts     # named registry, renderGraphic, graphicDataUri, resolveParams
+├── GeneratedBackground.tsx  # React wrapper for inline / full-bleed use
+└── index.ts        # barrel
+```
+
+**`GraphicParams`:** `width`, `height`, `seed`, `accent`, `background`,
+`density` (0..1, how busy), `opacity` (0..1, whole-graphic), `strokeWidth`.
+
+**The six generators:** `dot-grid`, `diagonal-hatch`, `node-network`, `contour`,
+`iso-grid`, `scatter-blocks`. Each draws its marks at full strength; subtlety for
+backgrounds comes from the `opacity` param, so the gallery shows them boldly
+while talks dial them down.
+
+**Public API (`registry.ts`):**
+
+- `renderGraphic(name, overrides?) => string` — raw SVG.
+- `graphicDataUri(name, overrides?) => string` — `data:image/svg+xml,…` for a CSS
+  `url(...)` background.
+- `resolveParams(name, overrides?)` — merges defaults; **drops `undefined`
+  overrides** so an omitted prop falls back to its default instead of clobbering it.
+- `GENERATOR_LIST`, `getGenerator(name)`.
+
+Render inline anywhere:
+
+```tsx
+<GeneratedBackground generator="contour" accent="#39ff14" opacity={0.3} />
+```
+
+## 4. Talk backgrounds (named, decoupled, per-slide)
+
+Backgrounds are defined **once**, **named**, and referenced by name, so slides
+can share a backdrop or switch between several. The backdrop only transitions
+when the active slide's background name actually changes — otherwise it stays
+fixed while the content moves.
+
+**Frontmatter** (`data/talks/*.mdx`):
+
+```yaml
+backgrounds:
+  main:
+    generator: dot-grid
+    seed: 7
+    accent: '#22d3ee'
+    density: 0.4
+    opacity: 0.28
+  activity:
+    generator: scatter-blocks
+    seed: 3
+    accent: '#facc15'
+    opacity: 0.24
+background: main        # deck-wide default background name
+```
+
+**Per-slide override** — a directive anywhere in a slide's body (it's an MDX
+comment, so it renders nothing and is stripped at compile):
+
+```mdx
+{/* bg: activity */}
+
+# Try it: making toast
+```
+
+**How it works:**
+
+- `lib/talks.ts` parses the `{/* bg: name */}` directive per slide → `slide.background`.
+- `SpectacleDeck` renders one fixed `DeckBackground` layer per named background,
+  each shown via `opacity` (1 for the active slide's background, 0 otherwise) with
+  a 500 ms CSS fade. Slides that share a name never change that layer's opacity, so
+  the backdrop is genuinely fixed between them; a name change cross-fades.
+- When any background exists, slides and the deck's own backdrop go transparent so
+  the fixed layer shows through, and content uses `fadeTransition` (§2).
+- The active slide is reported from inside Spectacle's persistent template via
+  `ActiveSlideReporter`, so tracking works in every mode (attendee/presenter/console).
+
+`So You Want To Build Software?` (`so-you-want-to-build-software.mdx`) is the
+worked example: `main` dot-grid throughout, switching to the `activity` scatter
+backdrop on its two hands-on slides.
+
+## 5. Experiments gallery
+
+`/experiments/graphics` (`pages/experiments/graphics.tsx`, linked from the
+experiments index) is a live gallery of all six generators with **accent /
+seed-shuffle / density / opacity** controls (defaults: density 0.5, opacity 0.5).
+Each card's **Config** button copies a ready-to-paste `backgrounds:` frontmatter
+block reflecting the current controls, and the page documents the per-slide
+directive.
+
+## 6. Provenance & archive
+
+- **Static export:** the four original slides.com decks were captured to PNGs via
+  the `agent-browser` CDP workflow (reveal.js `/fullscreen` view, driven over CDP
+  on port 9223) — full-slide screenshots plus each deck's original embedded image
+  assets. Reusable capture script lives at `temp/capture-deck.sh` (gitignored).
+- **Archive:** that export (54 files, ~55 MB) is copied to personal Google Drive
+  at `My Drive/Archive/slides.com Talks Archive/` (with a provenance README), via
+  the local Google Drive for Desktop folder. Convex/site are not the long-term
+  store.
+
+## 7. Accessibility
+
+Ran **axe-core** (`color-contrast`) against five text-heavy slides of the
+software-engineering talk (with a background) on the deployed preview:
+
+- **Zero violations.** The only flags are "needs review", all from Spectacle's
+  own slide pseudo-element — an A/B test (background image on vs. off) returned an
+  **identical** count, so the generated background contributes nothing to the
+  contrast picture.
+- Worst-case math confirms it: the brightest possible dot (accent at effective
+  ~0.11 alpha over black) leaves white body text at ~18:1 contrast, far above AA
+  (4.5:1) and AAA (7:1).
+
+Backgrounds are safe to keep at the opacities in use.
+
+---
+
+## Authoring recipes
+
+**Add a background to a talk:** open `/experiments/graphics`, tune the controls,
+copy a card's Config block into the talk's frontmatter. For multiple backdrops,
+add more named entries and switch per slide with `{/* bg: name */}`. Keep opacity
+low (~0.12–0.3) behind text-heavy slides.
+
+**Add a new generator:**
+
+1. Write a pure `RenderFn` in `components/graphics/generators.ts` (use the seeded
+   `rng` helpers; draw marks at full strength, let `opacity` handle subtlety) and
+   add it to the `GENERATORS` map.
+2. Add a label/description/defaults entry in `registry.ts`'s `META`.
+3. It appears in the gallery and is usable by name in any talk automatically.

--- a/lib/talks.ts
+++ b/lib/talks.ts
@@ -215,7 +215,16 @@ export type TalkSlide = {
    * tag — drives the console's per-slide pacing indicator. Null = no window.
    */
   window: SlideWindow | null;
+  /**
+   * Name of the background this slide selects, parsed from a `{/* bg: name *\/}`
+   * directive in the slide body. Null falls back to the deck default. The deck
+   * only transitions the backdrop when this name changes between slides.
+   */
+  background: string | null;
 };
+
+/** Match a `{/* bg: name *\/}` directive (MDX comment — renders nothing). */
+const BG_DIRECTIVE = /\{\/\*\s*bg:\s*([\w-]+)\s*\*\/\}/;
 
 export async function getTalkBySlug(
   slug: string,
@@ -237,8 +246,11 @@ export async function getTalkBySlug(
     chunks.map(async (chunk) => {
       const [body, ...noteParts] = chunk.split(/^\?\?\?$/m);
       const notes = noteParts.join('\n').trim();
+      const background = body.match(BG_DIRECTIVE)?.[1] ?? null;
+      // Strip the directive so it never reaches the MDX compiler as content.
+      const cleanBody = body.replace(new RegExp(BG_DIRECTIVE, 'g'), '').trim();
       const [code, notesCode] = await Promise.all([
-        compileSlide(body.trim()),
+        compileSlide(cleanBody),
         notes ? compileSlide(notes) : Promise.resolve(null),
       ]);
       return {
@@ -246,6 +258,7 @@ export async function getTalkBySlug(
         notes: notes || null,
         notesCode,
         window: parseSlideWindow(notes),
+        background,
       };
     }),
   );

--- a/pages/experiments.tsx
+++ b/pages/experiments.tsx
@@ -1,4 +1,4 @@
-import { Beaker, Palette, Terminal, Type } from 'lucide-react';
+import { Beaker, Palette, Sparkles, Terminal, Type } from 'lucide-react';
 import Link from '@/components/Link';
 import { PageSEO } from '@/components/SEO';
 import siteMetadata from '@/data/siteMetadata';
@@ -20,6 +20,15 @@ const experiments = [
     icon: <Type className="w-12 h-12" />,
     status: 'active',
     components: 3,
+  },
+  {
+    name: 'Graphics Generators',
+    path: '/experiments/graphics',
+    description:
+      'Seed-driven SVG background + graphic generators for talks and heroes',
+    icon: <Sparkles className="w-12 h-12" />,
+    status: 'active',
+    components: 6,
   },
 ];
 

--- a/pages/experiments/graphics.tsx
+++ b/pages/experiments/graphics.tsx
@@ -17,12 +17,14 @@ function frontmatterSnippet(
   opacity: number,
 ): string {
   return [
-    'background:',
-    `  generator: ${name}`,
-    `  seed: ${seed}`,
-    `  accent: '${accent}'`,
-    `  density: ${density.toFixed(2)}`,
-    `  opacity: ${opacity.toFixed(2)}`,
+    'backgrounds:',
+    `  ${name}:`,
+    `    generator: ${name}`,
+    `    seed: ${seed}`,
+    `    accent: '${accent}'`,
+    `    density: ${density.toFixed(2)}`,
+    `    opacity: ${opacity.toFixed(2)}`,
+    `background: ${name}`,
   ].join('\n');
 }
 
@@ -211,9 +213,9 @@ export default function GraphicsGallery() {
           <div className="space-y-3 font-mono text-xs text-white">
             <p>
               <span className="text-brutalist-cyan">&gt;</span> In a talk's MDX
-              frontmatter, add a{' '}
-              <code className="text-brutalist-yellow">background</code> block
-              (copy it from any card above):
+              frontmatter, define one or more named{' '}
+              <code className="text-brutalist-yellow">backgrounds</code> and
+              pick a deck-wide default (copy it from any card above):
             </p>
             <pre className="overflow-x-auto border-2 border-white bg-black p-3 text-brutalist-cyan">
               {frontmatterSnippet(
@@ -224,6 +226,14 @@ export default function GraphicsGallery() {
                 opacity,
               )}
             </pre>
+            <p className="text-zinc-400">
+              <span className="text-brutalist-cyan">&gt;</span> Any slide can
+              switch background by name with a directive — the backdrop only
+              transitions when the name changes:{' '}
+              <code className="text-brutalist-yellow">
+                {'{/* bg: intense */}'}
+              </code>
+            </p>
             <p className="text-zinc-400">
               <span className="text-brutalist-cyan">&gt;</span> Or render inline
               anywhere:{' '}

--- a/pages/experiments/graphics.tsx
+++ b/pages/experiments/graphics.tsx
@@ -13,20 +13,27 @@ function frontmatterSnippet(
   name: string,
   seed: number,
   accent: string,
+  density: number,
+  opacity: number,
 ): string {
   return [
     'background:',
     `  generator: ${name}`,
     `  seed: ${seed}`,
     `  accent: '${accent}'`,
-    '  opacity: 0.18',
+    `  density: ${density.toFixed(2)}`,
+    `  opacity: ${opacity.toFixed(2)}`,
   ].join('\n');
 }
 
 export default function GraphicsGallery() {
   const [accent, setAccent] = useState('#22d3ee');
   const [seed, setSeed] = useState(7);
+  // Reasonable defaults: half density, and an opacity that reads clearly in the
+  // gallery yet is a sane starting point for a talk backdrop (dial down to ~0.15
+  // for a whisper-quiet background, up towards 1 for hero art).
   const [density, setDensity] = useState(0.5);
+  const [opacity, setOpacity] = useState(0.5);
   const [selected, setSelected] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
@@ -35,7 +42,7 @@ export default function GraphicsGallery() {
   const copy = async (name: string) => {
     try {
       await navigator.clipboard.writeText(
-        frontmatterSnippet(name, seed, accent),
+        frontmatterSnippet(name, seed, accent, density, opacity),
       );
       setSelected(name);
       setCopied(true);
@@ -122,6 +129,21 @@ export default function GraphicsGallery() {
               className="w-full accent-brutalist-cyan"
             />
           </div>
+
+          <div className="min-w-[180px]">
+            <div className="mb-2 font-mono text-xs uppercase text-zinc-400">
+              Opacity · {opacity.toFixed(2)}
+            </div>
+            <input
+              type="range"
+              min={0.05}
+              max={1}
+              step={0.05}
+              value={opacity}
+              onChange={(e) => setOpacity(Number(e.target.value))}
+              className="w-full accent-brutalist-cyan"
+            />
+          </div>
         </div>
 
         {/* Gallery grid */}
@@ -139,6 +161,7 @@ export default function GraphicsGallery() {
                   seed={seed}
                   accent={accent}
                   density={density}
+                  opacity={opacity}
                   background="#000000"
                   style={{
                     position: 'absolute',
@@ -193,7 +216,13 @@ export default function GraphicsGallery() {
               (copy it from any card above):
             </p>
             <pre className="overflow-x-auto border-2 border-white bg-black p-3 text-brutalist-cyan">
-              {frontmatterSnippet('node-network', seed, accent)}
+              {frontmatterSnippet(
+                'node-network',
+                seed,
+                accent,
+                density,
+                opacity,
+              )}
             </pre>
             <p className="text-zinc-400">
               <span className="text-brutalist-cyan">&gt;</span> Or render inline

--- a/pages/experiments/graphics.tsx
+++ b/pages/experiments/graphics.tsx
@@ -1,0 +1,223 @@
+import { Check, Copy, Dice5, Sparkles } from 'lucide-react';
+import { useState } from 'react';
+import {
+  ACCENT_SWATCHES,
+  GENERATOR_LIST,
+  GeneratedBackground,
+} from '@/components/graphics';
+import Link from '@/components/Link';
+import { PageSEO } from '@/components/SEO';
+import siteMetadata from '@/data/siteMetadata';
+
+function frontmatterSnippet(
+  name: string,
+  seed: number,
+  accent: string,
+): string {
+  return [
+    'background:',
+    `  generator: ${name}`,
+    `  seed: ${seed}`,
+    `  accent: '${accent}'`,
+    '  opacity: 0.18',
+  ].join('\n');
+}
+
+export default function GraphicsGallery() {
+  const [accent, setAccent] = useState('#22d3ee');
+  const [seed, setSeed] = useState(7);
+  const [density, setDensity] = useState(0.5);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const shuffle = () => setSeed(Math.floor(Math.random() * 9999));
+
+  const copy = async (name: string) => {
+    try {
+      await navigator.clipboard.writeText(
+        frontmatterSnippet(name, seed, accent),
+      );
+      setSelected(name);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1400);
+    } catch {
+      setSelected(name);
+    }
+  };
+
+  return (
+    <>
+      <PageSEO
+        title={`Graphics Generators - ${siteMetadata.author}`}
+        description="Standardised, seed-driven SVG background and graphic generators"
+      />
+      <div className="border-2 border-white bg-black">
+        {/* Header */}
+        <div className="border-b-2 border-white bg-zinc-900 px-6 pt-8 pb-8">
+          <div className="mb-4 flex items-center gap-4">
+            <Sparkles className="h-9 w-9 text-brutalist-cyan" />
+            <h1 className="font-display text-4xl font-bold uppercase text-white md:text-5xl">
+              [ GRAPHICS_GENERATORS ]
+            </h1>
+          </div>
+          <p className="font-mono text-sm text-zinc-400">
+            <span className="text-brutalist-yellow">&gt;</span> Deterministic,
+            seed-driven SVG generators. Same seed + params ⇒ identical output —
+            usable as talk backgrounds, hero art, or exported assets.
+          </p>
+          <p className="mt-2 font-mono text-xs text-zinc-500">
+            <span className="text-brutalist-cyan">&gt;</span> Tune the controls,
+            then copy a generator's config straight into a talk's frontmatter.
+          </p>
+        </div>
+
+        {/* Controls */}
+        <div className="flex flex-wrap items-end gap-8 border-b-2 border-white bg-black px-6 py-6">
+          <div>
+            <div className="mb-2 font-mono text-xs uppercase text-zinc-400">
+              Accent
+            </div>
+            <div className="flex gap-2">
+              {ACCENT_SWATCHES.map((s) => (
+                <button
+                  key={s.name}
+                  type="button"
+                  aria-label={s.name}
+                  onClick={() => setAccent(s.value)}
+                  className={`h-8 w-8 border-2 transition-transform ${
+                    accent === s.value
+                      ? 'scale-110 border-white'
+                      : 'border-zinc-700 hover:border-zinc-400'
+                  }`}
+                  style={{ backgroundColor: s.value }}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <div className="mb-2 font-mono text-xs uppercase text-zinc-400">
+              Seed · {seed}
+            </div>
+            <button
+              type="button"
+              onClick={shuffle}
+              className="flex items-center gap-2 border-2 border-white bg-zinc-900 px-3 py-1.5 font-mono text-xs uppercase text-white transition-colors hover:border-brutalist-cyan hover:text-brutalist-cyan"
+            >
+              <Dice5 className="h-4 w-4" /> Shuffle
+            </button>
+          </div>
+
+          <div className="min-w-[180px]">
+            <div className="mb-2 font-mono text-xs uppercase text-zinc-400">
+              Density · {density.toFixed(2)}
+            </div>
+            <input
+              type="range"
+              min={0.1}
+              max={1}
+              step={0.05}
+              value={density}
+              onChange={(e) => setDensity(Number(e.target.value))}
+              className="w-full accent-brutalist-cyan"
+            />
+          </div>
+        </div>
+
+        {/* Gallery grid */}
+        <div className="grid grid-cols-1 gap-6 p-6 md:grid-cols-2">
+          {GENERATOR_LIST.map((gen) => (
+            <div
+              key={gen.name}
+              className={`border-2 bg-black transition-colors ${
+                selected === gen.name ? 'border-brutalist-cyan' : 'border-white'
+              }`}
+            >
+              <div className="relative aspect-video w-full overflow-hidden bg-black">
+                <GeneratedBackground
+                  generator={gen.name}
+                  seed={seed}
+                  accent={accent}
+                  density={density}
+                  background="#000000"
+                  style={{
+                    position: 'absolute',
+                    inset: 0,
+                    width: '100%',
+                    height: '100%',
+                  }}
+                />
+              </div>
+              <div className="flex items-start justify-between gap-4 border-t-2 border-white p-4">
+                <div>
+                  <h3 className="font-display text-lg font-bold uppercase text-white">
+                    {gen.label}
+                  </h3>
+                  <p className="mt-1 font-mono text-xs text-zinc-400">
+                    {gen.description}
+                  </p>
+                  <code className="mt-2 inline-block font-mono text-xs text-brutalist-yellow">
+                    {gen.name}
+                  </code>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => copy(gen.name)}
+                  className="flex shrink-0 items-center gap-1.5 border-2 border-white bg-zinc-900 px-2.5 py-1.5 font-mono text-xs uppercase text-white transition-colors hover:border-brutalist-cyan hover:text-brutalist-cyan"
+                >
+                  {copied && selected === gen.name ? (
+                    <>
+                      <Check className="h-3.5 w-3.5" /> Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-3.5 w-3.5" /> Config
+                    </>
+                  )}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Usage */}
+        <div className="border-t-2 border-brutalist-yellow bg-zinc-900 p-6">
+          <h2 className="mb-3 font-display text-lg font-bold uppercase text-brutalist-yellow">
+            [ HOW_TO_USE ]
+          </h2>
+          <div className="space-y-3 font-mono text-xs text-white">
+            <p>
+              <span className="text-brutalist-cyan">&gt;</span> In a talk's MDX
+              frontmatter, add a{' '}
+              <code className="text-brutalist-yellow">background</code> block
+              (copy it from any card above):
+            </p>
+            <pre className="overflow-x-auto border-2 border-white bg-black p-3 text-brutalist-cyan">
+              {frontmatterSnippet('node-network', seed, accent)}
+            </pre>
+            <p className="text-zinc-400">
+              <span className="text-brutalist-cyan">&gt;</span> Or render inline
+              anywhere:{' '}
+              <code className="text-brutalist-yellow">
+                {'<GeneratedBackground generator="contour" accent="#39ff14" />'}
+              </code>
+            </p>
+            <p className="text-zinc-500">
+              <span className="text-brutalist-cyan">&gt;</span> Generators live
+              in <code>components/graphics/</code> as pure{' '}
+              <code>(params) =&gt; svgString</code> functions.
+            </p>
+          </div>
+          <div className="mt-6">
+            <Link
+              href="/experiments"
+              className="font-mono text-xs uppercase text-brutalist-cyan hover:text-brutalist-pink"
+            >
+              ← Back to experiments
+            </Link>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/pages/talks/[slug]/present.tsx
+++ b/pages/talks/[slug]/present.tsx
@@ -103,6 +103,7 @@ export default function Present({
         slides={slides}
         slug={frontMatter.slug}
         durationMins={frontMatter.durationMins}
+        background={frontMatter.background}
       />
     </>
   );

--- a/pages/talks/[slug]/present.tsx
+++ b/pages/talks/[slug]/present.tsx
@@ -103,7 +103,8 @@ export default function Present({
         slides={slides}
         slug={frontMatter.slug}
         durationMins={frontMatter.durationMins}
-        background={frontMatter.background}
+        backgrounds={frontMatter.backgrounds}
+        defaultBackground={frontMatter.background}
       />
     </>
   );

--- a/types/TalkFrontMatter.ts
+++ b/types/TalkFrontMatter.ts
@@ -1,3 +1,18 @@
+/**
+ * Optional generated deck background (see components/graphics). Renders behind
+ * every slide via a data-URI SVG, keyed to the talk's signature accent.
+ */
+export type TalkBackground = {
+  /** Generator id from the graphics registry (e.g. `node-network`). */
+  generator: string;
+  seed?: number;
+  /** Hex accent; defaults to the generator's own default when omitted. */
+  accent?: string;
+  /** 0..1 overall opacity — keep low so slide content stays legible. */
+  opacity?: number;
+  density?: number;
+};
+
 export type TalkFrontMatter = {
   title: string;
   /** ISO date string, or null when the talk omits a date. */
@@ -13,5 +28,7 @@ export type TalkFrontMatter = {
   pdf?: string;
   /** Optional link to a recording of the talk. */
   videoUrl?: string;
+  /** Optional generated deck background. */
+  background?: TalkBackground;
   slug: string;
 };

--- a/types/TalkFrontMatter.ts
+++ b/types/TalkFrontMatter.ts
@@ -1,6 +1,7 @@
 /**
- * Optional generated deck background (see components/graphics). Renders behind
- * every slide via a data-URI SVG, keyed to the talk's signature accent.
+ * One generated deck background (see components/graphics). Backgrounds are
+ * defined once, named, and referenced by name — so multiple slides can share a
+ * backdrop (which then stays fixed between them) or switch to a different one.
  */
 export type TalkBackground = {
   /** Generator id from the graphics registry (e.g. `node-network`). */
@@ -28,7 +29,13 @@ export type TalkFrontMatter = {
   pdf?: string;
   /** Optional link to a recording of the talk. */
   videoUrl?: string;
-  /** Optional generated deck background. */
-  background?: TalkBackground;
+  /**
+   * Named background definitions. A slide picks one by name via a
+   * `{/* bg: name *\/}` directive; `background` below is the deck-wide default.
+   * The backdrop only transitions when the active slide's name changes.
+   */
+  backgrounds?: Record<string, TalkBackground>;
+  /** Name of the default background (from `backgrounds`) applied to all slides. */
+  background?: string;
   slug: string;
 };


### PR DESCRIPTION
A standardised, reusable mechanism for generated graphics and backgrounds — surfaced in the experiments section and applied to the recreated talks.

## The mechanism — `components/graphics/`

Pure, framework-agnostic **`(params) => svgString`** generators driven by a deterministic seed (same seed + params ⇒ identical SVG — SSR-safe, snapshotable, shareable):

- `rng.ts` — seeded PRNG (mulberry32) + helpers
- `types.ts` — `GraphicParams` contract + base defaults
- `palette.ts` — brutalist accent swatches (mirrors tailwind) + `withAlpha`
- `generators.ts` — six generators: **dot-grid, diagonal-hatch, node-network, contour, iso-grid, scatter-blocks**
- `registry.ts` — named registry + `renderGraphic` / `graphicDataUri` (data-URI for CSS/Spectacle backgrounds)
- `GeneratedBackground.tsx` — React wrapper for inline/full-bleed use

## Experiments gallery — `/experiments/graphics`

Live gallery of all generators with **accent / seed-shuffle / density** controls and a **copyable frontmatter snippet** per generator. Registered in the experiments index.

## Talk backgrounds

Optional `background` frontmatter block, threaded `present.tsx → SpectacleDeck → each Slide`'s `backgroundImage`. Each recreated talk gets a themed backdrop keyed to its signature accent:

| Talk | Generator | Accent |
| --- | --- | --- |
| Map/Reduce with AWS Batch | node-network | green |
| Railway Oriented Programming | contour | magenta |
| The SAFE Stack | iso-grid | cyan |
| Paket and its Perks | scatter-blocks | amber |

## Verify

`tsc` and `biome` clean. (Local dev couldn't run in the isolated worktree — Next 16 Turbopack rejects a cross-root `node_modules` symlink — so please eyeball on the preview.)

- `/experiments/graphics` — the gallery
- `/talks/aws-batch-mapreduce/present` — background behind the deck

Independent of #61 (slide sizing); both touch talk/deck files but different lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)