### PR TITLE
fix(deps): restore codeload tarball resolution for @rtkelly/mermaid-toolkit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
         version: 5.2.7
       '@rtkelly/mermaid-toolkit':
         specifier: github:rtkelly13/mermaid-toolkit#a91c9d3
-        version: git+https://git@github.com:rtkelly13/mermaid-toolkit.git#a91c9d35128550180b59a3d576d6e34a61875c58(mermaid@11.16.0)
+        version: https://codeload.github.com/rtkelly13/mermaid-toolkit/tar.gz/a91c9d35128550180b59a3d576d6e34a61875c58(mermaid@11.16.0)
       '@tailwindcss/forms':
         specifier: ^0.5.11
         version: 0.5.11(tailwindcss@4.3.1)
@@ -2203,8 +2203,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rtkelly/mermaid-toolkit@git+https://git@github.com:rtkelly13/mermaid-toolkit.git#a91c9d35128550180b59a3d576d6e34a61875c58':
-    resolution: {commit: a91c9d35128550180b59a3d576d6e34a61875c58, repo: git@github.com:rtkelly13/mermaid-toolkit.git, type: git}
+  '@rtkelly/mermaid-toolkit@https://codeload.github.com/rtkelly13/mermaid-toolkit/tar.gz/a91c9d35128550180b59a3d576d6e34a61875c58':
+    resolution: {tarball: https://codeload.github.com/rtkelly13/mermaid-toolkit/tar.gz/a91c9d35128550180b59a3d576d6e34a61875c58}
     version: 0.0.1
     peerDependencies:
       mermaid: ^11.0.0
@@ -7709,7 +7709,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.55.1':
     optional: true
 
-  '@rtkelly/mermaid-toolkit@git+https://git@github.com:rtkelly13/mermaid-toolkit.git#a91c9d35128550180b59a3d576d6e34a61875c58(mermaid@11.16.0)':
+  '@rtkelly/mermaid-toolkit@https://codeload.github.com/rtkelly13/mermaid-toolkit/tar.gz/a91c9d35128550180b59a3d576d6e34a61875c58(mermaid@11.16.0)':
     dependencies:
       mermaid: 11.16.0
 


### PR DESCRIPTION
## What

Restores the `@rtkelly/mermaid-toolkit` resolution in `pnpm-lock.yaml` to its original `https://codeload.github.com/.../tar.gz/<sha>` tarball form.

## Why

During the PR-merge batch, a lockfile regeneration rewrote the resolution to `git+https://git@github.com:rtkelly13/mermaid-toolkit.git#<sha>` — an SSH clone URL. The `ci.yml` main-push workflow has no SSH key for that private repo, so `setup-blog` fails at install with `git@github.com: Permission denied (publickey)` before lint/typecheck/tests can run. (PR checks pass because that workflow authenticates over HTTPS.)

The codeload tarball is public and token-free, and is exactly what the last green `main` (commit `e1c7941`) used — the restored lines are byte-identical to it.

## Verification

- The three lockfile entries (importer version, package key, snapshot key) and the resolution metadata line now match `e1c7941` exactly.
- No `git@github.com:rtkelly13` references remain in the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJjybgFm7pXJkRrTDn61LT)_