### PR TITLE
Preview admin bypass sign-in (phase 2 of 3)

### DIFF
--- a/components/admin/AdminGate.tsx
+++ b/components/admin/AdminGate.tsx
@@ -4,13 +4,18 @@ import type { ReactNode } from 'react';
 import { api } from '@/convex/_generated/api';
 import { isConvexConfigured } from '@/lib/convexClient';
 
-// E2E bypass sign-in is offered only when the build opts in — and never on the
-// test-github branch, whose whole point is exercising the real OAuth flow.
-// (Hard-coded, not configurable: matching the server-side guard philosophy in
-// convex/auth.ts.) The secret is public to this bundle by design: it only
-// exists on dev/CI deployments, where the bypass provider is enabled anyway.
+// E2E bypass sign-in is offered when the build opts in — or automatically on
+// Vercel *preview* builds (ADR-0004's recommended path), so feature-branch
+// previews can reach the admin-gated pages (/ideas, /admin) without real
+// OAuth, which can never work on an ephemeral callback URL. Never on the
+// test-github branch, whose whole point is exercising the real OAuth flow,
+// and never on production (NEXT_PUBLIC_VERCEL_ENV === 'production' fails the
+// preview check, and the prod Convex deployment is hard-immune server-side
+// regardless). The secret is public to this bundle by design: it only exists
+// on dev/preview/CI deployments, where the bypass provider is enabled anyway.
 const E2E_BYPASS_AVAILABLE =
-  process.env.NEXT_PUBLIC_E2E_BYPASS === '1' &&
+  (process.env.NEXT_PUBLIC_E2E_BYPASS === '1' ||
+    process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview') &&
   process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF !== 'test-github';
 
 function SignIn() {

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -37,7 +37,7 @@ design and identity is enforced where writes happen.
 |---|---|---|---|---|
 | Production (ryankelly.dev) | `fiery-minnow-77` (prod) | ✅ own OAuth app | ❌ **hard-coded impossible** | Bypass provider excluded by a source constant, not config |
 | Local dev (localhost:3002) | `keen-shark-231` (dev) | ✅ own OAuth app | ✅ enabled | `SITE_URL=http://localhost:3002`; dev server **must run on 3002** |
-| Feature-branch previews (Vercel) | Convex **preview deployments**, one per branch | ❌ (ephemeral callback URL — ADR-0004) | ✅ via project-default env vars | The recommended way to test feature branches; see §6 |
+| Feature-branch previews (Vercel) | Convex **preview deployments**, one per branch | ❌ (ephemeral callback URL — ADR-0004) | ✅ via project-default env vars; **sign-in button auto-offered** (`NEXT_PUBLIC_VERCEL_ENV === 'preview'`) | The recommended way to test feature branches — admin-gated pages (/ideas, /admin) are reachable on previews; see §6 |
 | CI (live-e2e workflow) | dedicated E2E deployment (or a preview) | ❌ | ✅ | Secrets in GitHub Actions; job self-activates when provisioned |
 | `test-github` branch | *none yet — deliberately* | (would be ✅) | ❌ hard-coded off in the client | Stable branch URL `https://my-blog-0j5s-git-test-github-rtkelly13s-projects.vercel.app` reserved for a pre-prod OAuth rehearsal env. With the per-ship prod OAuth check (§8) it may never be needed — dormant until decided |
 
@@ -73,9 +73,15 @@ provider catches and falls through to `createAccount`.
 ### Current client affordance (to be removed)
 
 The first iteration renders an "E2E dev sign-in" button on the AdminGate
-wall when built with `NEXT_PUBLIC_E2E_BYPASS=1`, reading the secret from
-`NEXT_PUBLIC_E2E_BYPASS_SECRET` — i.e. **the secret is embedded in those
-bundles**. Acceptable for dev/CI (the secret is worthless against prod) but
+wall when built with `NEXT_PUBLIC_E2E_BYPASS=1` — or **automatically on any
+Vercel preview build** (`NEXT_PUBLIC_VERCEL_ENV === 'preview'`; ADR-0004's
+recommended preview-bypass path), so feature-branch previews can view the
+admin-gated pages (/ideas, /admin). It reads the secret from
+`NEXT_PUBLIC_E2E_BYPASS_SECRET` (set in the Vercel Preview env —
+`pnpm provision vercel-preview`; until per-branch preview deployments are
+wired, previews point at the shared **dev** deployment, so the value must
+equal dev's `AUTH_E2E_BYPASS_SECRET`) — i.e. **the secret is embedded in
+those bundles**. Acceptable for dev/CI (the secret is worthless against prod) but
 it's a view-source leak on any publicly reachable preview. The session-init
 CLI (§5) supersedes it; once that lands, the button and both `NEXT_PUBLIC_*`
 vars are deleted and test bundles become byte-identical to production's.

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -26,7 +26,12 @@ convex.prod.env:     AUTH_GITHUB_ID, AUTH_GITHUB_SECRET (prod OAuth app),
                      SITE_URL=https://www.ryankelly.dev, ADMIN_GITHUB_LOGINS
 convex.preview.env:  AUTH_E2E_BYPASS_SECRET, ADMIN_GITHUB_LOGINS
 ci.env:              AUTH_E2E_BYPASS_SECRET, VERCEL_AUTOMATION_BYPASS_SECRET
-vercel.preview.env:  CONVEX_DEPLOY_KEY (preview deploy key)
+vercel.preview.env:  CONVEX_DEPLOY_KEY (preview deploy key),
+                     NEXT_PUBLIC_E2E_BYPASS_SECRET (arms the AdminGate
+                     bypass button on preview builds; must equal the
+                     AUTH_E2E_BYPASS_SECRET of whichever Convex deployment
+                     previews point at — the shared dev deployment until
+                     per-branch preview deployments are wired)
 ```
 
 Deliberately excluded: `JWKS` / `JWT_PRIVATE_KEY` — per-deployment signing


### PR DESCRIPTION
Phase 2 of splitting #84. Config/docs only — no animation code.

- `AdminGate` auto-offers the existing e2e bypass sign-in on Vercel **preview** builds (`NEXT_PUBLIC_VERCEL_ENV === 'preview'`) — ADR-0004's recommended path — so feature-branch previews can reach the admin-gated pages (`/ideas`, `/admin`) without real OAuth, which can't work on an ephemeral callback URL. Production (fails the preview check + prod Convex deployment is hard-immune) and `test-github` (keeps real OAuth) are unaffected.
- `docs/auth.md` and the `secrets/README.md` provisioning spec updated with the `NEXT_PUBLIC_E2E_BYPASS_SECRET` requirement (must equal dev's `AUTH_E2E_BYPASS_SECRET` until per-branch Convex preview deployments are wired).

Note: for the button to authenticate on a preview, `NEXT_PUBLIC_E2E_BYPASS_SECRET` must be set in the Vercel Preview env (`pnpm provision vercel-preview`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jgc8xvrNmyAW35qLUEExDc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jgc8xvrNmyAW35qLUEExDc)_