### PR TITLE
ci(visual): /update-snapshots command that commits snapshots back to the PR

### DIFF
--- a/.github/workflows/update-snapshots-command.yml
+++ b/.github/workflows/update-snapshots-command.yml
@@ -1,0 +1,141 @@
+name: Update snapshots (command)
+
+# On-demand visual-snapshot integration, triggered by a PR comment.
+#
+# Comment `/update-snapshots` on a pull request and this workflow regenerates
+# the committed Linux visual-regression snapshots on a CI runner (so they match
+# what pr-checks.yml → e2e-visual compares against) and commits them straight
+# back to the PR branch. This replaces the manual dance of running
+# `pnpm test:snapshots:remote` locally, downloading the artifact, and
+# hand-committing the files.
+#
+# Human-gated by design: a maintainer decides when a visual diff is an
+# INTENTIONAL change worth baking in. CI never blindly accepts a diff, so a
+# genuine regression still fails the gate instead of being silently absorbed.
+#
+# Note on re-runs: pushes made with the default GITHUB_TOKEN do not themselves
+# re-trigger the `pull_request` gate. Set a `SNAPSHOT_PAT` repo secret (a PAT or
+# fine-grained token with `contents: write`) and the snapshot commit will push
+# under it so pr-checks re-runs automatically; without it, re-run "PR checks"
+# manually (or push any commit) to see the refreshed gate.
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: update-snapshots-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  update-snapshots:
+    name: Regenerate & commit snapshots
+    # Only on PR comments issuing the command, from someone who can push here.
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/update-snapshots') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Acknowledge command
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
+      - name: Resolve PR head branch
+        id: pr
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const headRepo = pr.data.head.repo?.full_name ?? '';
+            const sameRepo = headRepo === `${context.repo.owner}/${context.repo.repo}`;
+            core.setOutput('ref', pr.data.head.ref);
+            core.setOutput('same_repo', String(sameRepo));
+
+      - name: Guard against fork PRs
+        if: steps.pr.outputs.same_repo != 'true'
+        run: |
+          echo "::error::/update-snapshots only supports PR branches in this repository (a fork's branch can't be pushed to)."
+          exit 1
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          path: blog
+          ref: ${{ steps.pr.outputs.ref }}
+          # Persisted so the snapshot commit can be pushed back. Prefer a PAT
+          # (SNAPSHOT_PAT) so the push re-triggers pr-checks; fall back to the
+          # default token, which commits fine but won't re-trigger workflows.
+          token: ${{ secrets.SNAPSHOT_PAT || secrets.GITHUB_TOKEN }}
+
+      - uses: ./blog/.github/actions/setup-blog
+        with:
+          install-playwright: "true"
+
+      - name: Build the site
+        working-directory: blog
+        run: pnpm build
+
+      - name: Regenerate snapshots
+        working-directory: blog
+        # Same command playwright.yml uses; webServer serves the build just built.
+        run: pnpm exec playwright test --update-snapshots
+
+      - name: Commit & push snapshots
+        id: commit
+        working-directory: blog
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- tests/__snapshots__; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Committed snapshots already match the freshly generated ones — nothing to commit."
+            exit 0
+          fi
+          git add tests/__snapshots__
+          git commit -m "test(visual): regenerate snapshots via /update-snapshots"
+          git push origin "HEAD:${{ steps.pr.outputs.ref }}"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Report result
+        if: always()
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const status = '${{ job.status }}';
+            const changed = '${{ steps.commit.outputs.changed }}';
+            let body;
+            if (status !== 'success') {
+              body = '❌ `/update-snapshots` failed before it could commit — see the [workflow run](' +
+                `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})` +
+                ' for details.';
+            } else if (changed === 'true') {
+              body = '✅ Regenerated the visual snapshots and pushed them to this branch. ' +
+                'If the PR gate does not re-run on its own, re-run **PR checks** (a `SNAPSHOT_PAT` secret makes this automatic).';
+            } else {
+              body = 'ℹ️ Ran `--update-snapshots`, but the committed snapshots already matched — nothing to commit.';
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,20 +213,24 @@ PR → .github/workflows/pr-checks.yml
 
 push main → .github/workflows/ci.yml   # full suite + uploads `coverage-main` baseline
 workflow_dispatch → playwright.yml      # manual-only: regenerate Linux snapshots
+PR comment `/update-snapshots`          # regenerate snapshots AND commit them
+  → update-snapshots-command.yml        #   back to the PR branch (see below)
 ```
 
 - Each feeder job runs its command with `continue-on-error` and exports its
   outcome; the `conclusion` job aggregates them and is the only merge-blocking check.
 - Visual regression (`visual.spec.ts` / `visual-responsive.spec.ts`) runs inside
   `e2e-visual` against a locally built site (no Vercel dependency). **Blocking** —
-  intentional visual changes must ship regenerated snapshots (via `playwright.yml`)
-  in the same PR.
+  intentional visual changes must ship regenerated snapshots in the same PR.
 - Coverage delta is computed deterministically by `scripts/ci/coverage-delta.mjs`
   against the `coverage-main` artifact published by `ci.yml` on each main push.
 - Shared setup (mermaid-toolkit checkout + build, pnpm/node install) lives in the
   repo-local composite action `.github/actions/setup-blog`.
-- Snapshots must be (re)generated on the CI runner via `playwright.yml`
-  (`workflow_dispatch`) so they match what `e2e-visual` compares against.
+- Snapshots must be (re)generated on the CI runner so they match what
+  `e2e-visual` compares against. On a PR, comment `/update-snapshots` and
+  `update-snapshots-command.yml` regenerates them and commits them back to the
+  branch; `playwright.yml` (`workflow_dispatch`) remains for the artifact-only
+  path. Both are maintainer-gated (the command checks author association).
 
 ### Branch workflow
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -39,17 +39,25 @@ tests/
 **Update flow:**
 
 ```bash
-# Option 1: Trigger CI workflow
+# Option 1 (PRs): comment on the PR — CI regenerates AND commits the
+# snapshots back to the branch for you (update-snapshots-command.yml).
+/update-snapshots
+
+# Option 2: trigger CI, then pull the artifact down locally
 pnpm test:update-snapshots
 
-# Option 2: Manual via GitHub Actions
+# Option 3: manual via GitHub Actions
 gh workflow run playwright.yml --ref <branch> -f update_snapshots=true
 
-# Then download and commit
+# For options 2 & 3, download and commit the regenerated files
 gh run download <run-id> -n playwright-snapshots
 cp -r playwright-snapshots/* tests/__snapshots__/
 git add tests/__snapshots__ && git commit
 ```
+
+Option 1 is human-gated on purpose: you only comment `/update-snapshots` once
+you've confirmed the visual diff is intentional, so a genuine regression still
+fails the gate rather than being auto-absorbed.
 
 **Snapshot path template:**
 


### PR DESCRIPTION
Automates integration of regenerated visual-regression snapshots, so intentional visual changes no longer need the manual regenerate → download artifact → hand-commit dance.

## What
New workflow `.github/workflows/update-snapshots-command.yml`. Comment **`/update-snapshots`** on a PR and CI:
1. resolves the PR's head branch,
2. checks it out, builds the site, runs `pnpm exec playwright test --update-snapshots` on the Linux runner (so snapshots match what `pr-checks.yml → e2e-visual` compares against),
3. commits any changed `tests/__snapshots__/` files and pushes them **back to the PR branch**,
4. reacts to the command and comments the result.

## Why this shape
- **Human-gated, not automatic-on-failure.** The command requires an explicit comment from someone with push access (`OWNER`/`MEMBER`/`COLLABORATOR`). CI never blindly accepts a visual diff, so a genuine regression still fails the gate rather than being silently absorbed — you run it only once you've confirmed the diff is intentional.
- **Builds on the existing snapshot path.** Same regeneration command as `playwright.yml`; that manual/artifact workflow stays for the download-locally case.
- **Re-trigger caveat handled honestly.** Pushes made with the default `GITHUB_TOKEN` don't re-trigger the `pull_request` gate. The checkout prefers an optional `SNAPSHOT_PAT` secret (so the snapshot push re-runs pr-checks automatically) and falls back to `GITHUB_TOKEN`; the result comment tells you to re-run **PR checks** when no PAT is set.
- Fork PRs are guarded with a clear error (their branch can't be pushed to).

## Notes
- Independent of #55/#76 — branched off current `main`.
- Docs updated: `AGENTS.md` and `tests/AGENTS.md` now list `/update-snapshots` as the primary PR update flow.
- YAML validated; `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmzZDbScaUPFzjdSyeJnbN)_