### PR TITLE
feat(security): preconfigured security headers + CSP

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,64 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
 
+// Every external origin the site talks to must be listed here. Current set:
+// - giscus.app                comments widget (script + iframe)
+// - www.youtube-nocookie.com  talk recording embeds (RecordingEmbed)
+// - *.convex.cloud            realtime backend (HTTPS + WebSocket)
+// - fonts.googleapis.com / fonts.gstatic.com  Inter stylesheet in _document
+// - cdn.jsdelivr.net          KaTeX stylesheet in _document
+// 'unsafe-eval' is required by mdx-bundler, which evaluates compiled MDX
+// with `new Function` at render time.
+const ContentSecurityPolicy = `
+  default-src 'self';
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app;
+  style-src 'self' 'unsafe-inline' fonts.googleapis.com cdn.jsdelivr.net;
+  img-src * blob: data:;
+  media-src 'self';
+  connect-src 'self' https://*.convex.cloud wss://*.convex.cloud;
+  font-src 'self' data: fonts.gstatic.com cdn.jsdelivr.net;
+  frame-src giscus.app www.youtube-nocookie.com;
+  frame-ancestors 'none';
+`;
+
+const securityHeaders = [
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+  {
+    key: 'Content-Security-Policy',
+    value: ContentSecurityPolicy.replace(/\n/g, ''),
+  },
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control
+  {
+    key: 'X-DNS-Prefetch-Control',
+    value: 'on',
+  },
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=31536000; includeSubDomains',
+  },
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+];
+
 /**
  * @type {import('next').NextConfig}
  **/
@@ -14,4 +72,12 @@ module.exports = withBundleAnalyzer({
   // rehype-autolink-headings and its transitive deps) aren't resolvable at
   // runtime, which broke `next start` in CI. Bundling fixes the whole class.
   bundlePagesRouterDependencies: true,
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
+  },
 });


### PR DESCRIPTION
Ports the upstream [tailwind-nextjs-starter-blog](https://github.com/timlrx/tailwind-nextjs-starter-blog) preconfigured security headers — item 1 from `docs/template-divergence.md` §2 ("the clearest immediate win"). The site currently serves **no** security headers.

## What's included

- **Content-Security-Policy**, tuned to this site's real external origins (upstream's is looser, e.g. `connect-src *`):
  - `giscus.app` — comments widget (script + iframe)
  - `www.youtube-nocookie.com` — talk recording embeds (the only host `youtubeEmbedUrl` ever emits)
  - `https://*.convex.cloud` + `wss://*.convex.cloud` — realtime backend
  - `fonts.googleapis.com` / `fonts.gstatic.com` and `cdn.jsdelivr.net` — stylesheets currently linked from `_document.tsx`
  - `'unsafe-eval'` in `script-src` is required by mdx-bundler (`new Function` over compiled MDX)
- **Referrer-Policy**, **X-Frame-Options: DENY** (+ `frame-ancestors 'none'`), **X-Content-Type-Options**, **X-DNS-Prefetch-Control**, **Strict-Transport-Security**, **Permissions-Policy**

## Verification

- `next build` passes; headers confirmed on a running `next start` via `curl -I`
- `pnpm lint`, `pnpm typecheck`, all 118 unit tests pass

## Notes

- If the Vercel preview toolbar is used on preview deployments, `vercel.live` will need adding to `script-src`/`frame-src`.
- Once the `next/font` and self-hosted-KaTeX PRs land, the `fonts.googleapis.com`, `fonts.gstatic.com`, and `cdn.jsdelivr.net` entries can be removed for a tighter policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFiJ82KhW9wja3tiKEcz6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFiJ82KhW9wja3tiKEcz6M)_