### PR TITLE
docs(readme): refresh to cover live-talk platform and full toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,20 +43,12 @@ pnpm post:wizard             # Interactive post composer
 
 ## Environment
 
-Copy `.env.example` to `.env` and fill in what you need. Everything is optional
-for a basic build — the blog runs without any of it:
-
-| Variable                 | Purpose                                                   |
-| ------------------------ | --------------------------------------------------------- |
-| `NEXT_PUBLIC_GISCUS_*`    | Giscus comments (repo, category, and their IDs)           |
-| `BUTTONDOWN_API_KEY`      | Newsletter signups via Buttondown                         |
-| `NEXT_PUBLIC_CONVEX_URL`  | Convex deployment URL for the live-talk features          |
-| `CONVEX_DEPLOYMENT`       | Convex deployment name (set by `npx convex dev`/`deploy`) |
-
-Without a Convex deployment, the audience-activity pages show a "not configured"
-notice and the rest of the site builds and runs unchanged. The moderation secret
-is **not** a Next.js env var — it lives in Convex
-(`npx convex env set MODERATION_KEY <secret>`).
+Copy `.env.example` to `.env` and fill in what you need — everything is optional
+for a basic build. It covers Giscus comments, the Buttondown newsletter, and the
+Convex deployment (`NEXT_PUBLIC_CONVEX_URL` / `CONVEX_DEPLOYMENT`) that powers the
+live-talk features. Without Convex, the audience-activity pages show a "not
+configured" notice and the rest of the site runs unchanged. See `.env.example`
+for the full list and inline notes.
 
 ## Project Structure
 
@@ -121,28 +113,24 @@ terminal-style UI. Design tokens are defined in `tailwind.config.js`.
 ## Testing & Quality
 
 ```bash
-pnpm test                    # Vitest (watch)
-pnpm test:unit               # Vitest (run once)
-pnpm test:coverage           # Unit tests with coverage
+pnpm test:unit               # Vitest unit tests
 pnpm test:e2e                # Playwright end-to-end + visual tests
-pnpm test:regression         # Diff local build vs deployed main
 pnpm lint                    # Biome check
 pnpm typecheck               # tsc --noEmit
-pnpm format                  # Biome format
 ```
 
-Visual snapshots are regenerated on CI (via the `playwright.yml`
-`workflow_dispatch`) so they match the Linux runner the checks compare against.
+Coverage, regression, and snapshot commands are listed in [AGENTS.md](./AGENTS.md).
+Visual snapshots are regenerated on CI so they match the runner the checks
+compare against.
 
 ## Contributing
 
 `main` enforces linear history — rebase feature branches onto `main` (no merge
-commits) and land PRs via squash merge. The PR gate (lint, typecheck, unit,
-build, e2e-visual) must be green.
+commits) and land PRs via squash merge, with the PR gate green.
 
-See [AGENTS.md](./AGENTS.md) for the full development workflow, architecture, and
-deployment details. It's the root of a hierarchical knowledge base with deeper
-docs under `components/`, `lib/`, and `tests/`.
+See [AGENTS.md](./AGENTS.md) for the full workflow, architecture, and deployment
+details — it's the root of a doc hierarchy with deeper guides under `components/`,
+`lib/`, and `tests/`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,46 +1,84 @@
 # Ryan Kelly's Blog
 
-Personal blog for sharing technical knowledge, tutorials, and insights.
+Personal blog for sharing technical knowledge, tutorials, and insights — plus a
+real-time **live-talk platform** where an audience joins from their own devices
+to react, ask questions, and answer polls during a presentation.
 
 **Live site:** [ryankelly.dev](https://ryankelly.dev)
 
 ## Tech Stack
 
-- **Framework:** Next.js 16 with React 19
-- **Styling:** Tailwind CSS v4
+- **Framework:** Next.js 16 (Pages Router) with React 19
+- **Styling:** Tailwind CSS v4 — custom brutalist design system
 - **Content:** MDX (Markdown + React components)
-- **Hosting:** Vercel
+- **Backend:** [Convex](https://convex.dev) — real-time talk sessions, presence, Q&A, polls
+- **Design system:** Storybook
 - **Comments:** Giscus (GitHub Discussions)
+- **Newsletter:** Buttondown
+- **Hosting:** Vercel
 
 Based on [tailwind-nextjs-starter-blog](https://github.com/timlrx/tailwind-nextjs-starter-blog).
+
+## Requirements
+
+- Node.js `>= 22`
+- pnpm `>= 9`
 
 ## Quick Start
 
 ```bash
-pnpm install    # Install dependencies
-pnpm dev        # Start dev server at http://localhost:3000
-pnpm storybook  # View design system at http://localhost:6006
-pnpm build      # Production build
-pnpm test:e2e   # Run tests
+pnpm install                 # Install dependencies
+cp .env.example .env         # Configure environment (see below)
+pnpm dev                     # Dev server at http://localhost:3000
 ```
 
-## Design System
-
-The brutalist design system is documented in Storybook. View component variations, typography styles, and usage examples:
+Other common tasks:
 
 ```bash
-pnpm storybook
+pnpm storybook               # Design system at http://localhost:6006
+pnpm build                   # Production build (+ sitemap, search index, RSS)
+pnpm post:create             # Scaffold a new blog post
+pnpm post:wizard             # Interactive post composer
 ```
 
-Stories are located in `stories/` and include:
+## Environment
 
-- Button variations (colors, sizes, shadows)
-- Card layouts (basic, with images, with ASCII art)
-- Typography system (headings, code blocks, terminal prompts)
+Copy `.env.example` to `.env` and fill in what you need. Everything is optional
+for a basic build — the blog runs without any of it:
+
+| Variable                 | Purpose                                                   |
+| ------------------------ | --------------------------------------------------------- |
+| `NEXT_PUBLIC_GISCUS_*`    | Giscus comments (repo, category, and their IDs)           |
+| `BUTTONDOWN_API_KEY`      | Newsletter signups via Buttondown                         |
+| `NEXT_PUBLIC_CONVEX_URL`  | Convex deployment URL for the live-talk features          |
+| `CONVEX_DEPLOYMENT`       | Convex deployment name (set by `npx convex dev`/`deploy`) |
+
+Without a Convex deployment, the audience-activity pages show a "not configured"
+notice and the rest of the site builds and runs unchanged. The moderation secret
+is **not** a Next.js env var — it lives in Convex
+(`npx convex env set MODERATION_KEY <secret>`).
+
+## Project Structure
+
+```
+blog/
+├── components/   # React components + brutalist design system
+├── convex/       # Real-time backend: talk sessions, presence, Q&A, polls
+├── data/
+│   ├── blog/     # Blog post MDX
+│   └── talks/    # Talk deck MDX (slide-split decks)
+├── layouts/      # MDX layouts (PostLayout, ListLayout, SeriesLayout, …)
+├── lib/          # MDX pipeline, remark/rehype plugins, utilities
+├── pages/        # Next.js Pages Router (incl. /talks, /live, /admin)
+├── scripts/      # Build scripts (sitemap, search index, RSS, post scaffolding)
+├── stories/      # Storybook stories
+└── tests/        # Playwright (e2e + visual) and Vitest (unit)
+```
 
 ## Writing Content
 
-Blog posts are MDX files in `data/blog/`. Create a new post:
+Blog posts are MDX files in `data/blog/`. Scaffold one with `pnpm post:create`,
+or add it by hand:
 
 ```yaml
 ---
@@ -48,14 +86,64 @@ title: "Post Title"
 date: "2026-01-15"
 tags: ["tag1", "tag2"]
 summary: "Brief description"
+draft: false          # optional — hide from production
+series:               # optional — multi-part posts
+  name: "Series Name"
+  order: 1
 ---
-Your content here...
+
+Your content here…
 ```
+
+## Live Talks
+
+A presenter runs a slide deck (`data/talks/<slug>.mdx`) while the audience joins
+from their own devices via `/live` to react, ask questions, and answer polls —
+all in real time through Convex. Presenter controls and moderation live behind a
+GitHub-authenticated `/admin` surface.
+
+See [`CONTEXT.md`](./CONTEXT.md) for the domain language (Talk vs. Session,
+Attendee, Presenter, reveal, moderation) and `docs/adr/` for the design
+decisions behind it.
+
+## Design System
+
+The brutalist design system — hard shadows, 2px borders, zero border-radius, and
+a cyan/pink/yellow palette on black — is documented in Storybook:
+
+```bash
+pnpm storybook
+```
+
+Stories live in `stories/` and cover buttons, cards, typography, and
+terminal-style UI. Design tokens are defined in `tailwind.config.js`.
+
+## Testing & Quality
+
+```bash
+pnpm test                    # Vitest (watch)
+pnpm test:unit               # Vitest (run once)
+pnpm test:coverage           # Unit tests with coverage
+pnpm test:e2e                # Playwright end-to-end + visual tests
+pnpm test:regression         # Diff local build vs deployed main
+pnpm lint                    # Biome check
+pnpm typecheck               # tsc --noEmit
+pnpm format                  # Biome format
+```
+
+Visual snapshots are regenerated on CI (via the `playwright.yml`
+`workflow_dispatch`) so they match the Linux runner the checks compare against.
 
 ## Contributing
 
-See [AGENTS.md](./AGENTS.md) for development workflow, testing, and deployment details.
+`main` enforces linear history — rebase feature branches onto `main` (no merge
+commits) and land PRs via squash merge. The PR gate (lint, typecheck, unit,
+build, e2e-visual) must be green.
+
+See [AGENTS.md](./AGENTS.md) for the full development workflow, architecture, and
+deployment details. It's the root of a hierarchical knowledge base with deeper
+docs under `components/`, `lib/`, and `tests/`.
 
 ## License
 
-MIT
+[MIT](./LICENSE)


### PR DESCRIPTION
## Summary

The `README.md` had drifted behind the project. It described the site as just Next.js + MDX with "Giscus comments" and omitted the biggest feature added since — the **Convex-backed live-talk platform** (real-time presence, Q&A, polls, moderation). It also listed only a handful of the real commands and had no setup guidance.

This refresh brings it up to date, then trims it so it stays lean and doesn't duplicate the deeper docs (`AGENTS.md`, `CONTEXT.md`).

## Changes

- **Tech stack** now lists the Convex backend, Storybook, and Buttondown newsletter.
- **New "Live Talks" section** describing the presenter/audience flow, linking to `CONTEXT.md` and `docs/adr/`.
- **Requirements** (Node ≥ 22, pnpm ≥ 9) surfaced from `package.json`.
- **Environment** section pointing at `.env.example`, noting the site runs fine without Convex.
- **Project structure** tree for quick orientation.
- **Commands** expanded to the ones contributors actually run (post scaffolding, unit/e2e tests, lint, typecheck), with reference-only commands deferred to `AGENTS.md`.
- **Contributing** notes the real workflow (linear history, rebase, squash merge) and points to the `AGENTS.md` doc hierarchy.

Everything was verified against `package.json`, `AGENTS.md`, `CONTEXT.md`, and `.env.example`. Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015PBi2gUqngsw2m1oAA4WgX)_