### PR TITLE
feat(talks): embed a talk's YouTube recording inline

### DIFF
--- a/components/RecordingEmbed.tsx
+++ b/components/RecordingEmbed.tsx
@@ -1,0 +1,36 @@
+import { youtubeEmbedUrl } from '@/lib/utils/youtubeEmbed';
+
+/**
+ * Inline recording player for a talk. Renders a responsive 16:9 YouTube embed
+ * when `url` is a recognisable YouTube link; renders nothing otherwise (the talk
+ * page falls back to a "Watch Recording" link for non-embeddable URLs). This is
+ * the archival counterpart to the live Convex room — the recording captures the
+ * whole projected surface (slides *and* demos), which the slide-sync can't.
+ */
+export default function RecordingEmbed({
+  url,
+  title,
+}: {
+  url: string;
+  title: string;
+}) {
+  const embed = youtubeEmbedUrl(url);
+  if (!embed) return null;
+
+  return (
+    <section className="mt-10 border-t-2 border-white pt-8">
+      <h2 className="mb-4 font-mono text-xs uppercase text-brutalist-cyan">
+        Recording
+      </h2>
+      <div className="relative aspect-video border-2 border-white shadow-hard-md">
+        <iframe
+          src={embed}
+          title={`${title} — recording`}
+          className="absolute inset-0 h-full w-full"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+        />
+      </div>
+    </section>
+  );
+}

--- a/lib/utils/youtubeEmbed.ts
+++ b/lib/utils/youtubeEmbed.ts
@@ -1,0 +1,40 @@
+/**
+ * Turn a YouTube watch / youtu.be / live / shorts / embed URL into its
+ * privacy-enhanced (`youtube-nocookie`) embed URL, or return null when the
+ * string isn't a recognisable YouTube link. The talk page uses this to decide
+ * whether a talk's `videoUrl` renders as an inline player (YouTube) or a plain
+ * "Watch Recording" link (anything else — Vimeo, a raw file, etc.).
+ */
+export function youtubeEmbedUrl(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  const host = parsed.hostname.replace(/^www\./, '');
+  let id: string | null = null;
+
+  if (host === 'youtu.be') {
+    id = parsed.pathname.slice(1).split('/')[0] || null;
+  } else if (
+    host === 'youtube.com' ||
+    host === 'm.youtube.com' ||
+    host === 'youtube-nocookie.com'
+  ) {
+    if (parsed.pathname === '/watch') {
+      id = parsed.searchParams.get('v');
+    } else {
+      const match = parsed.pathname.match(
+        /^\/(?:embed|live|shorts|v)\/([^/]+)/,
+      );
+      id = match ? match[1] : null;
+    }
+  }
+
+  // A YouTube video id is exactly 11 URL-safe chars. Anything else (a channel
+  // link, a truncated path) falls back to null so the caller shows a link.
+  if (!id || !/^[A-Za-z0-9_-]{11}$/.test(id)) return null;
+  return `https://www.youtube-nocookie.com/embed/${id}`;
+}

--- a/pages/talks/[slug]/index.tsx
+++ b/pages/talks/[slug]/index.tsx
@@ -4,11 +4,13 @@ import Head from 'next/head';
 import type { TalkFrontMatter } from 'types/TalkFrontMatter';
 import Link from '@/components/Link';
 import LiveTalkBanner from '@/components/LiveTalkBanner';
+import RecordingEmbed from '@/components/RecordingEmbed';
 import { PageSEO } from '@/components/SEO';
 import Tag from '@/components/Tag';
 import siteMetadata from '@/data/siteMetadata';
 import { getTalkMeta, getTalkStaticPaths } from '@/lib/talks';
 import formatDate from '@/lib/utils/formatDate';
+import { youtubeEmbedUrl } from '@/lib/utils/youtubeEmbed';
 
 export const getStaticPaths = getTalkStaticPaths;
 
@@ -42,6 +44,9 @@ export default function TalkLanding({
     pdf,
     draft,
   } = frontMatter;
+
+  // A YouTube videoUrl becomes an inline player; anything else stays a link.
+  const embeddable = videoUrl ? youtubeEmbedUrl(videoUrl) !== null : false;
 
   return (
     <>
@@ -124,7 +129,7 @@ export default function TalkLanding({
           >
             Download PDF
           </Link>
-          {videoUrl && (
+          {videoUrl && !embeddable && (
             <Link
               href={videoUrl}
               className="border-2 border-white bg-brutalist-pink px-6 py-3 font-mono font-bold uppercase text-black shadow-hard-md transition-all hover:shadow-hard-lg active:translate-x-1 active:translate-y-1 active:shadow-none"
@@ -136,6 +141,8 @@ export default function TalkLanding({
             {slideCount} slides
           </span>
         </div>
+
+        {videoUrl && <RecordingEmbed url={videoUrl} title={title} />}
       </article>
     </>
   );

--- a/tests/youtube-embed.test.ts
+++ b/tests/youtube-embed.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { youtubeEmbedUrl } from '../lib/utils/youtubeEmbed';
+
+const EMBED = 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ';
+
+describe('youtubeEmbedUrl', () => {
+  it.each([
+    'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    'https://youtube.com/watch?v=dQw4w9WgXcQ',
+    'https://m.youtube.com/watch?v=dQw4w9WgXcQ',
+    'https://youtu.be/dQw4w9WgXcQ',
+    'https://youtu.be/dQw4w9WgXcQ?t=42',
+    'https://www.youtube.com/embed/dQw4w9WgXcQ',
+    'https://www.youtube.com/live/dQw4w9WgXcQ',
+    'https://www.youtube.com/shorts/dQw4w9WgXcQ',
+    'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+  ])('embeds YouTube URL: %s', (url) => {
+    expect(youtubeEmbedUrl(url)).toBe(EMBED);
+  });
+
+  it('keeps extra query params off the embed (only the id is used)', () => {
+    expect(
+      youtubeEmbedUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=abc'),
+    ).toBe(EMBED);
+  });
+
+  it.each([
+    'https://vimeo.com/123456789',
+    'https://example.com/talk.mp4',
+    '/talks/foo/present?printMode=true',
+    'not a url',
+    '',
+    // A channel/playlist link is not a single video.
+    'https://www.youtube.com/@someone',
+    'https://www.youtube.com/playlist?list=PL123',
+    // An id of the wrong length is rejected rather than embedded blindly.
+    'https://youtu.be/short',
+  ])('returns null for non-embeddable URL: %s', (url) => {
+    expect(youtubeEmbedUrl(url)).toBeNull();
+  });
+});

--- a/types/TalkFrontMatter.ts
+++ b/types/TalkFrontMatter.ts
@@ -27,7 +27,11 @@ export type TalkFrontMatter = {
   durationMins?: number;
   /** Optional path to a pre-rendered PDF in /public (overrides the print export). */
   pdf?: string;
-  /** Optional link to a recording of the talk. */
+  /**
+   * Optional link to a recording of the talk. A YouTube URL (watch / youtu.be /
+   * live / shorts) renders as an inline player on the talk page; any other URL
+   * renders as a "Watch Recording" link. See lib/utils/youtubeEmbed.ts.
+   */
   videoUrl?: string;
   /**
    * Named background definitions. A slide picks one by name via a


### PR DESCRIPTION
## What

A talk's `videoUrl` front-matter now renders as an **inline 16:9 player** on the talk page when it's a YouTube link (`watch` / `youtu.be` / `live` / `shorts` / `embed`), using a privacy-enhanced `youtube-nocookie` embed. Any other URL keeps the existing **"Watch Recording"** link button.

## Why

This is the archival counterpart to the live Convex room. In the room, Convex + the projector are the source of truth. A **local OBS recording** (screen + webcam PiP) captures the whole projected surface — slides *and* live demos — which the slide-sync model structurally can't. Recording locally (no streaming) keeps the network off the critical path so a demo isn't interrupted; the file is uploaded to YouTube after, then linked via `videoUrl`.

## Changes

- `lib/utils/youtubeEmbed.ts` — pure helper: YouTube URL → `youtube-nocookie` embed URL, or `null` (validates the 11-char id, so non-video links fall through to a plain link).
- `components/RecordingEmbed.tsx` — responsive 16:9 embed in a brutalist frame; renders nothing for non-YouTube URLs.
- `pages/talks/[slug]/index.tsx` — embed when `videoUrl` is YouTube; keep the link only for non-embeddable URLs.
- `types/TalkFrontMatter.ts` — documents the embed-vs-link behaviour on `videoUrl`.
- `tests/youtube-embed.test.ts` — 18 cases (all URL forms, query-param stripping, non-embeddable/garbage → null).

## Verification

- 18 unit tests pass; `tsc --noEmit` clean; biome clean.
- Drove `/talks/e2e-debug-deck` in dev with a temporary YouTube `videoUrl`: the `youtube-nocookie` iframe + "Recording" heading render, and the "Watch Recording" link is correctly suppressed.
- Backward compatible: no `videoUrl` → page unchanged; non-YouTube `videoUrl` → existing link button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)