### PR TITLE
perf(fonts): serve fonts via next/font/local, drop CDN + duplicate loading

### DIFF
--- a/components/AdminIndicator.tsx
+++ b/components/AdminIndicator.tsx
@@ -33,7 +33,7 @@ export default function AdminIndicator() {
         background: '#000',
         color: '#22d3ee',
         padding: '0.15rem 0.5rem',
-        fontFamily: '"IBM Plex Mono", monospace',
+        fontFamily: 'var(--font-ibm-plex-mono, "IBM Plex Mono"), monospace',
         fontSize: '0.65rem',
         fontWeight: 700,
         textTransform: 'uppercase',

--- a/components/talks/DeckLive.tsx
+++ b/components/talks/DeckLive.tsx
@@ -220,7 +220,7 @@ export function Follower({
         left: '50%',
         transform: 'translateX(-50%)',
         zIndex: 40,
-        fontFamily: '"IBM Plex Mono", monospace',
+        fontFamily: 'var(--font-ibm-plex-mono, "IBM Plex Mono"), monospace',
         fontWeight: 700,
         textTransform: 'uppercase',
         fontSize: '0.8rem',

--- a/components/talks/SpectacleDeck.tsx
+++ b/components/talks/SpectacleDeck.tsx
@@ -49,7 +49,8 @@ interface SpectacleDeckProps {
 
 type Mode = 'attendee' | 'presenter' | 'console';
 
-const MONO = '"IBM Plex Mono", "Courier New", Courier, monospace';
+const MONO =
+  'var(--font-ibm-plex-mono, "IBM Plex Mono"), "Courier New", Courier, monospace';
 
 // Brutalist deck chrome: fullscreen toggle, progress dots, slide counter.
 function Chrome({

--- a/components/talks/theme.ts
+++ b/components/talks/theme.ts
@@ -1,9 +1,11 @@
 import type { DeckProps } from 'spectacle';
 
 // Proposal C — Editorial Three-Role typography
-const DISPLAY = '"Space Grotesk", ui-sans-serif, system-ui, sans-serif';
-const BODY = 'Inter, system-ui, sans-serif';
-const MONO = '"IBM Plex Mono", "Courier New", Courier, monospace';
+const DISPLAY =
+  'var(--font-space-grotesk, "Space Grotesk"), ui-sans-serif, system-ui, sans-serif';
+const BODY = 'var(--font-inter, Inter), system-ui, sans-serif';
+const MONO =
+  'var(--font-ibm-plex-mono, "IBM Plex Mono"), "Courier New", Courier, monospace';
 
 /**
  * Brutalist Spectacle theme. Most slide styling comes from the MDX content's

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -37,7 +37,7 @@
   }
 
   body {
-    font-family: Inter, system-ui, sans-serif;
+    font-family: var(--font-inter, Inter), system-ui, sans-serif;
     background-color: #000000;
     color: #ffffff;
     overflow-x: clip;
@@ -55,7 +55,9 @@
    The @tailwindcss/typography plugin does not emit a per-heading
    font-family, so headings would otherwise inherit the Inter body font. */
 .prose :where(h1, h2, h3, h4, h5, h6):not(:where([class~="not-prose"] *)) {
-  font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+  font-family:
+    var(--font-space-grotesk, "Space Grotesk"), ui-sans-serif, system-ui,
+    sans-serif;
 }
 
 .remark-code-title {
@@ -181,7 +183,9 @@ html {
   .ascii-divider::after {
     content: "//========================================//";
     display: block;
-    font-family: "IBM Plex Mono", "Courier New", Courier, monospace;
+    font-family:
+      var(--font-ibm-plex-mono, "IBM Plex Mono"), "Courier New", Courier,
+      monospace;
     color: #ffffff;
     text-align: center;
     margin: 1rem 0;

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -1,0 +1,126 @@
+import localFont from 'next/font/local';
+
+/**
+ * Site fonts, served through next/font/local instead of raw @fontsource CSS
+ * imports. The woff2 files still come from the pinned @fontsource packages
+ * (so font versions stay locked by pnpm), but next/font adds preloading,
+ * size-adjusted fallback metrics (less CLS on slow connections), and hashed
+ * family names scoped via CSS variables.
+ *
+ * This module must be imported from pages/_app.tsx — importing next/font from
+ * _document.tsx silently skips CSS extraction (no @font-face is emitted).
+ * _app defines the `--font-*` variables on :root via `fontRootVariables`, so
+ * they reach everything including portalled UI (kbar). Consumers reference
+ * them with a fallback — e.g. `var(--font-inter, Inter)` — so contexts
+ * without next/font (Storybook) degrade to system fonts instead of an
+ * invalid declaration.
+ *
+ * Latin subset only: next/font/local can't express @fontsource's per-subset
+ * unicode-range splits, and the site is English-language.
+ */
+
+export const inter = localFont({
+  src: [
+    {
+      path: '../node_modules/@fontsource/inter/files/inter-latin-400-normal.woff2',
+      weight: '400',
+      style: 'normal',
+    },
+    {
+      path: '../node_modules/@fontsource/inter/files/inter-latin-500-normal.woff2',
+      weight: '500',
+      style: 'normal',
+    },
+    {
+      path: '../node_modules/@fontsource/inter/files/inter-latin-600-normal.woff2',
+      weight: '600',
+      style: 'normal',
+    },
+    {
+      path: '../node_modules/@fontsource/inter/files/inter-latin-700-normal.woff2',
+      weight: '700',
+      style: 'normal',
+    },
+    {
+      path: '../node_modules/@fontsource/inter/files/inter-latin-800-normal.woff2',
+      weight: '800',
+      style: 'normal',
+    },
+  ],
+  display: 'swap',
+});
+
+export const spaceGrotesk = localFont({
+  src: [
+    {
+      path: '../node_modules/@fontsource/space-grotesk/files/space-grotesk-latin-400-normal.woff2',
+      weight: '400',
+      style: 'normal',
+    },
+    {
+      path: '../node_modules/@fontsource/space-grotesk/files/space-grotesk-latin-500-normal.woff2',
+      weight: '500',
+      style: 'normal',
+    },
+    {
+      path: '../node_modules/@fontsource/space-grotesk/files/space-grotesk-latin-600-normal.woff2',
+      weight: '600',
+      style: 'normal',
+    },
+    {
+      path: '../node_modules/@fontsource/space-grotesk/files/space-grotesk-latin-700-normal.woff2',
+      weight: '700',
+      style: 'normal',
+    },
+  ],
+  display: 'swap',
+});
+
+export const ibmPlexMono = localFont({
+  src: [
+    {
+      path: '../node_modules/@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-400-normal.woff2',
+      weight: '400',
+      style: 'normal',
+    },
+    {
+      path: '../node_modules/@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-500-normal.woff2',
+      weight: '500',
+      style: 'normal',
+    },
+    {
+      path: '../node_modules/@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-600-normal.woff2',
+      weight: '600',
+      style: 'normal',
+    },
+    {
+      path: '../node_modules/@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-700-normal.woff2',
+      weight: '700',
+      style: 'normal',
+    },
+  ],
+  display: 'swap',
+});
+
+export const vt323 = localFont({
+  src: [
+    {
+      path: '../node_modules/@fontsource/vt323/files/vt323-latin-400-normal.woff2',
+      weight: '400',
+      style: 'normal',
+    },
+  ],
+  display: 'swap',
+});
+
+/**
+ * CSS that exposes the hashed next/font family names as the site's font
+ * variables. Rendered as a <style> tag in _app.tsx; :root scope (rather than
+ * next/font's `variable` classes on a wrapper div) keeps portalled UI covered.
+ */
+export const fontRootVariables = `:root {
+  --font-inter: ${inter.style.fontFamily};
+  --font-space-grotesk: ${spaceGrotesk.style.fontFamily};
+  --font-ibm-plex-mono: ${ibmPlexMono.style.fontFamily};
+  --font-vt323: ${vt323.style.fontFamily};
+}`;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,19 +1,6 @@
-import '@fontsource/vt323/400.css';
-// Proposal C — Editorial Three-Role typography
-// Display: Space Grotesk · Body: Inter · Code/UI: IBM Plex Mono
-import '@fontsource/space-grotesk/400.css';
-import '@fontsource/space-grotesk/500.css';
-import '@fontsource/space-grotesk/600.css';
-import '@fontsource/space-grotesk/700.css';
-import '@fontsource/inter/400.css';
-import '@fontsource/inter/500.css';
-import '@fontsource/inter/600.css';
-import '@fontsource/inter/700.css';
-import '@fontsource/inter/800.css';
-import '@fontsource/ibm-plex-mono/400.css';
-import '@fontsource/ibm-plex-mono/500.css';
-import '@fontsource/ibm-plex-mono/600.css';
-import '@fontsource/ibm-plex-mono/700.css';
+// Proposal C — Editorial Three-Role typography, loaded via next/font/local
+// (lib/fonts.ts; --font-* variables defined on :root below).
+// Display: Space Grotesk · Body: Inter · Code/UI: IBM Plex Mono · Logo: VT323
 import '@/css/tailwind.css';
 
 import { ConvexAuthProvider } from '@convex-dev/auth/react';
@@ -27,6 +14,7 @@ import Analytics from '@/components/analytics';
 import LayoutWrapper from '@/components/LayoutWrapper';
 import SearchProvider from '@/components/search/SearchProvider';
 import { convex } from '@/lib/convexClient';
+import { fontRootVariables } from '@/lib/fonts';
 
 type NextPageWithLayout = AppProps['Component'] & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -47,6 +35,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <Head>
           <meta content="width=device-width, initial-scale=1" name="viewport" />
         </Head>
+        <style dangerouslySetInnerHTML={{ __html: fontRootVariables }} />
         <Analytics />
         {getLayout(<Component {...pageProps} />)}
       </SearchProvider>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -38,15 +38,6 @@ class MyDocument extends Document {
           <meta name="theme-color" content="#000000" />
           <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
           <link
-            rel="preconnect"
-            href="https://fonts.gstatic.com"
-            crossOrigin="anonymous"
-          />
-          <link
-            href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
-            rel="stylesheet"
-          />
-          <link
             rel="stylesheet"
             href="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css"
             integrity="sha384-Um5gpz1odJg5Z4HAmzPtgZKdTBHZdw8S29IecapCSB31ligYPhHQZMIlWLYQGVoc"

--- a/pages/talks/[slug]/present.tsx
+++ b/pages/talks/[slug]/present.tsx
@@ -89,7 +89,7 @@ export default function Present({
             color: '#f472b6',
             background: '#000',
             padding: '0.2rem 0.5rem',
-            fontFamily: '"IBM Plex Mono", monospace',
+            fontFamily: 'var(--font-ibm-plex-mono, "IBM Plex Mono"), monospace',
             fontSize: '0.7rem',
             fontWeight: 700,
             textTransform: 'uppercase',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,16 +26,21 @@ module.exports = {
       },
       fontFamily: {
         // Proposal C — Editorial Three-Role
-        sans: ['Inter', ...defaultTheme.fontFamily.sans], // body / reading
-        display: ['"Space Grotesk"', ...defaultTheme.fontFamily.sans], // headings / display
+        // Families come from next/font/local (lib/fonts.ts) via CSS variables;
+        // the var() fallbacks keep non-Next contexts (Storybook) on sane fonts.
+        sans: ['var(--font-inter, Inter)', ...defaultTheme.fontFamily.sans], // body / reading
+        display: [
+          'var(--font-space-grotesk, "Space Grotesk")',
+          ...defaultTheme.fontFamily.sans,
+        ], // headings / display
         mono: [
-          '"IBM Plex Mono"',
+          'var(--font-ibm-plex-mono, "IBM Plex Mono")',
           'Courier New',
           'Courier',
           'monospace',
           ...defaultTheme.fontFamily.mono,
         ], // code + UI / metadata
-        pixel: ['"VT323"', 'monospace'], // decorative accent (hero/logo)
+        pixel: ['var(--font-vt323, "VT323")', 'monospace'], // decorative accent (hero/logo)
       },
       colors: {
         primary: colors.teal,


### PR DESCRIPTION
Adopts the `next/font` item from `docs/template-divergence.md` §2 — and fixes a real duplication found on the way: `_document.tsx` was loading Inter from the Google Fonts CDN on every page **in addition to** the bundled `@fontsource` copy (render-blocking stylesheet + extra origin, same font twice).

## Approach

**`next/font/local`, fed by the pinned `@fontsource` woff2 files** (rather than `next/font/google`):

- Font versions stay locked by pnpm; builds need no network and can't drift when Google revs a font
- Still gets the next/font wins: preload links, generated size-adjust fallback metrics (less CLS), single self-hosted pipeline
- Zero third-party font origins — once this and #67 land, #66's CSP can drop `fonts.googleapis.com`, `fonts.gstatic.com`, and `cdn.jsdelivr.net`

## Wiring

- `lib/fonts.ts` defines the four roles (Inter / Space Grotesk / IBM Plex Mono / VT323) and exports `fontRootVariables` — a `:root { --font-* }` style injected in `_app.tsx`. `:root` scope (not next/font's `variable` classes on a wrapper) keeps portalled UI (kbar) covered.
- Every font-family reference now goes through `var(--font-x, Fallback)`: Tailwind config, `css/tailwind.css`, the Spectacle talk theme, and inline styles in `DeckLive`/`AdminIndicator`/presenter view. The fallback means Storybook (no next/font) degrades to system fonts instead of an invalid declaration.
- Gotcha documented in code: importing next/font from `_document.tsx` **silently skips CSS extraction** — no `@font-face` is emitted and everything falls back. Found the hard way; fonts must be imported from `_app`.
- Latin subset only (next/font/local can't express per-subset unicode-range splits; site is English).

## Verification

Against a production build in a real browser (`document.fonts` + computed styles):
- All four roles resolve to hashed next/font families with generated `* Fallback` metrics; fonts load; preloads emitted; **zero** requests to `fonts.googleapis.com`/`gstatic.com`
- Homepage screenshot pixel-identical rendering (Space Grotesk hero, mono nav, VT323 logo)
- `pnpm typecheck`, `pnpm lint`, all 118 unit tests, `next build` (45/45) pass

Visual snapshots may shift by sub-pixel metrics — worth including in the same CI snapshot update as #69/#70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFiJ82KhW9wja3tiKEcz6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFiJ82KhW9wja3tiKEcz6M)_