### PR TITLE
feat(mdx): citation and bibliography support via rehype-citation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ layout: string # Optional (default: PostLayout)
 series: # Optional multi-part posts
   name: string
   order: number
+bibliography: string # Optional .bib/CSL-JSON in data/ for [@BibKey] citations
 ```
 
 ### Pages Router (Not App Router)

--- a/data/references-data.bib
+++ b/data/references-data.bib
@@ -1,0 +1,10 @@
+@article{Nash1950,
+  title={Equilibrium points in n-person games},
+  author={Nash, John},
+  journal={Proceedings of the national academy of sciences},
+  volume={36},
+  number={1},
+  pages={48--49},
+  year={1950},
+  publisher={National Acad Sciences}
+}

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -107,6 +107,8 @@ getMachineId(); // machineId.ts — stable per-browser id (localStorage)
 - `rehype-slug` - Heading IDs
 - `rehype-autolink-headings` - Heading links
 - `rehype-katex` - Math rendering
+- `rehype-citation` - Citations/bibliography (only when the post's frontmatter
+  sets `bibliography:` — a .bib/CSL-JSON filename relative to `data/`)
 - `rehype-prism-plus` - Syntax highlighting
 
 ## CUSTOM PLUGINS

--- a/lib/mdx.ts
+++ b/lib/mdx.ts
@@ -4,6 +4,7 @@ import matter from 'gray-matter';
 import { bundleMDX } from 'mdx-bundler';
 import readingTime from 'reading-time';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
+import rehypeCitation from 'rehype-citation';
 import rehypeKatex from 'rehype-katex';
 import rehypeKatexNoTranslate from 'rehype-katex-notranslate';
 import rehypePrismPlus from 'rehype-prism-plus';
@@ -77,12 +78,31 @@ export function getRemarkPlugins(toc?: Toc): Pluggable[] {
  * Rehype plugins shared across all MDX compilation. Includes the Prism token
  * class-name remapper that powers the brutalist code highlighting.
  */
-export function getRehypePlugins(): Pluggable[] {
+export function getRehypePlugins(
+  options: { bibliography?: string } = {},
+): Pluggable[] {
   return [
     rehypeSlug,
     rehypeAutolinkHeadings,
     rehypeKatex,
     rehypeKatexNoTranslate,
+    // Citations ([@BibKey]) resolve against the post's `bibliography`
+    // frontmatter — a .bib/CSL-JSON filename relative to data/. bundleMDX
+    // strips frontmatter before rehype runs, so the caller reads the field
+    // and passes it in rather than letting rehype-citation look it up. The
+    // filename must stay relative: rehype-citation path.joins it onto `path`.
+    ...(options.bibliography
+      ? [
+          [
+            rehypeCitation,
+            {
+              bibliography: options.bibliography,
+              path: path.join(root, 'data'),
+              linkCitations: true,
+            },
+          ] as Pluggable,
+        ]
+      : []),
     [rehypePrismPlus, { ignoreMissing: true }] as Pluggable,
     (() => {
       return (tree: any) => {
@@ -152,6 +172,13 @@ export async function getFileBySlug<_T>(
 
   const toc: Toc = [];
 
+  // bundleMDX strips frontmatter before plugins run, so read the optional
+  // bibliography field up front and hand it to the rehype pipeline explicitly.
+  const { data: rawFrontmatter } = matter(source);
+  const bibliography = rawFrontmatter.bibliography
+    ? String(rawFrontmatter.bibliography)
+    : undefined;
+
   const { frontmatter, code } = await bundleMDX({
     source,
     // mdx imports can be automatically source from the components directory
@@ -163,7 +190,7 @@ export async function getFileBySlug<_T>(
       ];
       options.rehypePlugins = [
         ...(options.rehypePlugins ?? []),
-        ...getRehypePlugins(),
+        ...getRehypePlugins({ bibliography }),
       ];
       return options;
     },

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-timer-hook": "^4.0.6",
     "reading-time": "1.5.0",
     "rehype-autolink-headings": "^7.1.0",
+    "rehype-citation": "^2.3.2",
     "rehype-katex": "^7.0.1",
     "rehype-katex-notranslate": "^1.1.4",
     "rehype-prism-plus": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       rehype-autolink-headings:
         specifier: ^7.1.0
         version: 7.1.0
+      rehype-citation:
+        specifier: ^2.3.2
+        version: 2.3.2
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
@@ -457,6 +460,36 @@ packages:
     engines: {node: '>=20.0.0', yarn: '>=1.22.18'}
     peerDependencies:
       storybook: ^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0
+
+  '@citation-js/core@0.7.21':
+    resolution: {integrity: sha512-Vobv2/Yfnn6C6BVO/pvj7madQ7Mfzl83/jAWwixbemGF6ZThhGMz8++FD9hWHyHXDMYuLGa6fK68c2VsolZmTA==}
+    engines: {node: '>=16.0.0'}
+
+  '@citation-js/date@0.5.1':
+    resolution: {integrity: sha512-1iDKAZ4ie48PVhovsOXQ+C6o55dWJloXqtznnnKy6CltJBQLIuLLuUqa8zlIvma0ZigjVjgDUhnVaNU1MErtZw==}
+    engines: {node: '>=10.0.0'}
+
+  '@citation-js/name@0.4.2':
+    resolution: {integrity: sha512-brSPsjs2fOVzSnARLKu0qncn6suWjHVQtrqSUrnqyaRH95r/Ad4wPF5EsoWr+Dx8HzkCGb/ogmoAzfCsqlTwTQ==}
+    engines: {node: '>=6'}
+
+  '@citation-js/plugin-bibjson@0.7.21':
+    resolution: {integrity: sha512-Q3eRpeV3pDqX91fvJ8xoYGJk4jB5MQD2woEr6GAoAauAzGVE19J5Lw0SksCHegoAn4z0ZbWMXtOq6rwZPtERbA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@citation-js/core': ^0.7.0
+
+  '@citation-js/plugin-bibtex@0.7.21':
+    resolution: {integrity: sha512-O008pSsJgiYKn4+7gAWrbNpNdUH++aMeYmZaJ2oFQ8X1tcY5jNBxJcr0zZojNtUi5CVOaXXHQ0yIifoUhuF2Vg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@citation-js/core': ^0.7.0
+
+  '@citation-js/plugin-csl@0.7.22':
+    resolution: {integrity: sha512-/rGdtbeP3nS4uZDdEbQUHT8PrUcIs0da2t+sWMKYXoOhXQqfw3oJJ7p4tUD+R8lptyIR5Eq20/DFk/kQDdLpYg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@citation-js/core': ^0.7.0
 
   '@convex-dev/auth@0.0.94':
     resolution: {integrity: sha512-A/ily6mXQFhSOUAYoiVZdzAZj3RBhiU4d2MOqpEByL7Uzzub6Y+MYQCzSTi0hQzE1dv7dVHprFku0lQuiq6A5w==}
@@ -2819,6 +2852,9 @@ packages:
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -2920,6 +2956,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -3035,6 +3074,9 @@ packages:
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
+
+  citeproc@2.4.63:
+    resolution: {integrity: sha512-68F95Bp4UbgZU/DBUGQn0qV3HDZLCdI9+Bb2ByrTaNJDL5VEm9LqaiNaxljsvoaExSLEXe1/r6n2Z06SCzW3/Q==}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -3167,6 +3209,9 @@ packages:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
     engines: {node: '>=20'}
     hasBin: true
+
+  cross-fetch@4.1.0:
+    resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3480,6 +3525,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -3652,6 +3701,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-ponyfill@7.1.0:
+    resolution: {integrity: sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==}
 
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
@@ -4147,6 +4199,10 @@ packages:
 
   js-yaml@3.15.0:
     resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+    hasBin: true
+
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsc-safe-url@0.2.4:
@@ -4715,6 +4771,9 @@ packages:
   module-alias@2.3.4:
     resolution: {integrity: sha512-bOclZt8hkpuGgSSoG07PKmvzTizROilUTvLNyrMqvlC9snhs7y7GzjNWAVbISIOlhCP1T14rH1PDAV9iNyBq/w==}
 
+  moo@0.5.3:
+    resolution: {integrity: sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==}
+
   mousetrap@1.6.5:
     resolution: {integrity: sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==}
 
@@ -4777,6 +4836,24 @@ packages:
       babel-plugin-react-compiler:
         optional: true
       sass:
+        optional: true
+
+  node-fetch@2.6.13:
+    resolution: {integrity: sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
         optional: true
 
   node-int64@0.4.0:
@@ -4882,6 +4959,9 @@ packages:
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -5196,6 +5276,9 @@ packages:
 
   rehype-autolink-headings@7.1.0:
     resolution: {integrity: sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==}
+
+  rehype-citation@2.3.2:
+    resolution: {integrity: sha512-apeGbeIYrfbirZZMZ0KY9tEZPnMlqomlGbQDNJfMoTV8wBSmLq8XyBywlfHrPLvchFIq9Mrn7g7SmXdQob+5lw==}
 
   rehype-katex-notranslate@1.1.4:
     resolution: {integrity: sha512-zr2NMVDnTHAFyyVC14I00NDDlSwjvd//EWzIhazz6eNn34LeJQyFECaRBCVdqBIVA6KMvBooO26pfSZXjUG84Q==}
@@ -5615,6 +5698,10 @@ packages:
     peerDependencies:
       react: 19.2.7
 
+  sync-fetch@0.4.5:
+    resolution: {integrity: sha512-esiWJ7ixSKGpd9DJPBTC4ckChqdOjIwJfYhVHkcQ2Gnm41323p1TRmEI+esTQ9ppD+b5opps2OTEGTCGX5kF+g==}
+    engines: {node: '>=14'}
+
   tailwindcss@4.3.1:
     resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
 
@@ -5676,6 +5763,9 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -5994,6 +6084,9 @@ packages:
   webdriver-bidi-protocol@0.4.2:
     resolution: {integrity: sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webpack-bundle-analyzer@4.10.1:
     resolution: {integrity: sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==}
     engines: {node: '>= 10.13.0'}
@@ -6004,6 +6097,9 @@ packages:
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -6323,6 +6419,38 @@ snapshots:
       - '@chromatic-com/cypress'
       - '@chromatic-com/playwright'
       - '@chromatic-com/vitest'
+
+  '@citation-js/core@0.7.21':
+    dependencies:
+      '@citation-js/date': 0.5.1
+      '@citation-js/name': 0.4.2
+      fetch-ponyfill: 7.1.0
+      sync-fetch: 0.4.5
+    transitivePeerDependencies:
+      - encoding
+
+  '@citation-js/date@0.5.1': {}
+
+  '@citation-js/name@0.4.2': {}
+
+  '@citation-js/plugin-bibjson@0.7.21(@citation-js/core@0.7.21)':
+    dependencies:
+      '@citation-js/core': 0.7.21
+      '@citation-js/date': 0.5.1
+      '@citation-js/name': 0.4.2
+
+  '@citation-js/plugin-bibtex@0.7.21(@citation-js/core@0.7.21)':
+    dependencies:
+      '@citation-js/core': 0.7.21
+      '@citation-js/date': 0.5.1
+      '@citation-js/name': 0.4.2
+      moo: 0.5.3
+
+  '@citation-js/plugin-csl@0.7.22(@citation-js/core@0.7.21)':
+    dependencies:
+      '@citation-js/core': 0.7.21
+      '@citation-js/date': 0.5.1
+      citeproc: 2.4.63
 
   '@convex-dev/auth@0.0.94(@auth/core@0.37.0)(convex@1.42.1(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -8306,6 +8434,8 @@ snapshots:
     dependencies:
       sprintf-js: 1.0.3
 
+  argparse@2.0.1: {}
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -8422,6 +8552,11 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -8531,6 +8666,8 @@ snapshots:
 
   ci-info@3.9.0: {}
 
+  citeproc@2.4.63: {}
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -8636,6 +8773,12 @@ snapshots:
     dependencies:
       '@epic-web/invariant': 1.0.0
       cross-spawn: 7.0.6
+
+  cross-fetch@4.1.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   cross-spawn@7.0.6:
     dependencies:
@@ -8937,6 +9080,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@8.0.0: {}
+
   environment@1.1.0: {}
 
   error-stack-parser@2.1.4:
@@ -9187,6 +9332,12 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-ponyfill@7.1.0:
+    dependencies:
+      node-fetch: 2.6.13
+    transitivePeerDependencies:
+      - encoding
 
   fflate@0.8.3: {}
 
@@ -9752,6 +9903,10 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+
+  js-yaml@4.3.0:
+    dependencies:
+      argparse: 2.0.1
 
   jsc-safe-url@0.2.4: {}
 
@@ -10728,6 +10883,8 @@ snapshots:
 
   module-alias@2.3.4: {}
 
+  moo@0.5.3: {}
+
   mousetrap@1.6.5: {}
 
   mrmime@2.0.1: {}
@@ -10783,6 +10940,14 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-fetch@2.6.13:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-int64@0.4.0: {}
 
@@ -10924,6 +11089,10 @@ snapshots:
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
 
   parseurl@1.3.3: {}
 
@@ -11320,6 +11489,25 @@ snapshots:
       hast-util-is-element: 3.0.0
       unified: 11.0.5
       unist-util-visit: 5.1.0
+
+  rehype-citation@2.3.2:
+    dependencies:
+      '@citation-js/core': 0.7.21
+      '@citation-js/date': 0.5.1
+      '@citation-js/name': 0.4.2
+      '@citation-js/plugin-bibjson': 0.7.21(@citation-js/core@0.7.21)
+      '@citation-js/plugin-bibtex': 0.7.21(@citation-js/core@0.7.21)
+      '@citation-js/plugin-csl': 0.7.22(@citation-js/core@0.7.21)
+      citeproc: 2.4.63
+      cross-fetch: 4.1.0
+      hast-util-from-dom: 5.0.1
+      hast-util-from-parse5: 8.0.3
+      js-yaml: 4.3.0
+      parse5: 8.0.1
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+    transitivePeerDependencies:
+      - encoding
 
   rehype-katex-notranslate@1.1.4:
     dependencies:
@@ -11980,6 +12168,13 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  sync-fetch@0.4.5:
+    dependencies:
+      buffer: 5.7.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   tailwindcss@4.3.1: {}
 
   tapable@2.3.3: {}
@@ -12023,6 +12218,8 @@ snapshots:
   toml@3.0.0: {}
 
   totalist@3.0.1: {}
+
+  tr46@0.0.3: {}
 
   trim-lines@3.0.1: {}
 
@@ -12322,6 +12519,8 @@ snapshots:
 
   webdriver-bidi-protocol@0.4.2: {}
 
+  webidl-conversions@3.0.1: {}
+
   webpack-bundle-analyzer@4.10.1:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
@@ -12344,6 +12543,11 @@ snapshots:
   webpack-virtual-modules@0.6.2: {}
 
   whatwg-fetch@3.6.20: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:

--- a/tests/citations.test.ts
+++ b/tests/citations.test.ts
@@ -1,0 +1,48 @@
+import { bundleMDX } from 'mdx-bundler';
+import { describe, expect, it } from 'vitest';
+import {
+  getRehypePlugins,
+  getRemarkPlugins,
+  setEsbuildBinaryPath,
+} from '../lib/mdx';
+
+const bibliography = 'references-data.bib';
+
+async function render(source: string, options?: { bibliography?: string }) {
+  setEsbuildBinaryPath();
+  const { code } = await bundleMDX({
+    source,
+    mdxOptions(mdxOptions) {
+      mdxOptions.remarkPlugins = [
+        ...(mdxOptions.remarkPlugins ?? []),
+        ...getRemarkPlugins(),
+      ];
+      mdxOptions.rehypePlugins = [
+        ...(mdxOptions.rehypePlugins ?? []),
+        ...getRehypePlugins(options),
+      ];
+      return mdxOptions;
+    },
+  });
+  return code;
+}
+
+describe('rehype-citation pipeline', () => {
+  it('resolves [@BibKey] citations and appends a bibliography', async () => {
+    const code = await render('As shown in [@Nash1950], equilibria exist.', {
+      bibliography,
+    });
+    // In-text citation rendered from the .bib entry, not left as raw syntax.
+    expect(code).toContain('Nash');
+    expect(code).toContain('1950');
+    expect(code).not.toContain('[@Nash1950]');
+    // Reference list appended at the end of the document.
+    expect(code).toContain('Equilibrium points in n-person games');
+  });
+
+  it('leaves posts without a bibliography untouched', async () => {
+    const code = await render('Plain post, no citations.');
+    expect(code).toContain('Plain post, no citations.');
+    expect(code).not.toContain('csl');
+  });
+});

--- a/types/PostFrontMatter.ts
+++ b/types/PostFrontMatter.ts
@@ -20,4 +20,10 @@ export type PostFrontMatter = {
     name: string;
     order: number;
   };
+  /**
+   * Bibliography file (.bib or CSL-JSON) relative to data/, e.g.
+   * "references-data.bib". Enables [@BibKey] citations via rehype-citation;
+   * a bibliography section is appended to the post.
+   */
+  bibliography?: string;
 };


### PR DESCRIPTION
Adopts upstream's citation/bibliography support — from `docs/template-divergence.md` §2 ("cheap to add to the remark/rehype stack and a good fit for long-form technical posts").

## Usage

```yaml
---
title: "..."
bibliography: references-data.bib   # .bib or CSL-JSON, relative to data/
---
As shown in [@Nash1950], equilibria exist.
```

In-text citations render formatted (linked via `linkCitations`), and a reference list is appended to the post.

## Implementation notes

- Upstream wires `rehype-citation` through contentlayer, where frontmatter stays visible to plugins. Here `bundleMDX` strips frontmatter before the rehype stage, so `getFileBySlug` reads the `bibliography` field with gray-matter up front and passes it to `getRehypePlugins({ bibliography })`.
- The plugin is only added when a post declares a bibliography — zero pipeline cost for all existing posts (verified by test).
- The filename must stay relative — `rehype-citation` `path.join`s it onto its `path` option (absolute paths break; found the hard way, covered by test).
- Includes `data/references-data.bib` seed, `PostFrontMatter.bibliography` typing, and updates to `AGENTS.md` frontmatter schema + `lib/AGENTS.md` plugin list.

## Verification

- New `tests/citations.test.ts` runs real sources through the actual `bundleMDX` pipeline: `[@Nash1950]` resolves to a formatted citation + appended reference list; posts without a bibliography are untouched
- `pnpm typecheck`, `pnpm lint`, all 120 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFiJ82KhW9wja3tiKEcz6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFiJ82KhW9wja3tiKEcz6M)_