### PR TITLE
Ideas backlog, promoted ideas, and org-specifics ADR (phase 1 of 3)

### DIFF
--- a/data/ideas/batch-compute-in-production.mdx
+++ b/data/ideas/batch-compute-in-production.mdx
@@ -1,0 +1,132 @@
+---
+title: "Batch Compute in Production: Seven Years of Running the Heavy Stuff Elsewhere"
+kind: article
+status: developing
+created: "2026-07-18"
+updated: "2026-07-18"
+tags: ["aws", "aws-batch", "dotnet", "performance", "war-story", "architecture"]
+target: "future data/blog/batch-compute-in-production.mdx — possibly a two-parter (architecture / war stories)"
+summary: "The production sequel to the 2022 AWS Batch talk: adopting managed batch compute in 2019, scaling it through array jobs and Step Functions, and the seven-year war against memory, parallelism, and throttling — 181 commits of receipts. Working material, not copy."
+layout: IdeaLayout
+---
+
+## Where it stands
+
+Promoted from the [work-initiatives backlog](/ideas/work-initiatives-backlog)
+(entries B1 + B2, merged — the architecture and the war stories are one
+narrative). Verified against real history; per the org-specifics policy
+(ADR-0008) repo/app names, ticket IDs, and colleague names are omitted —
+dates and quoted commit fragments only. Per the authorship policy this is
+working material, not copy.
+
+**The thesis.** The 2022 talk and the published
+[AWS Batch cookbook](/blog/aws-batch/cookbook) showed the *patterns* —
+array jobs, dependent jobs, map-reduce. This post is what the patterns
+don't tell you: what seven years of running a data-heavy batch estate in
+production actually costs, and the specific ways it fights back.
+
+## The arc (verified against history)
+
+- **May–Jul 2019** — adoption: first Batch job definitions deployed via
+  IaC within weeks of joining; heavy file-matching work moved off the web
+  tier into managed batch compute. Early lesson lands the same year:
+  "errors on alternative threads aren't cleared properly, so we need to
+  avoid unmanaged threading" (Nov 2019).
+- **2021** — scale mechanics arrive: trace-context propagation *between*
+  batch jobs (Jul 2021), the array-job fan-out pattern debugged into shape
+  ("Batch array processing issue solved", Sep 2021), first
+  memory-pressure hotfixes (May 2021), Parquet adopted partly *as a
+  memory-reduction measure* (Aug 2021: "More Memory and Parquet files for
+  reduced memory usage").
+- **2022** — the map-reduce year (the talk's material, in production):
+  chunking large workloads ("chunking up rows", Apr 2022), Step Functions
+  orchestrating Batch, chunk-size tuning ("Decrease chunk size to
+  2 million", Oct 2022), and the great parallelism reckoning — "Limiting
+  simultaneous downloading of account data to avoid S3 exhaustion errors"
+  (Sep 2022), "Detect empty file returned → lower parallelism" (May 2022).
+- **2023** — orchestration simplification: calling Batch directly instead
+  of queueing through SQS, retiring the SQS worker deployment, internal
+  queues + Redis; a `Parallel.For` race condition found and removed
+  (Sep 2023).
+- **2024** — resource-lifecycle warfare: "Releasing connections early,
+  causing connection pooling deadlock" (Aug 2024), system-wide connection
+  timeouts, a mutex on hot-path loading, re-weighting jobs and reducing
+  array parallelism (Oct 2024).
+- **2025** — the cost pass: right-sizing instance sizes per job class,
+  deleting old compute environments, moving file processing to
+  streaming/async throughout.
+
+**~181 commits** in the estate match memory / parallelism / exhaustion /
+deadlock / timeout — the war was continuous, not episodic.
+
+## Proposed shape
+
+1. **Why batch compute at all** — the web tier is the wrong place for
+   hours-long, memory-hungry work; what managed batch buys you (spot
+   pricing, retries, job queues) and what it doesn't (your memory
+   problems come with you).
+2. **The architecture that emerged** — job definitions as IaC, array-job
+   fan-out, Step Functions as the reducer, trace context across the job
+   graph. Link back to the cookbook for the patterns; this is the
+   production configuration of them.
+3. **The war stories, thematically:**
+   - *Memory* — streaming over buffering, Parquet as a memory fix before
+     it was an analytics fix, OOM hotfix archaeology.
+   - *Parallelism* — every fan-out found a bottleneck downstream: S3
+     request rates, connection pools, the DB. "Add parallelism" is a loan,
+     not a gift; the empty-file→lower-parallelism gotcha.
+   - *Correctness under concurrency* — the `Parallel.For` race, unmanaged
+     threading and error handling, the mutex you eventually admit you
+     need.
+   - *Resource lifecycles* — the connection released early that deadlocked
+     the pool; disposal bugs in cloud SDK wrappers.
+4. **Simplify later** — the 2023 removal of the queueing middleman: the
+   orchestration you need at year one is not what you need at year five.
+5. **Pay the bill** — 2025 right-sizing; compute environments accrete like
+   everything else.
+6. **Takeaways** — batch compute moves the work, not the discipline; tune
+   chunk size empirically and write it down; cap parallelism where the
+   *victim* is, not where the work is.
+
+## Links to other posts/ideas
+
+- [AWS Batch cookbook](/blog/aws-batch/cookbook) — the published patterns
+  post this one sequels; the 2022 talk covers the same ground live.
+- [Merging repos without losing a single commit](/ideas/repo-merging-without-losing-history)
+  — the batch estate is one of the two histories grafted into the .NET
+  monorepo in Dec 2023; its full commit trail (and these war stories'
+  receipts) survive *because* of that technique.
+- The .NET migration idea (below) — the batch tier led the move to modern
+  .NET; the two posts bracket the same codebase from different angles.
+
+## Visualisation plan
+
+- **`<MapReduceViz>` — built and live in the cookbook post.** Reuse here
+  with different props per section (e.g. `mappers={12}` for the scale beats;
+  `spotReclaim` on for the resilience section). The component is the house
+  pattern for animated sims: seeded pure model (`buildRun` →
+  `stateAt(plan, t)`), rAF clock, autoplay-on-view, reduced-motion phase
+  stepper, tests over the model.
+- **"Parallelism is a loan" sim (to build)** — the war-story centrepiece: a
+  fan-out slider (4→64 workers) against a shared-resource meter (S3 request
+  rate / connection pool) that starts throttling and failing lanes as
+  fan-out climbs; capping parallelism at the *victim* recovers throughput.
+  Same model-first pattern as MapReduceViz.
+- **`<Terminal>` for hotfix archaeology** — a scripted `git log --grep`
+  session streaming the real (sanitised) OOM/exhaustion commit trail,
+  highlighting one commit per war-story theme.
+
+## Gaps to fill
+
+- [ ] Decide one post or two (architecture vs war stories). The war-story
+      half is the more distinctive; the architecture half overlaps the
+      cookbook.
+- [ ] Re-mine exact numbers privately: job counts, largest array sizes,
+      instance classes before/after right-sizing, and whether any
+      before/after run-time or cost figures are publishable.
+- [ ] The "chunk size 2 million" story deserves its full shape: what blew
+      up at larger sizes, what got slow at smaller ones.
+- [ ] Verify the threading-error claim from 2019 against the actual code
+      pattern (thread-local error state?) before quoting it.
+- [ ] Check employer comfort per ADR-0008 before naming any service or
+      showing real job graphs; diagrams should use generic job names.

--- a/data/ideas/dotnet-framework-migration-realities.mdx
+++ b/data/ideas/dotnet-framework-migration-realities.mdx
@@ -1,0 +1,138 @@
+---
+title: "The Realities of Porting a Complex .NET Framework Codebase"
+kind: article
+status: developing
+created: "2026-07-18"
+updated: "2026-07-18"
+tags: ["dotnet", "migration", "ef-core", "legacy", "strangler-fig", "war-story"]
+target: "future data/blog/dotnet-framework-migration-realities.mdx"
+summary: "Migrating a ~10-year-old .NET Framework estate to .NET 8 while shipping features the whole time: paired projects compiling the same sources twice, two ORMs kept in lockstep, migrations written for both worlds, a revert that taught pace — and the honest accounting of what 'no big bang' actually costs. Working material, not copy."
+layout: IdeaLayout
+---
+
+## Where it stands
+
+Promoted from the [work-initiatives backlog](/ideas/work-initiatives-backlog)
+(entry B5). Verified against real history; per the org-specifics policy
+(ADR-0008) repo/app names, ticket IDs, and colleague names are omitted —
+dates, structural facts, and quoted commit fragments only. Per the
+authorship policy this is working material, not copy.
+
+**The thesis.** Everyone knows the strangler-fig theory. This post is the
+practice: what it actually takes to port a fairly complex, revenue-bearing
+codebase — one with a decade of history, two runtimes, and a team shipping
+features through the whole migration. The honest version is not "we
+migrated"; it's "we are still migrating, on purpose, and here's why that's
+the correct state to be in".
+
+## The verified facts (mine of the real tree/history)
+
+- **Scale, today:** ~73 modern (.NET 8) projects alongside ~36 legacy
+  (.NET Framework 4.7.2) projects, with **two solution files at the root** —
+  one per world — as the honest artefact of an in-flight migration.
+- **The cross-compilation mechanic:** not TFM multi-targeting (zero
+  `<TargetFrameworks>` in the tree) but **paired project files over the
+  same sources** — `X.csproj` (framework) and `X.Core.csproj` (modern)
+  side by side in one folder, compiling the same `.cs` files, with only
+  ~20 files needing `#if` conditionals. Worth a section on *why* pairs
+  beat multi-targeting here (legacy web tooling, packages, and build
+  chains that can't load SDK-style multi-target projects).
+- **Two ORMs in lockstep:** EF6 and EF Core running side by side against
+  one database — "EF Core copied over, compiling with existing DB types"
+  (Jul 2024), "cross compilation of the data factory for EF / EF Core"
+  (Aug 2024), mapping fix-up (Sep 2024), then an **EF Core migration
+  checker in CI** (Nov 2024). The lockstep is ongoing and explicit in the
+  log: "More EFCore match to EFFramework work" (Aug 2025), schema
+  migrations authored with an explicit ".NET Framework side of things"
+  (Sep 2025), alignment fixes still landing mid-2026.
+- **Production teaches you what tests don't:** "Looks like the GetAsync
+  method isn't working for EF Core in production" (hotfix, Nov 2024) —
+  the async path of the new ORM behaving differently under real load.
+- **The revert that taught pace:** a large project-consolidation change
+  reverted whole (Jan 2025) — consolidations of shared AWS/domain projects
+  into a `core/` layout succeeded when staged (file-scoped namespaces →
+  shared enums → merged entities → repositories relocated, Jul–Dec 2024),
+  and failed when batched.
+- **The runway before the leap:** .NET Core 3.1 (Dec 2019), the .NET 5
+  upgrade *rolled back* in production and then deliberately reinstated in
+  a test lane to hunt the cause (Nov–Dec 2020), .NET 6 (Dec 2021), first
+  "make it cross-compilable" groundwork (Mar 2022). The 2024 push was the
+  fifth year of runway, not a fresh start.
+- **The written plan is candid:** the internal migration outline debates
+  by-function vs by-domain structure ("this requires us to have code
+  separated by domain which may be a challenge"), flags the two
+  irreconcilable configuration systems (interface-over-XML-config vs
+  concrete objects from JSON), admits "there is a LOT of shared code…
+  being copied between the two", and prescribes "a huge spreadsheet of
+  every page and its status" for the eventual UI strangler. Great primary
+  source for the "plans meet reality" beat.
+
+## Proposed shape
+
+1. **The setup** — a decade-old estate, two runtimes, no option to stop
+   shipping. Why big-bang was never on the table (revenue-bearing, ~110
+   projects, one shared database).
+2. **Make the same code build twice** — the paired-project mechanic vs
+   multi-targeting; what the ~20 `#if` files say about how little truly
+   differs, and how much effort the remaining 99% of sameness still costs.
+3. **Two ORMs, one database, zero drift allowed** — the EF6/EF Core
+   lockstep: copied types, a cross-compiled data factory, migrations
+   written for both worlds, and a CI checker standing guard. The real cost
+   of "no big bang": every data-layer change lands twice.
+4. **Production is the final reviewer** — the async-method-misbehaving
+   hotfix; why dual-running catches drift that test suites structurally
+   can't.
+5. **Pace: the revert** — staged consolidation worked; the batched one got
+   reverted whole. Change internals before interfaces; make each step
+   individually shippable.
+6. **The plan vs the migration** — quoting the candid internal outline:
+   structure debates, config-system collisions, copied shared code, the
+   page-inventory spreadsheet. Plans are hypotheses.
+7. **Being honestly unfinished** — 73:36 is not failure; it's a stable
+   operating mode with a direction. What "done" would even mean, and
+   whether it matters.
+
+## Links to other posts/ideas
+
+- [Merging repos without losing a single commit](/ideas/repo-merging-without-losing-history)
+  — the Dec 2023 unification of the web and batch histories into one
+  monorepo is what made the shared `core/` consolidation (and honest
+  side-by-side solutions) possible; this post picks up where that
+  technique left off.
+- [Batch compute in production](/ideas/batch-compute-in-production) — the
+  batch tier led the modern-.NET move; the two posts bracket the same
+  codebase from different angles.
+- The 2020 .NET 5 rollback is beat 0 of this story and could stay here or
+  become its own short war-story post (backlog C1).
+
+## Visualisation plan
+
+- **Paired-projects sim (to build)** — a `FileTree`-flavoured view: one
+  source folder, two project nodes (`X.csproj` / `X.Core.csproj`); pressing
+  "build" streams the same `.cs` files into both, with the ~20 `#if` files
+  flashing as they diverge per target. Lands the "same code, two worlds"
+  mechanic better than any prose.
+- **Migration ratio over time** — an animated stacked bar of legacy vs
+  modern project counts per year, ending at 36:73 (needs the private
+  re-mine; a static chart is acceptable fallback).
+- **Dual-ORM lockstep diagram** — `<Diagram type="mermaid">`: one schema
+  change fanning into two migration authoring paths with the CI checker as
+  the gate; animate only if the mermaid version reads poorly.
+- House pattern for any animated sim: seeded pure model + `stateAt(t)` +
+  reduced-motion stepper, as in `MapReduceViz` (components/AGENTS.md).
+
+## Gaps to fill
+
+- [ ] Re-mine exact figures privately: project counts per TFM over time
+      (plot the 36:73 ratio by year?), number of paired projects, `#if`
+      file count trend.
+- [ ] The paired-projects-vs-multi-targeting rationale needs verifying
+      with the actual constraint that forced it (old web project system?
+      packaging? build chain?) — don't guess in print.
+- [ ] Reconstruct the async-ORM production incident enough to tell it
+      accurately (symptom, blast radius, fix) without internal specifics.
+- [ ] Pull the exact staged-consolidation sequence and the revert scope to
+      make the "pace" section concrete.
+- [ ] Decide how much of the candid plan doc to quote and how to
+      anonymise its structure debate.
+- [ ] Check employer comfort per ADR-0008; all diagrams generic.

--- a/data/ideas/pulumi-good-and-bad.mdx
+++ b/data/ideas/pulumi-good-and-bad.mdx
@@ -1,0 +1,156 @@
+---
+title: "Seven Years of Pulumi: The Good and the Bad"
+kind: article
+status: developing
+created: "2026-07-19"
+updated: "2026-07-19"
+tags: ["pulumi", "iac", "aws", "devops", "opinion", "war-story"]
+target: "future data/blog/pulumi-good-and-bad.mdx"
+summary: "From a first commit literally titled 'My First Pulumi' (May 2019) to a multi-language, multi-team IaC estate with a self-hosted state backend and hard guardrails (2026): an honest assessment of what Pulumi has been great at, and where it has bitten. Working material, not copy."
+layout: IdeaLayout
+---
+
+## Where it stands
+
+Promoted from the [work-initiatives backlog](/ideas/work-initiatives-backlog)
+(entry D1, sharpened into an opinion piece: **the good and the bad**).
+Verified against real history — ~165 Pulumi-touching commits in the main
+.NET estate alone, plus stacks across the data, frontend, and platform
+repos. Per the org-specifics policy (ADR-0008) repo names, bucket names,
+and ticket IDs are omitted. Per the authorship policy this is working
+material — and for an opinion piece the *verdicts* especially must be
+yours, not an agent's; treat the good/bad lists below as an evidence
+inventory to react to.
+
+**The thesis.** Most IaC content is either advocacy or a teardown. This is
+neither: seven years, one tool, from "My First Pulumi" (the literal first
+commit at the day job, May 2019) to an estate-wide standard with hard
+operational guardrails — and an honest ledger of where Pulumi earned its
+keep and where it cost real time.
+
+## Timeline (verified against history)
+
+- **May 2019** — "My First Pulumi": first IaC at the company. Within
+  weeks: batch job definitions deployed via Pulumi.
+- **May 2019** — the day-one mistake, preserved in the log: "removed the
+  state file from source" — state was briefly *committed to git*. Honest
+  beat 0 for the state-management thread.
+- **Oct 2019** — secrets management via KMS ("Pulumi now has secrets
+  management that uses KMS").
+- **2021–2022** — infra-as-product era: analytics stacks, data lake
+  buckets/Glue/KMS, recurring "missing KMS users" drift hotfixes.
+- **2023–2025** — estate-wide spread, multi-language: TypeScript stacks
+  (data lake, frontend domains, platform tooling), Python stacks (the
+  medallion pipeline infra), and a C# Pulumi program in the .NET estate.
+  Environment cloning matures ("added 5 new clones… work with any clone",
+  Oct 2024). Deploy contention appears: a lock and priority added to the
+  CI pipeline (Dec 2024). Version pain: "Updating Pulumi version to
+  recognise the latest version" (Feb 2025).
+- **Jun 2026** — the state-backend reckoning: live deployments switched to
+  a **self-hosted S3 backend** (clones/UAT first, then live), the global
+  deploy lock removed and rethought per-stack, KMS secrets-provider
+  configs standardised, pre-deploy KMS checks added — and **AI-agent
+  guardrails** written into the repos: never the vendor cloud backend,
+  access-denied-means-stop.
+
+## The good (evidence inventory — react, don't adopt verbatim)
+
+- **Real languages.** Loops, types, functions, refactoring: cloning five
+  environments by parameterising one program; wiring EventBridge triggers
+  to batch jobs; CloudWatch canary alerts as code. The "it's just
+  TypeScript/Python/C#" promise held across three languages in one org.
+- **Meets teams where they are.** The .NET estate writes infra in C#, the
+  data platform in Python and TS — same tool, same state model, no
+  retraining. Arguably the deciding advantage over the alternatives.
+- **Secrets story.** KMS-backed secrets from 2019, later standardised as
+  per-stack secrets providers — encrypted-at-rest config without a bolt-on
+  vault integration.
+- **Grew from one commit to the org standard organically** — no platform
+  mandate, no big rollout; it spread because each team could start small.
+
+## The bad (evidence inventory)
+
+- **State is the sharp edge, forever.** The arc never ends: committed to
+  git (2019, oops) → moved out → service backend → **self-hosted S3 with
+  custom lock semantics (2026)**. Every era had a state incident or a
+  state migration. The 2026 switch — and the guardrails written to stop
+  *agents* touching the wrong backend — are the strongest evidence that
+  state management remained an operational liability, not a solved
+  problem.
+- **Deploy contention at team scale.** One global lock in CI (2024) was
+  the blunt fix; removing it safely (2026) required per-stack rethinking.
+  Concurrent `pulumi up` across a shared estate is a real coordination
+  problem the tool doesn't solve for you.
+- **Drift and the "missing KMS users" class of bug.** Resources touched
+  outside IaC (or config living half-in, half-out) recur across the whole
+  window — including an explicit 2026 commit *removing* a resource from
+  Pulumi because it's "managed manually outside IaC". An honest section on
+  the drift you tolerate on purpose.
+- **Version/provider churn.** CLI and provider upgrades as their own
+  maintenance stream; a hotfix just to get the version recognised.
+- **Multi-language cuts both ways.** Three languages means three sets of
+  idioms, three dependency chains, and no single reference program;
+  sharing patterns across them is copy-paste, not import.
+- **Small config papercuts** — e.g. resource-name length limits surfacing
+  as production fixes (a cron job name too long, 2025).
+
+## Proposed shape
+
+1. **How it started** — "My First Pulumi", and committing the state file
+   to git in week three. Establishes credibility: this is a user's
+   history, not a review.
+2. **What real languages actually buy you** — the clone-an-environment
+   story; infra refactored like code because it *is* code.
+3. **One tool, three languages, one org** — the polyglot adoption
+   argument; why this beat standardising on one config language.
+4. **The state ledger** — every state era and what it cost; ending at
+   self-hosted S3 + KMS + rethought locking, and why we banned the vendor
+   backend (written as policy agents must obey).
+5. **The drift you keep** — missing-users hotfixes, the resource
+   deliberately handed back to manual management. IaC coverage is a
+   dial, not a binary.
+6. **Verdict** — would I pick it again in 2026, for whom, and what I'd do
+   differently from commit one (state backend and locking decided *first*,
+   not seventh-year).
+
+## Links to other posts/ideas
+
+- [Batch compute in production](/ideas/batch-compute-in-production) — the
+  first Pulumi commits existed to deploy batch job definitions; the two
+  stories start the same week.
+- [Merging repos without losing a single commit](/ideas/repo-merging-without-losing-history)
+  and [the .NET migration realities](/ideas/dotnet-framework-migration-realities)
+  — same estate, same era; the infra programs moved through the monorepo
+  unification too.
+
+## Visualisation plan
+
+- **State-backend journey timeline (to build)** — an animated horizontal
+  timeline: state starts as a file *inside the repo box* (2019), hops out
+  to a backend, and lands in the self-hosted bucket with a lock icon and
+  guardrail wall (2026); incident markers ping along the way. Small bespoke
+  component on the `MapReduceViz` house pattern (seeded pure model +
+  `stateAt(t)` + reduced-motion stepper — components/AGENTS.md).
+- **`<Terminal>`: clone-an-environment** — scripted `pulumi up` session for
+  the "real languages" beat: a loop parameterising N environments, preview
+  diff streaming, one lock-contention pause ("another update is in
+  progress…") for the bad-ledger section.
+- **Drift dial** — a simple animated gauge of "resources managed in IaC vs
+  handed back to manual", moving as the timeline plays; makes the "IaC
+  coverage is a dial, not a binary" section visual.
+
+## Gaps to fill
+
+- [ ] **Verify the backend journey precisely** — which backend(s) were in
+      use between "removed the state file from source" (2019) and the
+      self-hosted S3 switch (2026)? Don't publish the arc until each hop
+      is confirmed.
+- [ ] Re-mine privately: stack counts per language/repo, the clone
+      mechanism's shape, the exact lock semantics before/after 2026.
+- [ ] The "would I pick it again" verdict and any comparison to
+      Terraform/CDK must be written from experience — the evidence above
+      only covers Pulumi; avoid armchair comparisons.
+- [ ] Decide how to tell the 2026 backend-switch story without internal
+      operational detail (ADR-0008; the access-denied guardrail is fine
+      described generically).
+- [ ] Check employer comfort per ADR-0008.

--- a/data/ideas/repo-merging-without-losing-history.mdx
+++ b/data/ideas/repo-merging-without-losing-history.mdx
@@ -1,0 +1,220 @@
+---
+title: "Merging Repos Without Losing a Single Commit"
+kind: article
+status: developing
+created: "2026-07-18"
+updated: "2026-07-18"
+tags: ["git", "monorepo", "migration", "tooling", "devex"]
+target: "future data/blog/repo-merging-without-losing-history.mdx"
+summary: "A repeatable, history-preserving repo-merge technique applied three times across two tech estates (2023–2025): filter-repo subdirectory rewrites, unrelated-histories merges, and cut-point branches as permanent markers. Promoted from the work-initiatives backlog; evidence verified against real history."
+layout: IdeaLayout
+---
+
+## Where it stands
+
+Promoted from the [work-initiatives backlog](/ideas/work-initiatives-backlog)
+(entry E3). The claims below are verified against real git history and two
+internal knowledge-base articles written at the time — this is
+reproducible material, not reconstruction. Per the authorship policy
+everything here is working material: structure and evidence to draft from,
+not copy. Per the org-specifics policy, repo/app names and internal
+identifiers are deliberately omitted; the private evidence trail lists
+them.
+
+**The thesis.** Most repo consolidations squash-import and lose the blame.
+This technique treats a repo merge as a *reversible, auditable, repeatable*
+operation: every commit survives, every branch survives, and the exact
+pre-merge state of each source repo is preserved as a named branch — one
+checkout away, forever. **Applied three times across two tech estates
+(2023–2025)** — a JS consolidation, a .NET monorepo unification, and a JS
+monorepo rebuild — so it's a pattern, not a one-off.
+
+## Timeline (verified against history)
+
+- **~H2 2023 (likely first)** — four satellite app repos merged into the
+  dashboard app repo (JS). Bounded ≥ Jul 2023 by the preserved cut
+  branches' newest commits; exact date lives in the source repo's history —
+  pin it when drafting. Likely the first outing: this campaign is the one
+  the *older* internal article documents, and the later .NET merges reuse
+  its commit-message convention.
+- **17 Oct 2023** — new .NET monorepo base created as an initial commit on
+  an orphan branch.
+- **18 Dec 2023** — the .NET unification lands: **two unrelated-histories
+  merges, five seconds apart**, grafting the web application's history
+  (roots back to 2016) and the batch estate's history (roots back to 2018)
+  into the new monorepo — commit messages following the same "Merge
+  &lt;source&gt; History" convention as the scripts. Every source branch
+  preserved under an `old-<source>/*` prefix (still on the remote today).
+- **Jul–Aug 2025 (third time)** — the JS estate consolidated again into a
+  frontend monorepo: the dashboard UI carved out of its old repo with all
+  branches and tags, then the newer React app grafted in on 22 Aug 2025,
+  the merge commit's two parents being exactly the preserved cut-point
+  branches.
+
+The chronology matters for the narrative: the technique crossed **from the
+JS estate to a .NET monorepo unification and back** — same message
+convention, same `old-*` branch preservation, refined mechanics each time
+(the 2025 campaign's mirror-clone carve-out superseding the original
+clone-and-filter). Reuse across estates is the strongest evidence this is
+a technique rather than an event. Ordering caveat: if the satellite merge
+turns out to postdate Dec 2023, the .NET unification was first — and there
+are hints (service folders already present in the dashboard repo before
+campaign 2's cleanup) of an even earlier consolidation wave worth checking
+when pinning dates.
+
+## The campaigns in detail
+
+*(In likely chronological order — see the timeline caveat.)*
+
+### 1. The satellite consolidation — four repos into one app repo (JS, ~H2 2023)
+
+Documented in an internal article at the time. Mechanics:
+
+1. Clone each of the four source repos.
+2. Rewrite each with `git-filter-repo --to-subdirectory-filter <name>` so
+   its entire history appears to have always lived in a subdirectory.
+3. Add each rewritten repo as a *local* remote, fetch, branch, and
+   `git merge --allow-unrelated-histories`.
+4. Preserve every source branch via a small script that re-pushed them
+   under an `old-original-repo-*` prefix.
+
+Includes a quotable observation: after stitching, **date-order beats
+topological order** for reading the combined history.
+
+### 2. Unifying the .NET estate (Oct–Dec 2023)
+
+Web and batch lived as separate repos with histories reaching back to 2016
+and 2018. A fresh monorepo was started on an orphan branch (17 Oct 2023),
+then on 18 Dec 2023 both histories were grafted in whole via two
+unrelated-histories merges five seconds apart; the combined tree carries
+all the original roots, and `git log --follow` walks any file back to its
+origin. Source branches survive under `old-<source>/*`.
+
+### 3. Building the frontend monorepo (JS, 2025)
+
+Documented in a second internal article. Two moves:
+
+1. **The carve-out:** a `split-folder.sh` script — mirror-clone the old
+   app repo, `git filter-repo --path <folder>/ --path-rename` into a new
+   subdirectory name, then push **all branches and tags** to the new
+   monorepo. A folder becomes a repo line with its history intact.
+2. **The graft:** the second app (a newer React codebase) reset to a known
+   commit, `--to-subdirectory-filter`'d into its own directory, added as a
+   remote, and merged with `--allow-unrelated-histories`.
+
+The result, verifiable in today's tree:
+
+- The merge commit's **two parents are exactly the preserved cut-point
+  branches** — one per source line.
+- `git log --max-parents=0` shows **two root commits** — each app's
+  original initial commit (2021 and 2024).
+- `git log --follow` on any file walks back to its original repo's root.
+
+The article also records the **rejected first approach** — folder-by-folder
+`--invert-paths` cleanup — with the frank note that a better approach
+superseded it. Good material for an honest "how the technique evolved"
+beat.
+
+## Proposed shape
+
+1. **The problem** — consolidating repos is common; doing it without
+   destroying history/blame/branches is not. What squash-import costs you
+   (bisect, blame, archaeology, contributor record).
+2. **The idea** — three invariants: every commit survives; every branch
+   survives; the cut point is a named, permanent ref.
+3. **First outing: the satellite consolidation (JS, 2023)** —
+   subdirectory-filter, local remotes, unrelated-histories merges, and the
+   branch-copy script. Small diagrams of the DAG before and after
+   (multiple roots, one head).
+4. **Crossing estates: the .NET unification (Dec 2023)** — orphan-branch
+   base, two unrelated-histories grafts five seconds apart, same
+   conventions on a completely different stack. The "it's a technique"
+   beat.
+5. **Third time, refined: the 2025 monorepo build** — the carve-out
+   variant (folder → new repo, all branches and tags) and the graft whose
+   merge commit's two parents are the cut-point branches (sanitised
+   names).
+6. **What breaks and how to handle it** — CI paths, tag collisions, blame
+   tooling, PR references, default-branch protection during the push,
+   `--force` semantics of a mirror push.
+7. **Why keep the cut branches** — rollback points, archaeology anchors,
+   and proof-of-provenance. Date-order vs topo-order for reading stitched
+   history.
+8. **The rejected approach** — and why iterating on the technique between
+   campaigns is the point: run three times, it's a pattern.
+
+## Gaps to fill
+
+- [ ] **Recover the reference links.** The first article's Resources
+      section cited a couple of external guides ("the original guide which
+      lines up with the specifics", a git-filter-repo filtering guide, the
+      basis of the branch-copy script) — the knowledge-base export stripped
+      the hyperlinks, leaving bare bullets. Confirm against the original
+      internal articles; they're the citation trail and likely `[@BibKey]`
+      candidates. **Web-search candidates** (contents unverified — the
+      research sandbox allowed search but blocked page fetches):
+      - *Python script for repo manipulation* — near-certain:
+        [newren/git-filter-repo](https://github.com/newren/git-filter-repo)
+        (the script the merge scripts invoke directly).
+      - *"The original guide which lines up with the specifics"* — the
+        popular recipes matching the exact flow (clone each repo →
+        `--to-subdirectory-filter` → local remote → merge
+        `--allow-unrelated-histories`):
+        [Chris Thompson, "Keeping git history when converting multiple repos into a monorepo"](https://medium.com/@chris_72272/keeping-git-history-when-converting-multiple-repos-into-a-monorepo-97641744d928),
+        [AlexV, "How to merge Git repositories and keep history"](https://alex-v.medium.com/how-to-merge-git-repositories-and-keep-history-587f973f06a0),
+        [knappi.org, "Git: Merging multiple repositories into a mono-repo"](https://blog.knappi.org/0009-mono-repo/).
+      - *"Interesting guide about filtering git repos"* — candidates:
+        [git-tower, "Git Filter-Repo: The Best Way to Rewrite Git History"](https://www.git-tower.com/learn/git/faq/git-filter-repo),
+        [ctooley, "Merging old repos into a monolithic git repo archive"](https://dev.to/ctooley/merging-old-repos-into-a-monolithic-git-repo-archive-4c7h).
+      - *Basis of the branch-copy script* — candidates for the
+        `git branch -r` loop:
+        [niksumeiko gist, "Moving git repository and all its branches, tags to a new remote"](https://gist.github.com/niksumeiko/8972566),
+        [alexlvovich, "Copy Git repository with branches to another server"](https://alexlvovich.com/blog/copy-git-repository-with-branches-to-another).
+- [ ] **Re-run the DAG checks for the draft** — capture real (sanitised)
+      output of `git log --max-parents=0`, the merge-commit parents, and a
+      `--follow` walk for a `<Terminal>` component.
+- [ ] **Pin the JS satellite-campaign date** — bounded ≥ Jul 2023 by the
+      preserved cut branches; the exact merge date lives in the dashboard
+      app repo's history (the UI-only carve-out pruned those merge commits
+      from the current monorepo).
+- [ ] **Campaign 1 verification** — the `old-<source>/*` branches are
+      confirmed on the remote for the .NET estate and the frontend
+      monorepo; confirm the satellite-campaign set too.
+- [ ] **Decide naming** — whether to name the repos/apps with employer
+      sign-off, or keep them generic throughout (default: generic, per the
+      org-specifics policy).
+- [ ] **What-breaks section needs specifics** — dig for the actual CI/tag
+      fallout commits around the 2025 merge window to ground section 5.
+- [ ] **Prior art paragraph** — `git subtree`, `git submodule`, josh,
+      copybara; when each fits and why filter-repo + graft won here.
+
+## Visualisation plan
+
+- **Animated git-DAG graft (to build, the post's centrepiece)** — two
+  independent commit chains with their own roots; step 1 rewrites one chain
+  into a subdirectory (nodes re-label in place), step 2 draws the
+  unrelated-histories merge commit with **two parent edges**, step 3 pins
+  the cut-point branch flags to the pre-merge tips. Either a bespoke
+  `GitGraphViz` following the `MapReduceViz` pattern (seeded pure model +
+  `stateAt(t)` + reduced-motion stepper — see components/AGENTS.md) or a
+  `<Walkthrough>` (xyflow) if step-highlighting is enough.
+- **`<Terminal>` command walkthrough** — the real (sanitised) command
+  sequence: clone → `git filter-repo --to-subdirectory-filter` →
+  `git remote add` → `git merge --allow-unrelated-histories`, ending on
+  `git log --max-parents=0` showing two roots and the merge commit's two
+  parents. Output highlighting lands the "one checkout away" point.
+
+## Related ideas
+
+- [The realities of porting a complex .NET Framework codebase](/ideas/dotnet-framework-migration-realities)
+  — the Dec 2023 unification here is what enabled that migration's shared
+  `core/` consolidation; natural follow-on post.
+- [Batch compute in production](/ideas/batch-compute-in-production) — the
+  batch estate's war-story receipts survive because of this technique.
+
+## Evidence (private trail)
+
+Exact repo names, article IDs, commit SHAs, branch names, and doc paths are
+deliberately not recorded here — re-mine them from the internal
+knowledge base (Devops/CICD section, current + archive copies) and the
+frontend monorepo's history when drafting.

--- a/data/ideas/work-initiatives-backlog.mdx
+++ b/data/ideas/work-initiatives-backlog.mdx
@@ -1,0 +1,443 @@
+---
+title: "Work Initiatives → Blog Posts: The Candidate Backlog (2019–2026)"
+kind: series
+status: spark
+created: "2026-07-18"
+updated: "2026-07-18"
+tags: ["backlog", "ai", "ci", "data-engineering", "platform-engineering", "testing", "devex", "dotnet", "aws"]
+target: "hub — each entry graduates to its own idea file in data/ideas/, then a post"
+summary: "Agent-produced survey of ~7 years of day-job and personal work, distilled into candidate posts organised by area and type of change. Every angle is engineering practice, not domain knowledge. Working material, not copy."
+layout: IdeaLayout
+---
+
+## What this is
+
+A survey of the major initiatives since joining the day job (first commit
+May 2019 — literally titled "My First Pulumi") across the work estate and
+the personal repos, filtered down to what travels: **agnostic tech
+utilisation, zero industry insider knowledge**. The business domain is
+off-limits as subject matter; the engineering built around it is the
+material.
+
+History was mined on **author dates** from full clones (~2,600 commits in
+the main application repo alone: 2019: 322, 2020: 817, 2021: 536,
+2022: 471, 2023: 242, 2024: 140, 2025: 45 — the 2026 shift to
+platform/agent work shows up in the other repos). Repo-topology note: the
+data-engineering infra history *originates in the main application repo*
+and was split out to the data repos in mid-2024, so several "data" stories
+trace back there.
+
+Per the authorship policy this whole file is working material — pitches,
+beats, and evidence pointers to react to, not prose to publish.
+
+<NoteBlock title="evidence pointers are deliberately vague" color="yellow">
+This file is source-controlled, so org specifics (repo names, ticket IDs,
+internal spec/article names, exact paths, colleague attribution) have been
+stripped. The detailed evidence trail — exact repos, doc paths, commit
+references — lives in the research session that produced this file;
+regenerate or re-mine per post when drafting. Also decide per post what
+internal figures (spend, GB-scanned) you're comfortable publishing.
+</NoteBlock>
+
+<NoteBlock title="attribution" color="red">
+Not everything in shared repos is yours to claim first-person. In the
+frontend monorepo the bundler migration and the UI library / build-tooling
+setup were led by a colleague; your defensible narratives there are CI/CD,
+feature flags, the CDN/DNS migration, and the repo merges — both product
+front-ends were folded into the monorepo by you, history intact (E3). The
+warehouse-vendor PoC in the data estate was others' work — cite it as "we
+prototyped", not "I built". Check each post's claims against git history
+before drafting.
+</NoteBlock>
+
+## Already covered / in flight (don't duplicate)
+
+- **Virtual monorepo for coding agents** — drafted;
+  [virtual-monorepo-workspace](/ideas/virtual-monorepo-workspace). Trust
+  tiers / prompt-injection-as-directory-layout is earmarked as a section
+  there.
+- **Devenv / tool provisioning** — [workspace-devenv](/ideas/workspace-devenv).
+- **Blog Revival 2026 series** — the 2022→2026 dormancy and revival.
+- **AWS Batch cookbook** (published 2022), ROP, SAFE stack, Paket talks.
+
+---
+
+## Index by type of change
+
+- **Greenfield builds:** A2, A4, A5, B1, D1, G1, F3, F5
+- **Migrations (incremental, live):** A3, B4, B5, C2, E2, E3 (★ repo merge, done twice)
+- **Reversals / roads not taken (workload move-offs, prototype → shelve):** B3 (partial — ES stayed), A6, B4
+- **Optimisation (cost / performance / memory):** A7, B2, F1
+- **Testing & quality engineering:** C3, C4, B6, T-seeds
+- **Governance / process-as-code:** D2, D3, D4, C5, D5
+- **War stories / incidents:** B2, B3, C1, A7, C4 (skip-as-green), B5 (the revert)
+- **AI-assisted engineering:** F1–F5
+- **Umbrella essays:** X1 (determinism), X2 (observability arc), series spines below
+
+★ = strongest candidates.
+
+---
+
+# Area A — Data engineering & analytics (2020 → 2026)
+
+The single best series arc in the estate. Natural six-part spine:
+*ad-hoc era → minimum viable lakehouse → growing it up → carving out the
+platform → medallion + Iceberg → paying the scan bill.*
+
+### A1. ★ Series spine: "From ad-hoc SQL to a lakehouse" (2020–2026)
+
+The full arc as a series hub. 2020–21: one-off SQL fix scripts against the
+operational DB and an Elasticsearch cluster doing analytics duty. 2021:
+batch jobs start emitting Parquet to S3; first Athena bolted on *after* the
+Elasticsearch step (Sep 2021). 2022: a real lake — Glue crawlers, KMS,
+bucket isolation, sync. 2023: SQL views become a version-controlled
+interface. 2024: platform split out of the monolith. 2025: medallion
+bronze/silver/gold on Iceberg. 2026: the cost reckoning. Each part below
+can stand alone.
+
+### A2. The cheapest possible data lake (2021–2022) — *greenfield*
+
+Start by writing Parquet from existing batch jobs and pointing Athena at
+the bucket; graduate to Glue catalogs, KMS, bucket isolation, and
+incremental sync only when each pain arrives ("Parquet Converter
+Implemented", Feb 2021; first Athena stack via Pulumi, Sep 2021).
+"Minimum viable lakehouse" as a sequencing story — what you can defer,
+what you can't.
+
+### A3. Running two analytics stores at once (2022–2023) — *migration*
+
+The Athena↔Elasticsearch dual-sync period: migrating analytics queries
+without a big-bang cutover — dual-write, historic backfill, verify jobs,
+then feature-flagged switchover of specific workloads. Pairs with B3 (the
+data-path move-off; ES itself stayed).
+
+### A4. ★ Your SQL view IS the table (2023–2025) — *greenfield / architecture*
+
+The medallion design where a version-controlled Athena view definition is
+the source of truth and a Python pipeline materialises it into an Iceberg
+table, orchestrated by Step Functions. Covers the 2023 "check your SQL into
+git" formalisation through the 2025 bronze/silver/gold build-out and
+metadata validation. Genuinely novel pattern, fully tech-transferable.
+Primary source: the medallion-architecture design doc.
+
+### A5. Building SCD2 history from scratch on an immutable lake — *greenfield*
+
+Temporal tables via generated pending-changes views + MERGE: tombstones,
+validity windows, per-key version ids, hash-pivoted change detection,
+non-destructive schema evolution — and the determinism dependency (a flappy
+source view silently fabricates history). Primary source: the history
+system-design doc.
+
+### A6. Query-over-S3 over a warehouse vendor — *road not taken*
+
+An honest platform-selection piece backed by receipts: a real
+warehouse-vendor PoC (IaC provider config, DDL — others' work, cite
+accordingly) that was shelved, no Redshift ever, and the reasoning that
+kept everything on query-over-S3 with open table formats.
+
+### A7. ★ We reverse-engineered our own cloud bill — *optimisation / war story*
+
+Cost attribution: CloudTrail query events joined to pricing data until the
+model reproduced ~99.8% of the actual Athena bill over 45 days — tracing
+~55% of spend to six SCD2 MERGEs sharing one codegen template, and one
+pending-changes view scanning hundreds of GB per run (3× over the history
+table) to apply a tiny delta. Fix levers: hash-only change detection (read
+2 columns, not 21), watermark incrementality, and the "a watermark can't
+see DELETEs" trap. The payoff post of the whole arc. Primary source: the
+cost-reduction plan doc.
+
+### A8. Timestamp-free CDC with content hashes — *pattern*
+
+Syncing a warehouse to a search index on a two-field contract: stable key +
+xxhash64 of everything else. No timestamps, no version columns. Short,
+sharp, searchable.
+
+### A9. Splitting the data platform out of the monolith (2024) — *re-org*
+
+Carving infra, batch utils, and the lake out of the application repo;
+migration boundaries; the guardrails ("do not reintroduce extracted code")
+and catalogue metadata that stop it re-merging. Pairs with the personal-repo
+Extraction Policy for a two-scale story.
+
+---
+
+# Area B — Backend & compute: the .NET estate (2019 → 2025)
+
+### B1 + B2. ★ Batch compute in production: architecture + the wars → **promoted**
+
+Now one idea:
+[batch-compute-in-production](/ideas/batch-compute-in-production).
+The 2019 adoption → array-job/Step Functions scale mechanics → the
+memory/parallelism/resource-lifecycle war stories (~181 commits of
+receipts) → 2023 orchestration simplification → 2025 right-sizing. Sequels
+the published cookbook and the 2022 talk; links to the repo-merge and
+.NET-migration ideas.
+
+### B3. ★ Right-sizing Elasticsearch's job (2019 → today) — *partial reversal*
+
+**Correction: Elasticsearch was never removed — it's still in use.** The
+real story is sharper: built the cluster and structured-logging pipeline
+in 2019, let ES accrete *application data-store* duties through 2022
+(conflict wrappers, verify jobs, backoff tuning — the friction
+accumulating in the log), then in 2023 moved specific data-path workloads
+back to the relational DB behind a feature switch — while keeping ES for
+what it's actually good at. Angle: "what belongs in your search cluster" —
+adopting a tool broadly, then paying down the workloads that never
+belonged there, without throwing the tool out. Credible because the same
+engineer drove both directions.
+
+### B4. Re-architecting job orchestration: SQS workers → internal queues + Redis (2023) — *migration / reversal*
+
+Calling Batch directly instead of pushing to SQS, retiring the SQS worker
+deployment, Redis-backed internal queues, durable RabbitMQ with exponential
+backoff (2021) as the precursor. "We removed a distributed component and
+got simpler and more reliable."
+
+### B5. ★ The realities of porting a complex .NET Framework codebase → **promoted**
+
+Now its own idea:
+[dotnet-framework-migration-realities](/ideas/dotnet-framework-migration-realities).
+Paired projects compiling the same sources twice, EF6/EF Core in lockstep
+with migrations written for both worlds, the production async-ORM hotfix,
+the consolidation revert that taught pace, and the candid internal plan
+doc. Links to the repo-merge and batch ideas.
+
+### B6. Integration tests that boot the real DI container — *testing*
+
+Resolve production objects from the real composition root; replace only the
+extremities with *strict* fail-fast mocks; assert behaviour, not
+invocations. Retrofitting harnesses onto a legacy estate (~1,900 lines in
+one PR). Primary source: the batch integration-test guide.
+
+### B7. A code-first registry as the single source of truth — *pattern*
+
+~100+ job types as immutable C# record descriptors carrying display
+metadata, feature flags, and type wiring — plus the CI guard for the classic
+"project on disk but not in the solution" trap.
+
+---
+
+# Area C — CI/CD, quality & release engineering (2019 → 2026)
+
+### C1. The .NET 5 upgrade we rolled back (2020) — *war story*
+
+Upgrade → break → hotfix rollback to Core 3.1 → *reinstate deliberately in a
+test lane to hunt the cause*. A small, honest post about upgrade discipline
+and keeping a reproduction path instead of just retreating.
+
+### C2. Release trains and reproducible local environments (2024) — *migration*
+
+A release-train pipeline plus Docker/Postgres local parity and
+locally-runnable migrations for a legacy estate; and CI that understands
+database migrations (the pipeline persists per-branch migration-timeout
+state across builds to gate deploys).
+
+### C3. ★ Coverage gates that can only go up (2024–2026) — *quality system*
+
+Union-merge multi-platform reports; diff per-file against a main baseline;
+one declarative config with `fixed` vs `ratchet` modes and a noise band;
+baseline-first rollout on legacy (threshold committed but disabled);
+unit-vs-integration partition to know which tier is thin. Featuring the
+**skip-as-green** footgun: a required check that gets *skipped* is reported
+green by branch protection — gates must fail closed with
+`if: ${{ !cancelled() }}` and "honest absence" semantics.
+
+### C4. ★ We built our own merge queue, and it fought back (2026) — *build + war story*
+
+GitHub's native queue can't do rebase-then-fast-forward linear history, so:
+a label-driven queue from reusable workflows — then an RFC-2119-style
+internal spec, and ~70 automated conformance PRs driving *real* runners and
+asserting invariants from label-event streams. Failure modes are the story:
+the "self-kick", FIFO starvation, stuck lock holders, and GitHub's compare
+API returning the pre-rebase relationship seconds after a force-push. Could
+be two posts (build it / prove it).
+
+### C5. RFC-2119 specs for internal systems — *governance*
+
+When internal engineering deserves a formal spec: spec vs ADR vs plan
+taxonomy, stable IDs, semver, named reference implementations, and
+conformance as the price of the word MUST. Natural companion act to C4.
+
+---
+
+# Area D — Platform engineering & governance (2019 → 2026)
+
+### D1. ★ Seven years of Pulumi: the good and the bad → **promoted**
+
+Now its own idea: [pulumi-good-and-bad](/ideas/pulumi-good-and-bad).
+From "My First Pulumi" (the literal first commit, May 2019, including the
+week-three state-file-in-git mistake) to a three-language org standard
+with a self-hosted state backend and hard guardrails (2026) — framed as an
+honest good/bad ledger: real languages and polyglot adoption on the good
+side; state management, deploy contention, drift, and version churn on the
+bad.
+
+### D2. Governance-as-code for a whole GitHub org (2025–2026) — *governance*
+
+From the first topics-enforcement reusable workflow (a central allow-list
+repo + `workflow_call`, late 2025) to declarative repo tiers driving
+audit/enforce for branch protection, rulesets, SHA-pinning, CODEOWNERS —
+dry-run-first, additive-by-default, destructive ops behind an explicit
+flag; billing seats modelled read-only because there's no API to buy them.
+Killer anecdote: the required check whose *producing workflow was disabled* —
+PRs pend forever while everything looks green (it happened).
+
+### D3. Your event bus won't validate your events (2026) — *governance / architecture*
+
+EventBridge validates nothing on publish, so the contract moves left: 13
+RFC-2119 rules with severities enforced at contract-authoring time, platform
+hard limits (256 KiB entries, Draft-4 registry, routing-key stability)
+encoded as lint rules, backward-compat diffs as a merge gate, generated
+types pushed outward via one continuously-refreshed PR per consumer with a
+`--check` drift guard. Legacy status + auditable waivers = the migration
+to-do list stays honest.
+
+### D4. Onboarding automation: the PowerShell → Python arc (2025–2026) — *devex*
+
+A 3,700-line PowerShell suite automating a dev machine end-to-end (winget,
+WSL, fonts, multi-account git), role-based selection, then a deliberate
+Python port with parallel validation — and Playwright driving SaaS
+provisioning. "Automate the first day" with an honest rewrite story.
+
+### D5. A git-tracked snapshot store + a throwaway DuckDB index — *pattern*
+
+History you can trust, queries you can rebuild: org-wide LOC analysis with
+snapshots as source of truth and a rebuildable local index; backfill via
+temporary worktrees.
+
+---
+
+# Area E — Frontend & delivery (2022 → 2025)
+
+*(See attribution note — these are the personally-defensible slices.)*
+
+### E1. Feature flags as an operational safety net (2022–2024) — *greenfield*
+
+Feature-flag platform introduction, env-driven config, maintenance mode
+behind a flag, tenant-based targeting (2024) — and flags as the retirement
+mechanism in B3's Elasticsearch removal. Release-engineering angle, not
+product-flag angle.
+
+### E2. Migrating a CDN without downtime (2023) — *migration*
+
+A concentrated fortnight moving CloudFront distributions, Route 53 records,
+and S3 buckets to new distributions live — cache invalidation, DNS cutover,
+rollback thinking. Compact, concrete, generic.
+
+### E3. ★ Merging repos without losing a single commit — *migration, novel technique* → **promoted**
+
+Now its own idea:
+[repo-merging-without-losing-history](/ideas/repo-merging-without-losing-history).
+Three verified campaigns across two estates — a JS satellite consolidation
+(~H2 2023), the .NET web/batch unification (Dec 2023), and the frontend
+monorepo build (2025) — filter-repo mechanics, cut-point branches as
+permanent markers, and the reference-link recovery task all live there.
+
+### E4. Seeds
+
+- **Monitoring-as-code** — synthetic checks written as the same Playwright
+  specs the team already writes.
+- **Search on button press** — draft vs committed query state instead of
+  debounced reactive filtering.
+- **Version alignment as a disk optimisation** — version-sync tooling framed
+  as pnpm store dedup.
+
+---
+
+# Area F — AI-assisted engineering (2026)
+
+### F1. ★ Putting AI agents in CI without a surprise bill — *optimisation*
+
+An agentic PR-check workflow was quietly burning tokens — raw coverage XML
+(~5M tokens) was flowing into the model. Move deterministic computation to
+plain CI and narrate a few-KB digest instead; concurrency cancellation so
+push-bursts don't pay twice; credit caps in frontmatter; multi-model
+tiering (cheap model for chores, strong model for review). Principle: *the
+model should reason, not compute*.
+
+### F2. Documentation that maintains itself — *pattern*
+
+Skills with a maturity lifecycle and evolution counts; a post-task
+reflection loop that writes learnings back into the skill and commits;
+agents as deliberately-thin routers over that knowledge.
+
+### F3. One source, many AI tools — *build*
+
+Agent/skill/command config compiled per-tool (multiple coding agents) from
+one spec, with a `--check` CI drift guard so generated config can't rot.
+
+### F4. Night Shift: a state machine made of file renames — *workflow*
+
+Human architects by day, agents execute overnight; the hand-off protocol is
+renaming `draft-*.md` → `active-*.md` → `done-*.md`; plus the honest
+counterpoint — a workflow compiler that hangs headless, so the tool *emits
+a script for a human to run*. Credit Jamon Holmgren's pattern.
+
+### F5. Offload the heavy compute to CI; ship state via git refs — *pattern*
+
+Embeddings built incrementally on Actions runners (GGUF caching,
+WAL-checkpoint before artifact upload), distributed cross-device via a
+rolling GitHub Release tag; a shadow git repo mirroring a Drive-owned vault
+for diffs and CI triggers; same shape as code-graph artifacts and a private
+package feed for internal CLIs.
+
+---
+
+# Cross-cutting umbrellas
+
+### X1. ★ Determinism is a feature (test it like one)
+
+Five stack-diverse mini-cases converging on one principle: a pandas→Polars
+migration shipped as *byte-identical*; two data sources required to render
+byte-identical reports; deterministic codegen enabling CI drift guards;
+content-hash CDC (A8); SCD2's determinism dependency (A5); and a
+deliberately duplicated hash function kept honest by a fuzz-corpus parity
+test — "when DRY is impossible, test the duplication."
+
+### X2. An observability arc, 2019 → 2026
+
+Ripping out NLog for Serilog + Elasticsearch (2019), trace-context
+propagation across distributed batch jobs (2021), zero-code OTel
+auto-instrumentation as the org pattern (2025), and a local-first OTel
+stack — every CLI auto-connects when the collector is up; NDJSON queryable
+via DuckDB (2026). One thread, seven years.
+
+### Personal-tooling seeds (short posts)
+
+- **Reliability beats cleverness** — the Windows workspace-restore tool that
+  abandoned live-inference for a hand-authored plan with frank per-app
+  launch delays.
+- **The `common` package that ate my imports** — multiple repos shipping a
+  top-level `common` can never share a `sys.path`.
+- **Validate at the boundary — even when the boundary is you** — a renderer
+  treating its own pipeline's SQLite as untrusted, exhaustiveness as compile
+  errors.
+- **Visual-regression testing for architecture diagrams** — pixel-diffing
+  draw.io exports with a CI gate.
+- **"Why we couldn't add a third S3 event trigger"** — S3 rejects
+  ambiguous/subset notification filters; EventBridge doesn't.
+- **An extraction policy for the junk drawer** — a written rubric for when a
+  utility earns its own repo (pairs with A9).
+
+---
+
+## Series groupings
+
+- **"From ad-hoc SQL to a lakehouse"** — A1 spine: A2 → A3 → A9 → A4/A6 → A7,
+  anchored by the 2022 AWS Batch talk (B1). The strongest multi-post arc,
+  seven years of first-person evidence.
+- **"The Modernisation Diaries"** — B5, B3, B4, C1, C2, E2: incremental
+  migration and honest reversals on a long-lived estate.
+- **"The Paved Road"** — C3, C4/C5, D2, D3: governance, contracts, and gates
+  as code, with baseline-then-enforce as the recurring move.
+- **"Agents at Work"** — F1–F5 + the shipped virtual-monorepo post as anchor.
+
+## Next steps
+
+- [ ] Pick 2–3 winners and promote each to its own idea file with an outline.
+- [ ] For each winner, re-mine the exact evidence (repos, paths, commits)
+      privately — this file deliberately omits it — and verify claims,
+      especially attribution in shared repos.
+- [ ] Decide the sanitisation line for internal numbers per post.
+- [ ] Check employer comfort with naming systems publicly (the virtual
+      monorepo post sets the precedent).

--- a/docs/adr/0008-no-organisational-specifics-in-source-controlled-content.md
+++ b/docs/adr/0008-no-organisational-specifics-in-source-controlled-content.md
@@ -1,0 +1,63 @@
+# No organisational specifics in source-controlled content
+
+## Context
+
+The ideas workbench (`data/ideas/`) holds pre-drafting material that often
+originates from day-job engineering work. Idea pages render only behind the
+admin login — but the *files* are committed to this repository, and repo
+visibility is not an access-control mechanism: clones, forks, CI logs, and
+git history all outlive any rendering restriction. A workbench file that
+cites employer repo names, ticket IDs, internal article/spec identifiers,
+commit SHAs, or colleague names has published them regardless of what the
+website shows.
+
+This became concrete when survey-generated backlog material landed with
+exact employer repo names, ticket prefixes, internal knowledge-base article
+IDs, and colleague attribution embedded in evidence pointers. Sanitising
+the working tree alone was insufficient — the specifics survived in branch
+history, which required rewriting.
+
+## Decision
+
+**Organisational specifics are excluded from every source-controlled file
+in this repository, including `data/ideas/`.** Rendering visibility
+(admin-only, draft, unlisted) grants no exemption; the test is "is it in
+git", not "is it on the site".
+
+Excluded:
+
+- Employer/org repository names and branch names
+- Ticket / issue identifiers and internal tracker prefixes
+- Internal system, spec, and knowledge-base article identifiers
+- Commit SHAs from organisational repositories
+- Colleague names and attribution for org work
+- Internal URLs, hostnames, and org account identifiers
+
+Permitted:
+
+- Generic descriptors ("the frontend monorepo", "the data platform repo",
+  "a colleague led X") — description, not identification
+- Technology names, cloud services, and open-source project references
+- Rounded magnitudes for internal figures, decided per post
+- Personal-project repo names (they are the author's own)
+
+Detailed evidence trails (exact repos, paths, commits) live **outside this
+repository** — in the research session, private notes, or re-mined on
+demand when drafting. Idea files say *where to look*, not *what it's
+called*.
+
+Naming employer systems in a **published post** remains a per-post decision
+requiring explicit sign-off (the virtual-monorepo post is the deliberate
+precedent), made at drafting time — never inherited by default from
+workbench material.
+
+## Consequences
+
+- Workbench evidence pointers are deliberately vaguer; each promoted idea
+  carries a "re-mine the evidence privately" step in its checklist.
+- If organisational specifics land in a commit by mistake, sanitising the
+  file is not enough — the branch history must be rewritten (or the branch
+  squashed) before merge, since the specifics live in every commit that
+  contained them.
+- Agents working in this repo must apply this policy to generated content
+  *before* committing, not as a cleanup pass.

--- a/docs/posting.md
+++ b/docs/posting.md
@@ -32,6 +32,11 @@ a suggestion, but the author owns the final wording.
 Rule of thumb: **if a reader reads it as the author's voice, a human wrote it;
 if it's structure, code, or an asset, an agent can.**
 
+Related policy: organisational specifics (employer repo names, ticket IDs,
+internal identifiers, colleague attribution) are excluded from **all**
+source-controlled content, including `data/ideas/` — see
+[ADR-0008](adr/0008-no-organisational-specifics-in-source-controlled-content.md).
+
 ## Adding a post
 
 A post is one MDX file: `data/blog/<slug>.mdx`. `scripts/create-post.mjs`


### PR DESCRIPTION
Phase 1 of splitting #84 into reviewable phases. **Content and docs only — no code, no build surface.**

### Ideas workbench (`data/ideas/`)
- `work-initiatives-backlog.mdx` — candidate posts from ~7 years of work, organised by area with a type-of-change index. Organisational specifics stripped per the new ADR.
- Four promoted ideas: `repo-merging-without-losing-history`, `batch-compute-in-production`, `dotnet-framework-migration-realities`, `pulumi-good-and-bad` — each with a verified timeline, proposed shape, visualisation plan, and gaps checklist.

### Policy
- **ADR-0008: no organisational specifics in source-controlled content** — employer repo names, ticket IDs, internal identifiers, colleague attribution excluded from every tracked file including `data/ideas/`. Pointer added in `docs/posting.md`.

### Phasing
This is the zero-risk slice. Phase 2 will carry the `MapReduceViz` cookbook interactive + the preview admin bypass; phase 3 the talk-animation prototypes (to be simplified first). PR #84 will be closed once these land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jgc8xvrNmyAW35qLUEExDc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jgc8xvrNmyAW35qLUEExDc)_