### PR TITLE
feat(storybook): foundations tier, atom/molecule stories & paper-and-ink metaphor docs

### DIFF
--- a/components/BracketText.stories.tsx
+++ b/components/BracketText.stories.tsx
@@ -1,0 +1,33 @@
+// @ts-nocheck
+import type { Meta, StoryObj } from '@storybook/react';
+import BracketText from './BracketText';
+
+const meta = {
+  title: 'Atoms/BracketText',
+  component: BracketText,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof BracketText>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InHeading: Story = {
+  args: { children: 'BRACKETED_TITLE' },
+  render: (args) => (
+    <h1 className="font-display text-4xl font-bold uppercase text-white">
+      <BracketText {...args} />
+    </h1>
+  ),
+};
+
+export const InlineAccent: Story = {
+  args: { children: 'STATUS' },
+  render: (args) => (
+    <p className="font-mono text-sm text-brutalist-cyan">
+      <BracketText {...args} />
+    </p>
+  ),
+};

--- a/components/Button.stories.tsx
+++ b/components/Button.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Button from './Button';
 
 const meta = {
-  title: 'Components/Button',
+  title: 'Atoms/Button',
   component: Button,
   parameters: {
     layout: 'centered',

--- a/components/Card.stories.tsx
+++ b/components/Card.stories.tsx
@@ -1,0 +1,42 @@
+// @ts-nocheck
+import type { Meta, StoryObj } from '@storybook/react';
+import Card from './Card';
+
+const meta = {
+  title: 'Molecules/Card',
+  component: Card,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    title: 'Design Systems',
+    description:
+      'One token set, three themes. Hard borders, hard shadows, zero radius.',
+    href: '/blog',
+  },
+};
+
+export const WithFilename: Story = {
+  args: {
+    title: 'Paper And Ink',
+    description: 'The SKETCH theme prints the terminal onto paper.',
+    filename: 'paper_and_ink.md',
+    href: '/blog',
+  },
+};
+
+export const WithAsciiArt: Story = {
+  args: {
+    title: 'Terminal Motifs',
+    description: 'ASCII art in the card chrome, on-brand for HIGH mode.',
+    asciiArt: '▓▒░',
+    href: '/blog',
+  },
+};

--- a/components/Link.stories.tsx
+++ b/components/Link.stories.tsx
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import type { Meta, StoryObj } from '@storybook/react';
+import Link from './Link';
+
+const meta = {
+  title: 'Atoms/Link',
+  component: Link,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Link>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Internal: Story = {
+  args: {
+    href: '/blog',
+    children: '> internal_link',
+    className: 'font-mono text-brutalist-cyan hover:text-brutalist-pink',
+  },
+};
+
+export const External: Story = {
+  args: {
+    href: 'https://example.com',
+    children: '> external_link (new tab)',
+    className: 'font-mono text-brutalist-cyan hover:text-brutalist-pink',
+  },
+};
+
+export const Anchor: Story = {
+  args: {
+    href: '#section',
+    children: '> anchor_link',
+    className: 'font-mono text-brutalist-yellow',
+  },
+};

--- a/components/NoteBlock.stories.tsx
+++ b/components/NoteBlock.stories.tsx
@@ -1,0 +1,52 @@
+// @ts-nocheck
+import type { Meta, StoryObj } from '@storybook/react';
+import NoteBlock from './NoteBlock';
+
+const meta = {
+  title: 'Atoms/NoteBlock',
+  component: NoteBlock,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    color: {
+      control: 'select',
+      options: ['primary', 'red', 'blue', 'green', 'yellow', 'gray'],
+    },
+  },
+} satisfies Meta<typeof NoteBlock>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'Note',
+    color: 'primary',
+    children: 'Build only on remapped tokens; never hardcode hex literals.',
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    title: 'Warning',
+    color: 'yellow',
+    children: 'Neon glows are a dark-mode device — sketch swaps them for ink.',
+  },
+};
+
+export const AllColors: Story = {
+  args: { children: 'note' },
+  render: () => (
+    <div>
+      {(['primary', 'red', 'blue', 'green', 'yellow', 'gray'] as const).map(
+        (c) => (
+          <NoteBlock key={c} title={c} color={c}>
+            NoteBlock with the {c} accent.
+          </NoteBlock>
+        ),
+      )}
+    </div>
+  ),
+};

--- a/components/PageHeader.stories.tsx
+++ b/components/PageHeader.stories.tsx
@@ -1,0 +1,62 @@
+// @ts-nocheck
+import type { Meta, StoryObj } from '@storybook/react';
+import { FileText, Lightbulb, Presentation } from 'lucide-react';
+import PageHeader from './PageHeader';
+
+const meta = {
+  title: 'Molecules/PageHeader',
+  component: PageHeader,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    accent: {
+      control: 'select',
+      options: ['cyan', 'pink', 'yellow'],
+    },
+  },
+} satisfies Meta<typeof PageHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Pages own the content wrapper; mirror it so the header reads in context.
+const Wrapper = (Story) => (
+  <div className="divide-y divide-white border-2 border-white bg-black">
+    <Story />
+    <div className="px-6 py-8 font-mono text-sm text-zinc-400">
+      {'>'} listing content goes here
+    </div>
+  </div>
+);
+
+export const BlogCyan: Story = {
+  decorators: [Wrapper],
+  args: {
+    title: 'BLOG',
+    subtitle: 'Long-form writing on TypeScript, Convex and design systems',
+    icon: FileText,
+    accent: 'cyan',
+  },
+};
+
+export const TalksPink: Story = {
+  decorators: [Wrapper],
+  args: {
+    title: 'TALKS',
+    subtitle: 'Live decks and recordings',
+    icon: Presentation,
+    accent: 'pink',
+  },
+};
+
+export const IdeasYellow: Story = {
+  decorators: [Wrapper],
+  args: {
+    title: 'IDEAS',
+    subtitle: 'The workbench of half-formed things',
+    icon: Lightbulb,
+    accent: 'yellow',
+  },
+};

--- a/components/PageTitle.stories.tsx
+++ b/components/PageTitle.stories.tsx
@@ -1,0 +1,27 @@
+// @ts-nocheck
+import type { Meta, StoryObj } from '@storybook/react';
+import PageTitle from './PageTitle';
+
+const meta = {
+  title: 'Atoms/PageTitle',
+  component: PageTitle,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof PageTitle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'Page Title',
+  },
+};
+
+export const LongTitle: Story = {
+  args: {
+    children: 'Interactive MDX components for technical talks',
+  },
+};

--- a/components/Pagination.stories.tsx
+++ b/components/Pagination.stories.tsx
@@ -1,0 +1,36 @@
+// @ts-nocheck
+import type { Meta, StoryObj } from '@storybook/react';
+import Pagination from './Pagination';
+
+const meta = {
+  title: 'Molecules/Pagination',
+  component: Pagination,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Pagination>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FirstPage: Story = {
+  args: {
+    currentPage: 1,
+    totalPages: 5,
+  },
+};
+
+export const MiddlePage: Story = {
+  args: {
+    currentPage: 3,
+    totalPages: 5,
+  },
+};
+
+export const LastPage: Story = {
+  args: {
+    currentPage: 5,
+    totalPages: 5,
+  },
+};

--- a/components/PostHeaderImage.stories.tsx
+++ b/components/PostHeaderImage.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import PostHeaderImage from './PostHeaderImage';
 
 const meta = {
-  title: 'Components/PostHeaderImage',
+  title: 'Molecules/PostHeaderImage',
   component: PostHeaderImage,
   parameters: {
     layout: 'fullscreen',

--- a/components/TLDR.stories.tsx
+++ b/components/TLDR.stories.tsx
@@ -1,0 +1,21 @@
+// @ts-nocheck
+import type { Meta, StoryObj } from '@storybook/react';
+import TLDR from './TLDR';
+
+const meta = {
+  title: 'Atoms/TLDR',
+  component: TLDR,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof TLDR>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    text: 'One token set, three themes: write the terminal look once and the paper look comes for free.',
+  },
+};

--- a/components/Tag.stories.tsx
+++ b/components/Tag.stories.tsx
@@ -1,0 +1,40 @@
+// @ts-nocheck
+import type { Meta, StoryObj } from '@storybook/react';
+import Tag from './Tag';
+
+const meta = {
+  title: 'Atoms/Tag',
+  component: Tag,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Tag>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    text: 'typescript',
+  },
+};
+
+export const MultiWord: Story = {
+  args: {
+    text: 'design systems',
+  },
+};
+
+export const TagCloud: Story = {
+  args: { text: 'tags' },
+  render: () => (
+    <div className="flex max-w-md flex-wrap gap-3">
+      {['typescript', 'convex', 'design systems', 'nextjs', 'storybook'].map(
+        (t) => (
+          <Tag key={t} text={t} />
+        ),
+      )}
+    </div>
+  ),
+};

--- a/docs/design-system-evaluation.md
+++ b/docs/design-system-evaluation.md
@@ -1,0 +1,54 @@
+# Design-system evaluation — Storybook & atomic structure
+
+An audit of the design system against industry practice for specifying a
+design system in Storybook, done July 2026. The gaps identified here were
+closed in the same change; this doc records the reasoning.
+
+## Strengths (already best-practice)
+
+- **Single-source tokens with theme remapping.** `.dim` / `.sketch` re-point
+  Tailwind's own colour variables (`--color-black`, `--color-white`, the zinc
+  scale, `--brutalist-*`) in `css/tailwind.css`, so components written once
+  against tokens re-theme automatically. This is the pattern CSS-variable-driven
+  systems (Style Dictionary et al.) recommend.
+- **Documented, enforced anti-patterns** — zero radius, hard shadows only, no
+  `dark:` pairs, no hex literals, no emoji as UI (`docs/design-system.md`).
+- **Tooling already wired** — Storybook (`@storybook/nextjs-vite`) with a11y,
+  vitest, docs and Chromatic addons; a live `/design-sandbox` page.
+
+## Gaps found (and how they were closed)
+
+1. **No theme switching in Storybook.** The preview only offered dark/light
+   *canvas backgrounds*; SKETCH and DIM were unreviewable in Storybook, so the
+   "verify both modes" discipline couldn't be exercised where components are
+   specified. → Fixed: `.storybook/preview.tsx` adds a HIGH / DIM / SKETCH
+   toolbar whose decorator sets the theme class on `<html>`, exactly as
+   `next-themes` does via `ThemeSwitch`.
+2. **No foundations tier.** Industry-standard Storybooks specify tokens first
+   (colors, type scale, elevation) as docs-first pages. → Added
+   `stories/foundations/`: Colors, Typography (moved + font-role stories),
+   Borders & Shadows, and the **Paper & Ink** metaphor page.
+3. **Sparse coverage, no hierarchy.** Only `Button` and `PostHeaderImage` had
+   component stories, and titles didn't encode composition. → Stories added for
+   `Tag`, `Link`, `BracketText`, `PageTitle`, `NoteBlock`, `TLDR` (Atoms) and
+   `Card`, `PageHeader`, `Pagination` (Molecules); everything retitled into
+   `Foundations / Atoms / Molecules / Design Sandbox`.
+4. **The paper metaphor was implicit.** HIGH leans into terminal devices
+   (scanlines, `//====//` dividers, `>` prompts, glows) but SKETCH's paper
+   analogues were undocumented and incomplete — and the terminal utilities
+   themselves hardcoded hex literals, breaking their own remap rule. → The
+   token-by-token analogy is now specified in
+   `stories/foundations/PaperAndInk.mdx` (and summarised in
+   `docs/design-system.md`); `ascii-divider` / `terminal-prompt` /
+   `file-extension` now read tokens; SKETCH gained explicit paper motifs:
+   hand-ruled pencil-dash dividers, highlighter-yellow `::selection`, and
+   pencil-dashed prose rules.
+
+## Known remaining gaps
+
+- Convex-backed `talks/` and `admin/` components still can't be storied
+  (provider + dep-optimizer issues — todo #18).
+- Organisms (LayoutWrapper, Footer, CyberHero) have no stories; they depend on
+  Next.js router/site metadata and are lower value per effort.
+- Chromatic visual regression is installed but not run per theme; running the
+  suite once per theme class would lock the paper/terminal parity in CI.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -65,6 +65,27 @@ tokens invert automatically. The discipline for any new component:
 
 Full mechanics and the per-token tables: **[docs/theming.md](./theming.md)**.
 
+### The paper ↔ terminal analogy
+
+Sketch is not a "light mode" — it is the same system printed on paper. Each
+terminal device has an explicit paper analogue at the token level:
+
+| Terminal (HIGH)            | Token / mechanism                | Paper (SKETCH)              |
+| -------------------------- | -------------------------------- | --------------------------- |
+| Black screen               | `--color-black`                  | Warm paper sheet            |
+| White phosphor text        | `--color-white`                  | Graphite ink                |
+| Neon cyan / pink / yellow  | `--brutalist-*`                  | Blue pen / red pen / green marker |
+| Hard neon shadow           | `--brutalist-shadow-color`       | Letterpress ink offset      |
+| Green scanlines            | `--scanline-color` / `--page-texture` | Pencil-hatch texture   |
+| `//====//` ASCII divider   | `.ascii-divider`                 | Hand-ruled pencil dashes    |
+| Solid strokes              | mermaid `stroke-dasharray`       | Pencil-sketched outlines    |
+| Block-cursor selection     | `::selection` (sketch remap)     | Highlighter-marker swipe    |
+
+The full table with atomic-structure notes lives in Storybook
+(`Foundations/Paper & Ink`, from `stories/foundations/PaperAndInk.mdx`); the
+audit that produced it is
+**[docs/design-system-evaluation.md](./design-system-evaluation.md)**.
+
 ## Components & primitives
 
 Component-level guidance (the `PageHeader` / `PageTitle` header primitives, the

--- a/stories/README.md
+++ b/stories/README.md
@@ -1,6 +1,6 @@
 # Storybook Design System
 
-This directory contains Storybook stories for the blog's design system components.
+This directory contains Storybook stories for the blog's design system.
 
 ## Running Storybook
 
@@ -14,30 +14,42 @@ pnpm build-storybook
 
 Storybook runs on http://localhost:6006 in development mode.
 
-## Stories Organization
+## Theme toolbar
 
-### Design Sandbox Stories
+The toolbar (paintbrush icon) cycles **HIGH (dark) / DIM / SKETCH** by setting
+the theme class on `<html>`, exactly as `next-themes` does on the site. Every
+story must read as intentional in both HIGH and SKETCH — see
+`Foundations/Paper & Ink` for the paper ↔ terminal token analogy.
 
-These stories are ported from the `/design-sandbox` pages and showcase the brutalist design system:
+## Organization (composition tiers)
 
-- **Buttons.stories.tsx** - All button variations with different colors, sizes, and shadow effects
-- **Cards.stories.tsx** - Card component variations (basic, with images, with ASCII art)
-- **Typography.stories.tsx** - Typography system including headings, body text, terminal prompts, code blocks, links, and tags
-
-### Component Stories
-
-- **Button.stories.tsx** - Individual Button component with interactive controls
+- **Foundations** (`stories/foundations/`) — the tokens themselves:
+  - `Colors.stories.tsx` — accent / surface / muted-text swatches, built on
+    token classes so they re-map per theme
+  - `Typography.stories.tsx` (in `stories/`) — font roles, headings, body,
+    terminal prompts, code, links, tags
+  - `BordersAndShadows.stories.tsx` — borders, hard shadows, press
+    interaction, terminal-vs-paper motifs
+  - `PaperAndInk.mdx` — the SKETCH metaphor, token by token
+- **Atoms** (colocated in `components/`) — `Button`, `Tag`, `Link`,
+  `BracketText`, `PageTitle`, `NoteBlock`, `TLDR`
+- **Molecules** (colocated in `components/`) — `Card`, `PageHeader`,
+  `Pagination`, `PostHeaderImage`
+- **Design Sandbox** (`stories/`) — exploratory catalogs ported from
+  `/design-sandbox` (`Buttons`, `Cards`)
 
 ## Adding New Stories
 
-Stories use the CSF (Component Story Format) 3.0 syntax:
+Stories use the CSF (Component Story Format) 3.0 syntax. Colocate component
+stories next to the component (`components/Foo.stories.tsx`) and title them by
+tier (`Atoms/Foo`, `Molecules/Foo`):
 
 ```tsx
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import Component from "../components/Component";
 
 const meta = {
-  title: "Category/ComponentName",
+  title: "Atoms/ComponentName",
   component: Component,
   parameters: {
     layout: "padded", // or 'centered', 'fullscreen'
@@ -55,16 +67,14 @@ export const Default: Story = {
 };
 ```
 
-## Styling
-
-Tailwind CSS v4 is configured in `.storybook/preview.ts` by importing `../css/tailwind.css`. All Tailwind classes and custom brutalist utilities are available in stories.
-
-The dark background (`#000000`) is set as the default in the preview configuration.
+Build only on remapped tokens (`bg-black`, `text-white`, `text-zinc-400`,
+`text-brutalist-*`, `shadow-hard-*`) — never hex literals or `dark:` pairs —
+and verify the story under both HIGH and SKETCH before committing.
 
 ## Configuration Files
 
 - **.storybook/main.ts** - Storybook configuration (framework, addons, story locations)
-- **.storybook/preview.ts** - Global preview settings (backgrounds, Tailwind import)
+- **.storybook/preview.tsx** - Theme toolbar + decorator, Tailwind import, a11y config
 - **.storybook/vitest.setup.ts** - Vitest integration setup
 
 ## Addons
@@ -77,6 +87,6 @@ The dark background (`#000000`) is set as the default in the preview configurati
 ## Notes
 
 - Stories follow the same brutalist aesthetic as the main site
-- All components use monospace fonts and hard borders
-- Terminal prefixes (`>`, `$`, `//`, `[  ]`) are used throughout
-- Color palette: cyan (#22d3ee), pink (#ec4899), yellow (#facc15), neon green (#39ff14)
+- Terminal prefixes (`>`, `$`, `//`, `[  ]`) are used throughout in HIGH;
+  SKETCH renders their paper analogues (pencil dashes, blue-pen prompts)
+- The audit behind this structure: `docs/design-system-evaluation.md`

--- a/stories/Typography.stories.tsx
+++ b/stories/Typography.stories.tsx
@@ -2,7 +2,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta = {
-  title: 'Design Sandbox/Typography',
+  title: 'Foundations/Typography',
   parameters: {
     layout: 'padded',
   },
@@ -11,6 +11,44 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+export const FontRoles: Story = {
+  render: () => (
+    <div className="bg-black border-2 border-white p-8 space-y-6">
+      <div>
+        <p className="font-mono text-xs text-zinc-500 uppercase">
+          font-display — Space Grotesk (headings, uppercase + tight tracking)
+        </p>
+        <p className="font-display text-3xl font-bold uppercase text-white">
+          [ Display Face ]
+        </p>
+      </div>
+      <div>
+        <p className="font-mono text-xs text-zinc-500 uppercase">
+          font-sans — Inter (body / reading copy)
+        </p>
+        <p className="font-sans text-base text-white">
+          Body copy uses Inter for long-form reading. The quick brown fox jumps
+          over the lazy dog.
+        </p>
+      </div>
+      <div>
+        <p className="font-mono text-xs text-zinc-500 uppercase">
+          font-mono — IBM Plex Mono (code + UI / metadata)
+        </p>
+        <p className="font-mono text-base text-brutalist-cyan">
+          {'>'} const role = 'code_and_ui_metadata';
+        </p>
+      </div>
+      <div>
+        <p className="font-mono text-xs text-zinc-500 uppercase">
+          font-pixel — VT323 (logo + hero accents only)
+        </p>
+        <p className="font-pixel text-3xl text-white">RYAN_KELLY.DEV</p>
+      </div>
+    </div>
+  ),
+};
 
 export const Headings: Story = {
   render: () => (

--- a/stories/foundations/BordersAndShadows.stories.tsx
+++ b/stories/foundations/BordersAndShadows.stories.tsx
@@ -1,0 +1,109 @@
+// @ts-nocheck
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Foundations/Borders & Shadows',
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Box = ({ className, label }: { className: string; label: string }) => (
+  <div className="flex flex-col items-start gap-2">
+    <div
+      className={`flex h-24 w-48 items-center justify-center bg-zinc-900 font-mono text-xs text-white ${className}`}
+    >
+      {label}
+    </div>
+    <code className="font-mono text-xs text-zinc-400">{label}</code>
+  </div>
+);
+
+export const Borders: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-8">
+      <Box className="border border-white" label="border (1px)" />
+      <Box className="border-2 border-white" label="border-2 (canonical)" />
+      <Box
+        className="border-4 border-double border-white"
+        label="border-4 double"
+      />
+      <Box className="border-2 border-brutalist-cyan" label="accent border" />
+    </div>
+  ),
+};
+
+export const HardShadows: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-10 p-4">
+      <Box
+        className="border-2 border-white shadow-hard-sm"
+        label="shadow-hard-sm"
+      />
+      <Box
+        className="border-2 border-white shadow-hard-md"
+        label="shadow-hard-md"
+      />
+      <Box
+        className="border-2 border-white shadow-hard-lg"
+        label="shadow-hard-lg"
+      />
+    </div>
+  ),
+};
+
+export const ColoredShadows: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-10 p-4">
+      <Box
+        className="border-2 border-white shadow-hard-cyan"
+        label="shadow-hard-cyan"
+      />
+      <Box
+        className="border-2 border-white shadow-hard-pink"
+        label="shadow-hard-pink"
+      />
+      <Box
+        className="border-2 border-white shadow-hard-yellow"
+        label="shadow-hard-yellow"
+      />
+    </div>
+  ),
+};
+
+export const PressInteraction: Story = {
+  render: () => (
+    <div className="p-4">
+      <button
+        type="button"
+        className="border-2 border-white bg-brutalist-cyan px-6 py-3 font-mono font-bold uppercase text-black shadow-hard-md transition-all hover:shadow-hard-lg active:translate-x-1 active:translate-y-1 active:shadow-none"
+      >
+        PRESS_ME
+      </button>
+      <p className="mt-4 font-mono text-sm text-zinc-400">
+        {'>'} Active state translates into the shadow — the element physically
+        presses into the page (letterpress on paper, button-mash on terminal).
+      </p>
+    </div>
+  ),
+};
+
+export const TerminalVsPaperMotifs: Story = {
+  render: () => (
+    <div className="space-y-6">
+      <div className="ascii-divider" />
+      <p className="terminal-prompt font-mono text-white">
+        terminal-prompt utility — blue pen prompt under SKETCH
+      </p>
+      <p className="file-extension font-mono font-bold text-white">my_note</p>
+      <p className="font-mono text-sm text-zinc-400">
+        {'>'} Cycle to SKETCH: the ASCII divider becomes a hand-ruled pencil
+        dash line, the prompt inks over, selection turns highlighter-yellow.
+      </p>
+    </div>
+  ),
+};

--- a/stories/foundations/PaperAndInk.mdx
+++ b/stories/foundations/PaperAndInk.mdx
@@ -1,0 +1,55 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Foundations/Paper & Ink" />
+
+# Paper & Ink — the SKETCH theme metaphor
+
+The design system ships one token set and three themes. **HIGH** (`dark`) leans
+into terminal devices: phosphor text on black, green scanlines, `//====//`
+ASCII dividers, `>` prompts, neon glows. **SKETCH** (`sketch`) is not a
+"light mode" — it is the same brutalist system printed on paper, and every
+terminal device has an explicit paper analogue at the *token* level.
+
+Because components build only on remapped tokens (`bg-black`, `text-white`,
+`text-brutalist-*`, `shadow-hard-*`), you write the terminal look once and the
+paper look comes for free.
+
+## The analogy, token by token
+
+| Terminal device (HIGH)          | Token / mechanism                          | Paper analogue (SKETCH)                     |
+| ------------------------------- | ------------------------------------------ | ------------------------------------------- |
+| Black terminal screen           | `--color-black` → `#f5f3ec`                | Warm paper sheet                             |
+| White phosphor text & borders   | `--color-white` → `#23262e`                | Graphite ink                                 |
+| Neon cyan links                 | `--brutalist-cyan` → `#2563eb`             | Ballpoint-blue pen                           |
+| Neon pink highlights            | `--brutalist-pink` → `#dc2626`             | Red correction pen                           |
+| Neon yellow emphasis            | `--brutalist-yellow` → `#15803d`           | Green marker                                 |
+| Hard neon offset shadow         | `shadow-hard-*` + `--brutalist-shadow-color` | Letterpress ink offset                     |
+| Green CRT scanlines             | `--scanline-color` / `--page-texture`      | Diagonal pencil-hatch paper texture          |
+| Neon glow halos                 | `shadow-glow-*` (remapped under `.sketch`) | Crisp ink drop shadow (glow is a dark device)|
+| `//====//` ASCII divider        | `.ascii-divider`                           | Hand-ruled pencil dash line `· ─ ─ ─ ·`      |
+| `>` prompt glyph                | `.terminal-prompt`                         | Blue-pen margin prompt                       |
+| Solid vector strokes            | mermaid node strokes (`stroke-dasharray: 8 4`) | Pencil-sketched dashed outlines          |
+| Terminal block cursor selection | `::selection` (remapped under `.sketch`)   | Highlighter-marker swipe (yellow)            |
+| Dark cyberpunk hero grid        | `--hero-grid`                              | Faint ink graph-paper grid                   |
+
+## Atomic structure
+
+The Storybook is organised by composition tier:
+
+- **Foundations** — the tokens themselves (this section): colors, typography,
+  borders & shadows, and this metaphor page.
+- **Atoms** — single-purpose components built directly on tokens: `Button`,
+  `Tag`, `Link`, `BracketText`, `PageTitle`, `NoteBlock`, `TLDR`.
+- **Molecules** — compositions of atoms: `Card`, `PageHeader`, `Pagination`.
+- **Design Sandbox** — exploratory catalogs ported from `/design-sandbox`.
+
+## The discipline
+
+- Build only on remapped tokens — never `text-gray-900`, `dark:` pairs, or hex
+  literals for surface/text/border colour.
+- Verify every story in both HIGH and SKETCH with the theme toolbar: it must
+  read as intentional on the terminal *and* on paper.
+- No rounded corners, no blurred shadows, no emoji as UI — these hold in every
+  theme.
+
+Full mechanics: `docs/theming.md`; token tables: `docs/design-system.md`.


### PR DESCRIPTION
Organises Storybook by composition tier and specifies the design system where components are reviewed:

- **Foundations** (`stories/foundations/`): token colour swatches (re-map per theme), borders & hard shadows, terminal-vs-paper motifs, and a **Paper & Ink** MDX page documenting the SKETCH metaphor token by token
- **Atoms/Molecules**: new stories for Tag, Link, BracketText, PageTitle, NoteBlock, TLDR, Card, PageHeader (all three accents), Pagination; Button/PostHeaderImage/Typography retitled into the hierarchy
- **Docs**: `docs/design-system-evaluation.md` records the audit behind this structure; the paper ↔ terminal analogy table added to `docs/design-system.md`; `stories/README.md` rewritten

Depends on the theme toolbar + paper-motif CSS from #82 (already on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)