### PR TITLE
Talk-deck animation prototypes in the experiments area (phase 3 of 3)

### DIFF
--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -125,6 +125,16 @@ Step-driven interactives usable in any MDX (posts, talks, ideas):
   traversable-by-agent (the two-ignore-files trick). Trust-tier dots
   (brain/trusted/untrusted). Pure model + rules in `fileTreeModel.ts`
   (unit-tested); no props needed — the workspace layout is baked in.
+- `MapReduceViz` — animated AWS-Batch-style pipeline: colour-coded job types
+  (PREPARE cyan → MAP array pink → REDUCE yellow; spot-reclaim orange) flow
+  from a JOB_QUEUE through a slot-limited COMPUTE_ENV into a SUCCEEDED stack,
+  with dependencies (maps wait on prepare, reduce waits on all maps), visible
+  queuing when maps outnumber slots, and one map losing its spot instance and
+  re-queueing. Deterministic seeded discrete-event scheduler in
+  `mapReduceModel.ts` (`buildRun` → pure `stateAt(plan, t)`, unit-tested);
+  rAF clock, autoplay-on-view, fan-out presets (x4/x8/x12), replay. Reduced
+  motion swaps the clock for a PREPARE/MAP/REDUCE/DONE phase stepper. Props:
+  `mappers`, `slots`, `spotReclaim`, `caption`, `title`, `autoplay`.
 
 Both are registered in `MDXComponents.tsx` via `next/dynamic` (`ssr: false`) so
 motion/@xyflow/react ship as lazy chunks only on pages that mount them.

--- a/components/MDXComponents.tsx
+++ b/components/MDXComponents.tsx
@@ -65,15 +65,39 @@ const FileTree = dynamic(() => import('./interactive/FileTree'), {
   loading: InteractiveLoading,
 });
 
+const MapReduceViz = dynamic(() => import('./interactive/MapReduceViz'), {
+  ssr: false,
+  loading: InteractiveLoading,
+});
+
+const RailwayTrack = dynamic(() => import('./interactive/RailwayTrack'), {
+  ssr: false,
+  loading: InteractiveLoading,
+});
+
+const MvuLoop = dynamic(() => import('./interactive/MvuLoop'), {
+  ssr: false,
+  loading: InteractiveLoading,
+});
+
+const DepResolve = dynamic(() => import('./interactive/DepResolve'), {
+  ssr: false,
+  loading: InteractiveLoading,
+});
+
 export const MDXComponents: MDXComponentsType = {
   Image: Image as any,
   TOCInline,
   Diagram,
   NoteBlock,
   References,
+  DepResolve,
   FileTree,
   IdeaDeck,
   IdeaSlide,
+  MapReduceViz,
+  MvuLoop,
+  RailwayTrack,
   QueryRouter,
   Terminal,
   Walkthrough,

--- a/components/interactive/DepResolve.tsx
+++ b/components/interactive/DepResolve.tsx
@@ -1,0 +1,354 @@
+import { RotateCcw } from 'lucide-react';
+import { useReducedMotion } from 'motion/react';
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * The diamond dependency conflict and its global resolution, animated.
+ * App needs A and B; A pins Lib v1, B pins Lib v2 — the classic
+ * two-versions-of-one-package problem. Paket's global resolution collapses
+ * it to a single version both agree on, then writes the lock. Prototype for
+ * the Paket talk.
+ */
+
+export type DepPhase = 'graph' | 'conflict' | 'resolve' | 'locked';
+
+export interface DepFrame {
+  phase: DepPhase;
+  /** 0..1 within the resolve transition (A's edge re-points, v1 fades). */
+  resolveProgress: number;
+  lockWritten: boolean;
+}
+
+const T_GRAPH = 1.6;
+const T_CONFLICT = 3.4;
+const T_RESOLVE = 5.4;
+const TOTAL = 7.0;
+
+export function depTotal(): number {
+  return TOTAL;
+}
+
+export function depFrameAt(t: number): DepFrame {
+  let phase: DepPhase;
+  if (t < T_GRAPH) phase = 'graph';
+  else if (t < T_CONFLICT) phase = 'conflict';
+  else if (t < T_RESOLVE) phase = 'resolve';
+  else phase = 'locked';
+  const resolveProgress =
+    t <= T_CONFLICT
+      ? 0
+      : t >= T_RESOLVE
+        ? 1
+        : (t - T_CONFLICT) / (T_RESOLVE - T_CONFLICT);
+  return { phase, resolveProgress, lockWritten: phase === 'locked' };
+}
+
+const C = {
+  cyan: 'var(--brutalist-cyan, #22d3ee)',
+  pink: 'var(--brutalist-pink, #ec4899)',
+  yellow: 'var(--brutalist-yellow, #facc15)',
+  green: 'var(--brutalist-neonGreen, #39ff14)',
+  orange: 'var(--brutalist-cyberOrange, #ff8c00)',
+  ink: 'var(--color-white, #ffffff)',
+  dim: 'var(--color-zinc-800, #27272a)',
+  muted: 'var(--color-zinc-600, #52525b)',
+};
+
+const VB_W = 460;
+const VB_H = 300;
+const N = {
+  app: { x: 230, y: 40 },
+  a: { x: 120, y: 140 },
+  b: { x: 340, y: 140 },
+  v1: { x: 120, y: 250 },
+  v2: { x: 340, y: 250 },
+};
+
+function lerp(a: number, b: number, u: number) {
+  return a + (b - a) * u;
+}
+
+function Node({
+  x,
+  y,
+  label,
+  sub,
+  color,
+  fill,
+  opacity = 1,
+}: {
+  x: number;
+  y: number;
+  label: string;
+  sub?: string;
+  color: string;
+  fill: string;
+  opacity?: number;
+}) {
+  return (
+    <g opacity={opacity}>
+      <rect
+        x={x - 48}
+        y={y - 22}
+        width={96}
+        height={44}
+        fill={fill}
+        stroke={color}
+        strokeWidth={2.5}
+      />
+      <text
+        x={x}
+        y={sub ? y - 2 : y + 5}
+        fill={fill === color ? '#000' : C.ink}
+        textAnchor="middle"
+        className="font-mono"
+        fontSize={12}
+      >
+        {label}
+      </text>
+      {sub && (
+        <text
+          x={x}
+          y={y + 13}
+          fill={fill === color ? '#000' : C.muted}
+          textAnchor="middle"
+          className="font-mono"
+          fontSize={10}
+        >
+          {sub}
+        </text>
+      )}
+    </g>
+  );
+}
+
+const PHASE_LABEL: Record<DepPhase, string> = {
+  graph: 'DEPENDENCY GRAPH',
+  conflict: '⚠ TWO VERSIONS OF Lib',
+  resolve: 'GLOBAL RESOLUTION',
+  locked: 'paket.lock WRITTEN',
+};
+
+export default function DepResolve({
+  autoplay = true,
+}: {
+  autoplay?: boolean;
+}) {
+  const reduceMotion = useReducedMotion() ?? false;
+  const ref = useRef<HTMLElement>(null);
+  const [t, setT] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [started, setStarted] = useState(false);
+
+  const frame = depFrameAt(reduceMotion ? TOTAL : t);
+
+  const restart = () => {
+    setT(0);
+    setPlaying(!reduceMotion);
+    setStarted(true);
+  };
+
+  useEffect(() => {
+    if (!autoplay || started || reduceMotion) return;
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      setStarted(true);
+      setPlaying(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      (es) => {
+        if (es.some((e) => e.isIntersecting)) {
+          setStarted(true);
+          setPlaying(true);
+          io.disconnect();
+        }
+      },
+      { threshold: 0.35 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [autoplay, started, reduceMotion]);
+
+  useEffect(() => {
+    if (!playing || reduceMotion) return;
+    let raf = 0;
+    let last: number | null = null;
+    const tick = (now: number) => {
+      if (last !== null) {
+        const dt = (now - last) / 1000;
+        setT((p) => {
+          const next = p + dt;
+          if (next >= TOTAL) {
+            setPlaying(false);
+            return TOTAL;
+          }
+          return next;
+        });
+      }
+      last = now;
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [playing, reduceMotion]);
+
+  const conflict = frame.phase === 'conflict';
+  const rp = frame.resolveProgress;
+  const resolved = frame.phase === 'resolve' || frame.phase === 'locked';
+  // A's edge target migrates from v1 to v2 during resolve.
+  const aTargetX = lerp(N.v1.x, N.v2.x, rp);
+  const aTargetY = N.v1.y;
+  const v1Opacity = 1 - rp;
+  const v2Color = resolved ? C.green : C.yellow;
+
+  return (
+    <figure className="my-6">
+      <section
+        ref={ref}
+        aria-label="Dependency resolution: App depends on A and B; A wants Lib v1 and B wants Lib v2. Global resolution collapses the conflict to a single version both use, then writes the lock file."
+        className="border-2 border-white bg-black shadow-hard-lg"
+      >
+        <div className="flex items-center justify-between border-b-2 border-white bg-zinc-900 px-3 py-2">
+          <span className="font-mono text-xs font-bold text-white">
+            RESOLVE.SIM
+          </span>
+          <div className="flex items-center gap-2">
+            <span
+              className="font-mono text-[11px]"
+              style={{
+                color: conflict ? C.orange : resolved ? C.green : C.ink,
+              }}
+            >
+              {PHASE_LABEL[frame.phase]}
+            </span>
+            <button
+              type="button"
+              onClick={restart}
+              aria-label="Replay"
+              className="border-2 border-white bg-black px-2 py-1 text-white hover:bg-zinc-900"
+            >
+              <RotateCcw size={12} />
+            </button>
+          </div>
+        </div>
+
+        <svg
+          viewBox={`0 0 ${VB_W} ${VB_H}`}
+          className="w-full"
+          role="img"
+          aria-hidden
+        >
+          <title>Dependency resolution</title>
+          {/* Edges */}
+          <line
+            x1={N.app.x}
+            y1={N.app.y + 22}
+            x2={N.a.x}
+            y2={N.a.y - 22}
+            stroke={C.muted}
+            strokeWidth={2}
+          />
+          <line
+            x1={N.app.x}
+            y1={N.app.y + 22}
+            x2={N.b.x}
+            y2={N.b.y - 22}
+            stroke={C.muted}
+            strokeWidth={2}
+          />
+          {/* B -> v2 (stable) */}
+          <line
+            x1={N.b.x}
+            y1={N.b.y + 22}
+            x2={N.v2.x}
+            y2={N.v2.y - 22}
+            stroke={C.muted}
+            strokeWidth={2}
+          />
+          {/* A -> lib: migrates v1 → v2 during resolve */}
+          <line
+            x1={N.a.x}
+            y1={N.a.y + 22}
+            x2={aTargetX}
+            y2={aTargetY - 22}
+            stroke={resolved ? C.green : conflict ? C.orange : C.muted}
+            strokeWidth={2.5}
+            strokeDasharray={frame.phase === 'resolve' ? '5 4' : undefined}
+          />
+
+          <Node {...N.app} label="App" color={C.cyan} fill={C.dim} />
+          <Node
+            {...N.a}
+            label="A"
+            sub="wants Lib 1.0"
+            color={C.cyan}
+            fill={C.dim}
+          />
+          <Node
+            {...N.b}
+            label="B"
+            sub="wants Lib 2.0"
+            color={C.cyan}
+            fill={C.dim}
+          />
+          {/* Lib v1 — pulses in conflict, fades in resolve */}
+          <Node
+            {...N.v1}
+            label="Lib 1.0"
+            color={conflict ? C.orange : C.pink}
+            fill={C.dim}
+            opacity={v1Opacity}
+          />
+          {/* Lib v2 — the survivor */}
+          <Node
+            {...N.v2}
+            label="Lib 2.0"
+            sub={resolved ? 'chosen' : undefined}
+            color={conflict ? C.orange : v2Color}
+            fill={resolved ? v2Color : C.dim}
+          />
+        </svg>
+
+        {/* Lock file */}
+        <div className="border-t-2 border-white px-3 py-2 font-mono text-[11px]">
+          <span className="text-zinc-500">paket.lock </span>
+          {frame.lockWritten ? (
+            <span className="text-brutalist-neonGreen">
+              NUGET → Lib 2.0 (one version, whole solution)
+            </span>
+          ) : (
+            <span className="text-zinc-600">— resolving…</span>
+          )}
+        </div>
+
+        {reduceMotion && (
+          <div className="flex items-center gap-1 border-t-2 border-white px-3 py-2">
+            <span className="font-mono text-[10px] text-zinc-500">STEP:</span>
+            {(
+              [
+                ['graph', 0.8],
+                ['conflict', 2.4],
+                ['resolve', 4.4],
+                ['locked', TOTAL],
+              ] as const
+            ).map(([lbl, at]) => (
+              <button
+                key={lbl}
+                type="button"
+                onClick={() => setT(at)}
+                className="border-2 border-white bg-black px-2 py-1 font-mono text-[10px] text-white hover:bg-zinc-900"
+              >
+                {lbl}
+              </button>
+            ))}
+          </div>
+        )}
+      </section>
+      <figcaption className="mt-2 text-center font-mono text-xs text-zinc-500">
+        The diamond conflict — two packages pin different versions of one
+        dependency — and Paket's single global resolution across the solution.
+      </figcaption>
+    </figure>
+  );
+}

--- a/components/interactive/MapReduceViz.tsx
+++ b/components/interactive/MapReduceViz.tsx
@@ -1,0 +1,467 @@
+import { Pause, Play, RotateCcw } from 'lucide-react';
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  buildRun,
+  type Frame,
+  type JobFrame,
+  type JobKind,
+  type Phase,
+  phaseTimes,
+  stateAt,
+} from './mapReduceModel';
+
+interface MapReduceVizProps {
+  title?: string;
+  caption?: string;
+  /** Number of parallel map jobs (the array-job size). */
+  mappers?: number;
+  /** Compute-environment slots (max concurrent jobs). */
+  slots?: number;
+  /** Simulate one map job losing its spot instance and retrying. */
+  spotReclaim?: boolean;
+  autoplay?: boolean;
+}
+
+const PHASE_LABEL: Record<Phase, string> = {
+  idle: 'READY',
+  prepare: 'PREPARE',
+  map: 'MAP',
+  reduce: 'REDUCE',
+  done: 'DONE',
+};
+
+/** Colour code per job type — the legend of the whole diagram. */
+const KIND_BAR: Record<JobKind, string> = {
+  prepare: 'bg-brutalist-cyan',
+  map: 'bg-brutalist-pink',
+  reduce: 'bg-brutalist-yellow',
+};
+const KIND_BORDER: Record<JobKind, string> = {
+  prepare: 'border-brutalist-cyan',
+  map: 'border-brutalist-pink',
+  reduce: 'border-brutalist-yellow',
+};
+/** The active-phase highlight follows the job-type colour code. */
+const PHASE_ACTIVE: Record<Exclude<Phase, 'idle'>, string> = {
+  prepare: 'bg-brutalist-cyan',
+  map: 'bg-brutalist-pink',
+  reduce: 'bg-brutalist-yellow',
+  done: 'bg-white',
+};
+
+function jobLabel(job: JobFrame): string {
+  if (job.kind === 'map') {
+    return `MAP[${String(job.index ?? 0).padStart(2, '0')}]`;
+  }
+  return job.kind === 'prepare' ? 'PREPARE' : 'REDUCE';
+}
+
+/** A colour-coded job chip, used in the queue and the done stack. */
+function JobChip({ job, note }: { job: JobFrame; note?: string }) {
+  const requeued = job.status === 'requeued';
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, x: -10 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: 10 }}
+      transition={{ duration: 0.25 }}
+      className="flex items-center gap-2 border border-white bg-zinc-900 px-1.5 py-0.5"
+    >
+      <span
+        aria-hidden
+        className={`inline-block h-2.5 w-2.5 shrink-0 ${
+          requeued ? 'bg-brutalist-cyberOrange' : KIND_BAR[job.kind]
+        }`}
+      />
+      <span className="font-mono text-[11px] text-white">{jobLabel(job)}</span>
+      {(note ?? (requeued ? 'RETRY' : undefined)) && (
+        <span
+          className={`ml-auto font-mono text-[10px] ${
+            requeued ? 'text-brutalist-cyberOrange' : 'text-zinc-500'
+          }`}
+        >
+          {note ?? 'RETRY'}
+        </span>
+      )}
+    </motion.div>
+  );
+}
+
+function SlotRow({
+  slotIndex,
+  job,
+}: {
+  slotIndex: number;
+  job: JobFrame | undefined;
+}) {
+  return (
+    <div className="flex items-center gap-2 py-1 font-mono text-xs">
+      <span className="w-14 shrink-0 text-zinc-600">vCPU_{slotIndex}</span>
+      {job ? (
+        <>
+          <span
+            aria-hidden
+            className={`inline-block h-2.5 w-2.5 shrink-0 ${KIND_BAR[job.kind]}`}
+          />
+          <span className="w-20 shrink-0 text-white">{jobLabel(job)}</span>
+          <div className="h-2 min-w-0 flex-1 border border-white bg-zinc-900">
+            <div
+              className={`h-full ${KIND_BAR[job.kind]}`}
+              style={{ width: `${Math.round(job.progress * 100)}%` }}
+            />
+          </div>
+          <span
+            className={`w-16 shrink-0 text-right text-[10px] ${
+              job.hasReclaim ? 'text-brutalist-cyberOrange' : 'text-zinc-500'
+            }`}
+          >
+            {job.hasReclaim ? 'SPOT' : 'RUNNING'}
+          </span>
+        </>
+      ) : (
+        <span className="min-w-0 flex-1 text-zinc-700">— idle —</span>
+      )}
+    </div>
+  );
+}
+
+function ControlButton({
+  onClick,
+  label,
+  active = false,
+  children,
+}: {
+  onClick: () => void;
+  label: string;
+  active?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      className={`border-2 border-white px-2 py-1 font-mono text-xs transition-colors ${
+        active
+          ? 'bg-brutalist-cyan text-black'
+          : 'bg-black text-white hover:bg-zinc-900'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+const MAPPER_OPTIONS = [4, 8, 12];
+
+export default function MapReduceViz({
+  title = 'BATCH_PIPELINE.SIM',
+  caption,
+  mappers = 8,
+  slots = 4,
+  spotReclaim = true,
+  autoplay = true,
+}: MapReduceVizProps) {
+  const reduceMotion = useReducedMotion() ?? false;
+  const containerRef = useRef<HTMLElement>(null);
+  const [mapperCount, setMapperCount] = useState(mappers);
+  const [runKey, setRunKey] = useState(0);
+  const [t, setT] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [started, setStarted] = useState(false);
+
+  const plan = useMemo(
+    () =>
+      buildRun({
+        mappers: mapperCount,
+        seed: runKey * 7919 + mapperCount,
+        slots,
+        spotReclaim,
+      }),
+    [mapperCount, runKey, slots, spotReclaim],
+  );
+  const frame: Frame = useMemo(() => stateAt(plan, t), [plan, t]);
+  const boundaries = useMemo(() => phaseTimes(plan), [plan]);
+
+  const replay = useCallback(() => {
+    setRunKey((k) => k + 1);
+    setT(0);
+    setPlaying(true);
+    setStarted(true);
+  }, []);
+
+  // Autoplay when scrolled into view (mirrors Terminal).
+  useEffect(() => {
+    if (!autoplay || started || reduceMotion) return;
+    const el = containerRef.current;
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      setStarted(true);
+      setPlaying(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setStarted(true);
+          setPlaying(true);
+          io.disconnect();
+        }
+      },
+      { threshold: 0.35 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [autoplay, started, reduceMotion]);
+
+  // Reduced motion: land on the finished state; the phase stepper drives it.
+  useEffect(() => {
+    if (reduceMotion) {
+      setStarted(true);
+      setPlaying(false);
+      setT(plan.total);
+    }
+  }, [reduceMotion, plan.total]);
+
+  // The clock: requestAnimationFrame while playing.
+  useEffect(() => {
+    if (!playing || reduceMotion) return;
+    let raf = 0;
+    let last: number | null = null;
+    const tick = (now: number) => {
+      if (last !== null) {
+        const dt = (now - last) / 1000;
+        setT((prev) => {
+          const next = prev + dt;
+          if (next >= plan.total) {
+            setPlaying(false);
+            return plan.total;
+          }
+          return next;
+        });
+      }
+      last = now;
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [playing, plan.total, reduceMotion]);
+
+  const jobsById = useMemo(() => {
+    const m = new Map<string, JobFrame>();
+    for (const j of frame.jobs) m.set(j.id, j);
+    return m;
+  }, [frame.jobs]);
+
+  const queuedJobs = frame.queue
+    .map((id) => jobsById.get(id))
+    .filter((j): j is JobFrame => j !== undefined);
+  const pendingJobs = frame.jobs.filter((j) => j.status === 'pending');
+  const doneJobs = frame.jobs.filter((j) => j.status === 'done');
+  const reducePct = Math.round(frame.reduceProgress * 100);
+
+  return (
+    <figure className="my-6">
+      <section
+        ref={containerRef}
+        aria-label={`Animated batch pipeline simulation: a PREPARE job splits the input, ${mapperCount} MAP array jobs flow through a ${plan.config.slots}-slot compute environment, and a REDUCE job merges the results. Current phase: ${PHASE_LABEL[frame.phase]}.`}
+        className="border-2 border-white bg-black shadow-hard-lg"
+      >
+        {/* Title bar */}
+        <div className="flex flex-wrap items-center justify-between gap-2 border-b-2 border-white bg-zinc-900 px-3 py-2">
+          <span className="font-mono text-xs font-bold text-white">
+            {title}
+          </span>
+          <div className="flex items-center gap-1" aria-hidden>
+            {(['prepare', 'map', 'reduce', 'done'] as const).map((p) => (
+              <span
+                key={p}
+                className={`px-1 font-mono text-[10px] ${
+                  frame.phase === p
+                    ? `${PHASE_ACTIVE[p]} font-bold text-black`
+                    : 'text-zinc-500'
+                }`}
+              >
+                {PHASE_LABEL[p]}
+              </span>
+            ))}
+          </div>
+          <div className="flex items-center gap-1">
+            {MAPPER_OPTIONS.map((n) => (
+              <ControlButton
+                key={n}
+                label={`Run with ${n} map jobs`}
+                active={mapperCount === n}
+                onClick={() => {
+                  setMapperCount(n);
+                  setT(0);
+                  setPlaying(!reduceMotion);
+                  setStarted(true);
+                }}
+              >
+                x{n}
+              </ControlButton>
+            ))}
+            {!reduceMotion && (
+              <ControlButton
+                label={playing ? 'Pause simulation' : 'Play simulation'}
+                onClick={() => {
+                  if (!playing && t >= plan.total) {
+                    replay();
+                    return;
+                  }
+                  setPlaying((p) => !p);
+                  setStarted(true);
+                }}
+              >
+                {playing ? <Pause size={12} /> : <Play size={12} />}
+              </ControlButton>
+            )}
+            <ControlButton label="Replay simulation" onClick={replay}>
+              <RotateCcw size={12} />
+            </ControlButton>
+          </div>
+        </div>
+
+        {/* Legend */}
+        <div
+          className="flex flex-wrap items-center gap-3 border-b-2 border-white px-3 py-1.5 font-mono text-[10px] text-zinc-500"
+          aria-hidden
+        >
+          <span>JOB_TYPES:</span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2 w-2 bg-brutalist-cyan" /> PREPARE
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2 w-2 bg-brutalist-pink" /> MAP
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2 w-2 bg-brutalist-yellow" /> REDUCE
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="inline-block h-2 w-2 bg-brutalist-cyberOrange" />{' '}
+            SPOT RECLAIM
+          </span>
+        </div>
+
+        {/* Reduced-motion phase stepper */}
+        {reduceMotion && (
+          <div className="flex items-center gap-1 border-b-2 border-white px-3 py-2">
+            <span className="font-mono text-[10px] text-zinc-500">
+              STEP_THROUGH:
+            </span>
+            {(['prepare', 'map', 'reduce', 'done'] as const).map((p) => (
+              <ControlButton
+                key={p}
+                label={`Show ${PHASE_LABEL[p]} phase`}
+                active={frame.phase === p}
+                onClick={() => setT(boundaries[p])}
+              >
+                {PHASE_LABEL[p]}
+              </ControlButton>
+            ))}
+          </div>
+        )}
+
+        {/* Stage: queue → compute environment → succeeded */}
+        <div className="grid gap-4 p-4 sm:grid-cols-[1fr_1.6fr_1fr]">
+          {/* Job queue */}
+          <div className="min-w-0">
+            <div className="mb-2 font-mono text-[10px] text-zinc-500">
+              JOB_QUEUE ({queuedJobs.length} runnable)
+            </div>
+            <div className="flex min-h-32 flex-col gap-1 border-2 border-white p-2">
+              <AnimatePresence initial={false}>
+                {queuedJobs.map((j) => (
+                  <JobChip key={j.id} job={j} />
+                ))}
+                {pendingJobs.map((j) => (
+                  <motion.div
+                    key={j.id}
+                    layout
+                    initial={false}
+                    exit={{ opacity: 0 }}
+                    className="flex items-center gap-2 border border-dashed border-zinc-700 px-1.5 py-0.5"
+                  >
+                    <span
+                      aria-hidden
+                      className={`inline-block h-2.5 w-2.5 shrink-0 border-2 ${KIND_BORDER[j.kind]}`}
+                    />
+                    <span className="font-mono text-[11px] text-zinc-500">
+                      {jobLabel(j)}
+                    </span>
+                    <span className="ml-auto font-mono text-[10px] text-zinc-600">
+                      WAITING_DEPS
+                    </span>
+                  </motion.div>
+                ))}
+              </AnimatePresence>
+              {queuedJobs.length === 0 && pendingJobs.length === 0 && (
+                <span className="font-mono text-[11px] text-zinc-700">
+                  — queue empty —
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Compute environment */}
+          <div className="min-w-0">
+            <div className="mb-2 flex items-baseline justify-between font-mono text-[10px] text-zinc-500">
+              <span>COMPUTE_ENV ({plan.config.slots} slots)</span>
+              <span>AWS_BATCH_JOB_ARRAY_INDEX</span>
+            </div>
+            <div className="border-2 border-white p-2">
+              {frame.slots.map((id, s) => (
+                <SlotRow
+                  key={`slot-${s}`}
+                  slotIndex={s}
+                  job={id ? jobsById.get(id) : undefined}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Succeeded + output */}
+          <div className="min-w-0">
+            <div className="mb-2 font-mono text-[10px] text-zinc-500">
+              SUCCEEDED → OUTPUT
+            </div>
+            <div className="border-2 border-white bg-zinc-900 p-2">
+              <div className="flex max-h-40 flex-col gap-1 overflow-hidden">
+                <AnimatePresence initial={false}>
+                  {doneJobs.slice(-6).map((j) => (
+                    <JobChip key={j.id} job={j} note="OK" />
+                  ))}
+                </AnimatePresence>
+              </div>
+              <div className="mt-2 h-2 border border-white bg-zinc-800">
+                <div
+                  className="h-full bg-brutalist-yellow"
+                  style={{ width: `${reducePct}%` }}
+                />
+              </div>
+              <div className="mt-2 font-mono text-[10px] text-zinc-500">
+                {frame.completedMaps}/{mapperCount} map results ·{' '}
+                {frame.phase === 'done' ? (
+                  <span className="bg-brutalist-yellow px-1 font-bold text-black">
+                    result written
+                  </span>
+                ) : frame.phase === 'reduce' ? (
+                  `reducing ${reducePct}%`
+                ) : (
+                  'awaiting reduce'
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      {caption && (
+        <figcaption className="mt-2 text-center font-mono text-xs text-zinc-500">
+          {caption}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/components/interactive/MvuLoop.tsx
+++ b/components/interactive/MvuLoop.tsx
@@ -1,0 +1,264 @@
+import { RotateCcw } from 'lucide-react';
+import { useReducedMotion } from 'motion/react';
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * The Elmish / MVU loop, animated. A message travels Model → View → Update
+ * → Model, and each full lap changes the model (a counter), so the "single
+ * source of truth mutating through a pure update function" is visible.
+ * Prototype for the SAFE-stack talk.
+ */
+
+export type MvuNode = 'model' | 'view' | 'update';
+
+export interface MvuFrame {
+  /** Edge the token is traversing. */
+  edge: 'model->view' | 'view->update' | 'update->model';
+  /** 0..1 along the current edge. */
+  progress: number;
+  active: MvuNode;
+  /** Model state value; increments once per lap. */
+  modelValue: number;
+  /** The message currently in flight, shown on view->update. */
+  message: string | null;
+}
+
+const EDGE_DUR = 1.1;
+const LAP = EDGE_DUR * 3;
+
+export function mvuFrameAt(t: number): MvuFrame {
+  const lap = Math.floor(t / LAP);
+  const within = t - lap * LAP;
+  const edgeIdx = Math.min(Math.floor(within / EDGE_DUR), 2);
+  const progress = (within - edgeIdx * EDGE_DUR) / EDGE_DUR;
+  const edges = ['model->view', 'view->update', 'update->model'] as const;
+  const active: MvuNode[] = ['view', 'update', 'model'];
+  return {
+    edge: edges[edgeIdx],
+    progress,
+    active: active[edgeIdx],
+    // The model updates as the token arrives back at Model (edge 2 done).
+    modelValue: lap + (edgeIdx === 2 ? 1 : 0),
+    message: edgeIdx === 1 ? 'Increment' : null,
+  };
+}
+
+const C = {
+  cyan: 'var(--brutalist-cyan, #22d3ee)',
+  pink: 'var(--brutalist-pink, #ec4899)',
+  yellow: 'var(--brutalist-yellow, #facc15)',
+  ink: 'var(--color-white, #ffffff)',
+  dim: 'var(--color-zinc-800, #27272a)',
+  muted: 'var(--color-zinc-600, #52525b)',
+};
+
+const VB = 320;
+// Triangle node centres.
+const NODES: Record<
+  MvuNode,
+  { x: number; y: number; label: string; color: string }
+> = {
+  model: { x: VB / 2, y: 70, label: 'Model', color: C.cyan },
+  view: { x: VB - 70, y: VB - 80, label: 'View', color: C.yellow },
+  update: { x: 70, y: VB - 80, label: 'Update', color: C.pink },
+};
+
+function lerp(a: number, b: number, u: number) {
+  return a + (b - a) * u;
+}
+
+const LAPS_TO_SHOW = 3;
+
+export default function MvuLoop({ autoplay = true }: { autoplay?: boolean }) {
+  const reduceMotion = useReducedMotion() ?? false;
+  const ref = useRef<HTMLElement>(null);
+  const [t, setT] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [started, setStarted] = useState(false);
+
+  const total = LAP * LAPS_TO_SHOW;
+  const frame = mvuFrameAt(reduceMotion ? LAP * 2 : t);
+
+  const restart = () => {
+    setT(0);
+    setPlaying(!reduceMotion);
+    setStarted(true);
+  };
+
+  useEffect(() => {
+    if (!autoplay || started || reduceMotion) return;
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      setStarted(true);
+      setPlaying(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      (es) => {
+        if (es.some((e) => e.isIntersecting)) {
+          setStarted(true);
+          setPlaying(true);
+          io.disconnect();
+        }
+      },
+      { threshold: 0.35 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [autoplay, started, reduceMotion]);
+
+  useEffect(() => {
+    if (!playing || reduceMotion) return;
+    let raf = 0;
+    let last: number | null = null;
+    const tick = (now: number) => {
+      if (last !== null) {
+        const dt = (now - last) / 1000;
+        setT((p) => (p + dt >= total ? 0 : p + dt)); // loop forever
+      }
+      last = now;
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [playing, total, reduceMotion]);
+
+  const [from, to] =
+    frame.edge === 'model->view'
+      ? (['model', 'view'] as const)
+      : frame.edge === 'view->update'
+        ? (['view', 'update'] as const)
+        : (['update', 'model'] as const);
+  const tx = lerp(NODES[from].x, NODES[to].x, frame.progress);
+  const ty = lerp(NODES[from].y, NODES[to].y, frame.progress);
+
+  const edgeLabel: Record<MvuFrame['edge'], string> = {
+    'model->view': 'render',
+    'view->update': `msg: ${frame.message ?? ''}`,
+    'update->model': 'new state',
+  };
+
+  return (
+    <figure className="my-6">
+      <section
+        ref={ref}
+        aria-label="Model-View-Update loop: a message flows from View to Update to a new Model, which re-renders the View. Each lap increments the model counter."
+        className="border-2 border-white bg-black shadow-hard-lg"
+      >
+        <div className="flex items-center justify-between border-b-2 border-white bg-zinc-900 px-3 py-2">
+          <span className="font-mono text-xs font-bold text-white">
+            MVU.LOOP
+          </span>
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-[11px] text-brutalist-cyan">
+              model.count = {frame.modelValue}
+            </span>
+            <button
+              type="button"
+              onClick={restart}
+              aria-label="Replay"
+              className="border-2 border-white bg-black px-2 py-1 text-white hover:bg-zinc-900"
+            >
+              <RotateCcw size={12} />
+            </button>
+          </div>
+        </div>
+
+        <div className="grid gap-2 p-3 sm:grid-cols-[1fr_auto]">
+          <svg
+            viewBox={`0 0 ${VB} ${VB}`}
+            className="mx-auto w-full max-w-sm"
+            role="img"
+            aria-hidden
+          >
+            <title>MVU loop</title>
+            {/* Directed edges (arrows) */}
+            {(['model->view', 'view->update', 'update->model'] as const).map(
+              (e) => {
+                const [f, tN] =
+                  e === 'model->view'
+                    ? (['model', 'view'] as const)
+                    : e === 'view->update'
+                      ? (['view', 'update'] as const)
+                      : (['update', 'model'] as const);
+                const on = frame.edge === e;
+                return (
+                  <line
+                    key={e}
+                    x1={NODES[f].x}
+                    y1={NODES[f].y}
+                    x2={NODES[tN].x}
+                    y2={NODES[tN].y}
+                    stroke={on ? C.ink : C.muted}
+                    strokeWidth={on ? 3 : 1.5}
+                    opacity={on ? 1 : 0.5}
+                  />
+                );
+              },
+            )}
+            {/* Nodes */}
+            {(Object.keys(NODES) as MvuNode[]).map((k) => {
+              const nd = NODES[k];
+              const on = frame.active === k;
+              return (
+                <g key={k}>
+                  <circle
+                    cx={nd.x}
+                    cy={nd.y}
+                    r={38}
+                    fill={on ? nd.color : C.dim}
+                    stroke={nd.color}
+                    strokeWidth={2.5}
+                  />
+                  <text
+                    x={nd.x}
+                    y={nd.y + 5}
+                    fill={on ? '#000' : C.ink}
+                    textAnchor="middle"
+                    className="font-mono"
+                    fontSize={13}
+                  >
+                    {nd.label}
+                  </text>
+                </g>
+              );
+            })}
+            {/* Token */}
+            <circle cx={tx} cy={ty} r={8} fill={C.ink} />
+            {/* Edge label near the token */}
+            <text
+              x={tx}
+              y={ty - 14}
+              fill={C.ink}
+              textAnchor="middle"
+              className="font-mono"
+              fontSize={10}
+            >
+              {edgeLabel[frame.edge]}
+            </text>
+          </svg>
+        </div>
+
+        {reduceMotion && (
+          <div className="flex items-center gap-1 border-t-2 border-white px-3 py-2">
+            <span className="font-mono text-[10px] text-zinc-500">STEP:</span>
+            {(['render', 'message', 'new state'] as const).map((lbl, i) => (
+              <button
+                key={lbl}
+                type="button"
+                onClick={() => setT(LAP + i * EDGE_DUR + EDGE_DUR / 2)}
+                className="border-2 border-white bg-black px-2 py-1 font-mono text-[10px] text-white hover:bg-zinc-900"
+              >
+                {lbl}
+              </button>
+            ))}
+          </div>
+        )}
+      </section>
+      <figcaption className="mt-2 text-center font-mono text-xs text-zinc-500">
+        Model-View-Update — one state, a pure update function, a re-rendered
+        view. Every message makes one full lap.
+      </figcaption>
+    </figure>
+  );
+}

--- a/components/interactive/RailwayTrack.tsx
+++ b/components/interactive/RailwayTrack.tsx
@@ -1,0 +1,362 @@
+import { RotateCcw } from 'lucide-react';
+import { useReducedMotion } from 'motion/react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+/**
+ * Railway Oriented Programming, animated. A value rides the success rail
+ * through a pipeline of steps; at the failing step `bind` switches it onto
+ * the failure rail, where it bypasses every remaining step and slides
+ * straight to the output. Prototype for the ROP talk.
+ *
+ * Deterministic: `railFrameAt(t, cfg)` is pure, so the render is
+ * reproducible/snapshotable and the clock is the only stateful part.
+ */
+
+export interface RailStep {
+  label: string;
+  op: string;
+}
+
+export interface RailConfig {
+  steps: RailStep[];
+  /** Index of the step that fails, or -1 for an all-success run. */
+  failAt: number;
+}
+
+export interface RailFrame {
+  /** 0..1 across the whole pipeline (station space normalised). */
+  x: number;
+  rail: 'success' | 'failure';
+  activeStep: number;
+  /** The value label carried by the token. */
+  value: 'Ok' | 'Error';
+  switching: boolean;
+  done: boolean;
+}
+
+const STEP_DUR = 1.15;
+const TAIL = 1.0;
+
+export function railTotal(cfg: RailConfig): number {
+  return cfg.steps.length * STEP_DUR + TAIL;
+}
+
+export function railFrameAt(t: number, cfg: RailConfig): RailFrame {
+  const n = cfg.steps.length;
+  const u = Math.min(t / STEP_DUR, n); // station-space position 0..n
+  const failed = cfg.failAt >= 0;
+  const switchU = failed ? cfg.failAt + 0.5 : Number.POSITIVE_INFINITY;
+  const onFailure = u >= switchU;
+  const switching = failed && Math.abs(u - switchU) < 0.28;
+  return {
+    x: u / n,
+    rail: onFailure ? 'failure' : 'success',
+    activeStep: Math.min(Math.floor(u), n - 1),
+    value: onFailure ? 'Error' : 'Ok',
+    switching,
+    done: t >= railTotal(cfg) - 1e-6,
+  };
+}
+
+const C = {
+  cyan: 'var(--brutalist-cyan, #22d3ee)',
+  pink: 'var(--brutalist-pink, #ec4899)',
+  ink: 'var(--color-white, #ffffff)',
+  muted: 'var(--color-zinc-600, #52525b)',
+  dim: 'var(--color-zinc-800, #27272a)',
+};
+
+const DEFAULT_STEPS: RailStep[] = [
+  { label: 'validate', op: 'bind' },
+  { label: 'parse', op: 'bind' },
+  { label: 'save', op: 'bind' },
+  { label: 'format', op: 'map' },
+];
+
+interface Props {
+  steps?: RailStep[];
+  failAt?: number;
+  autoplay?: boolean;
+}
+
+const VB_W = 720;
+const VB_H = 220;
+const SUCCESS_Y = 70;
+const FAILURE_Y = 165;
+const PAD = 60;
+
+export default function RailwayTrack({
+  steps = DEFAULT_STEPS,
+  failAt = 2,
+  autoplay = true,
+}: Props) {
+  const reduceMotion = useReducedMotion() ?? false;
+  const ref = useRef<HTMLElement>(null);
+  const [failIdx, setFailIdx] = useState(failAt);
+  const [t, setT] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [started, setStarted] = useState(false);
+
+  const cfg = useMemo<RailConfig>(
+    () => ({ steps, failAt: failIdx }),
+    [steps, failIdx],
+  );
+  const total = railTotal(cfg);
+  const frame = railFrameAt(reduceMotion ? total : t, cfg);
+
+  const restart = (nextFail = failIdx) => {
+    setFailIdx(nextFail);
+    setT(0);
+    setPlaying(!reduceMotion);
+    setStarted(true);
+  };
+
+  useEffect(() => {
+    if (!autoplay || started || reduceMotion) return;
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      setStarted(true);
+      setPlaying(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      (es) => {
+        if (es.some((e) => e.isIntersecting)) {
+          setStarted(true);
+          setPlaying(true);
+          io.disconnect();
+        }
+      },
+      { threshold: 0.35 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [autoplay, started, reduceMotion]);
+
+  useEffect(() => {
+    if (!playing || reduceMotion) return;
+    let raf = 0;
+    let last: number | null = null;
+    const tick = (now: number) => {
+      if (last !== null) {
+        const dt = (now - last) / 1000;
+        setT((p) => {
+          const next = p + dt;
+          if (next >= total) {
+            setPlaying(false);
+            return total;
+          }
+          return next;
+        });
+      }
+      last = now;
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [playing, total, reduceMotion]);
+
+  const n = steps.length;
+  const stationX = (i: number) => PAD + ((i + 0.5) / n) * (VB_W - 2 * PAD);
+  const tokenX = PAD + frame.x * (VB_W - 2 * PAD);
+  const tokenY =
+    frame.rail === 'failure'
+      ? frame.switching
+        ? SUCCESS_Y + (FAILURE_Y - SUCCESS_Y) * 0.5
+        : FAILURE_Y
+      : SUCCESS_Y;
+  const tokenColor = frame.rail === 'failure' ? C.pink : C.cyan;
+
+  return (
+    <figure className="my-6">
+      <section
+        ref={ref}
+        aria-label={`Railway oriented programming: a value rides the success rail through ${n} steps${failIdx >= 0 ? `, fails at "${steps[failIdx].label}", and switches to the failure rail` : ' and succeeds'}.`}
+        className="border-2 border-white bg-black shadow-hard-lg"
+      >
+        <div className="flex flex-wrap items-center justify-between gap-2 border-b-2 border-white bg-zinc-900 px-3 py-2">
+          <span className="font-mono text-xs font-bold text-white">
+            RAILWAY.SIM
+          </span>
+          <div className="flex items-center gap-1">
+            <span className="mr-1 font-mono text-[10px] text-zinc-500">
+              FAIL_AT:
+            </span>
+            {steps.map((s, i) => (
+              <button
+                key={s.label}
+                type="button"
+                onClick={() => restart(i)}
+                aria-label={`Fail at ${s.label}`}
+                className={`border-2 border-white px-2 py-1 font-mono text-[10px] transition-colors ${
+                  failIdx === i
+                    ? 'bg-brutalist-pink text-black'
+                    : 'bg-black text-white hover:bg-zinc-900'
+                }`}
+              >
+                {s.label}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => restart(-1)}
+              aria-label="All steps succeed"
+              className={`border-2 border-white px-2 py-1 font-mono text-[10px] transition-colors ${
+                failIdx === -1
+                  ? 'bg-brutalist-cyan text-black'
+                  : 'bg-black text-white hover:bg-zinc-900'
+              }`}
+            >
+              none
+            </button>
+            <button
+              type="button"
+              onClick={() => restart(failIdx)}
+              aria-label="Replay"
+              className="border-2 border-white bg-black px-2 py-1 text-white hover:bg-zinc-900"
+            >
+              <RotateCcw size={12} />
+            </button>
+          </div>
+        </div>
+
+        <svg
+          viewBox={`0 0 ${VB_W} ${VB_H}`}
+          className="w-full"
+          role="img"
+          aria-hidden
+        >
+          <title>Railway track</title>
+          {/* Rails */}
+          <line
+            x1={PAD}
+            y1={SUCCESS_Y}
+            x2={VB_W - PAD}
+            y2={SUCCESS_Y}
+            stroke={C.cyan}
+            strokeWidth={3}
+          />
+          <line
+            x1={PAD}
+            y1={FAILURE_Y}
+            x2={VB_W - PAD}
+            y2={FAILURE_Y}
+            stroke={C.pink}
+            strokeWidth={3}
+            strokeDasharray="2 6"
+            opacity={0.6}
+          />
+          {/* Rail labels */}
+          <text
+            x={8}
+            y={SUCCESS_Y + 4}
+            fill={C.cyan}
+            className="font-mono"
+            fontSize={11}
+          >
+            Ok
+          </text>
+          <text
+            x={2}
+            y={FAILURE_Y + 4}
+            fill={C.pink}
+            className="font-mono"
+            fontSize={11}
+          >
+            Err
+          </text>
+          {/* Stations */}
+          {steps.map((s, i) => {
+            const x = stationX(i);
+            const bypassed = frame.rail === 'failure' && i > failIdx;
+            const active = frame.activeStep === i && !bypassed;
+            return (
+              <g key={s.label} opacity={bypassed ? 0.3 : 1}>
+                <rect
+                  x={x - 42}
+                  y={SUCCESS_Y - 20}
+                  width={84}
+                  height={40}
+                  fill={active ? C.cyan : C.dim}
+                  stroke={C.ink}
+                  strokeWidth={2}
+                />
+                <text
+                  x={x}
+                  y={SUCCESS_Y - 2}
+                  fill={active ? '#000' : C.ink}
+                  textAnchor="middle"
+                  className="font-mono"
+                  fontSize={12}
+                >
+                  {s.label}
+                </text>
+                <text
+                  x={x}
+                  y={SUCCESS_Y + 13}
+                  fill={active ? '#000' : C.muted}
+                  textAnchor="middle"
+                  className="font-mono"
+                  fontSize={9}
+                >
+                  {s.op}
+                </text>
+                {i === failIdx && (
+                  <text
+                    x={x}
+                    y={SUCCESS_Y - 28}
+                    fill={C.pink}
+                    textAnchor="middle"
+                    className="font-mono"
+                    fontSize={10}
+                  >
+                    ✗ fails → switch
+                  </text>
+                )}
+              </g>
+            );
+          })}
+          {/* Output */}
+          <text
+            x={VB_W - PAD + 6}
+            y={(frame.rail === 'failure' ? FAILURE_Y : SUCCESS_Y) + 4}
+            fill={frame.rail === 'failure' ? C.pink : C.cyan}
+            className="font-mono"
+            fontSize={11}
+          >
+            {frame.value === 'Error' ? 'Error e' : 'Ok x'}
+          </text>
+          {/* Token */}
+          <circle
+            cx={tokenX}
+            cy={tokenY}
+            r={9}
+            fill={tokenColor}
+            stroke={C.ink}
+            strokeWidth={2}
+          />
+        </svg>
+
+        {reduceMotion && (
+          <div className="flex items-center gap-1 border-t-2 border-white px-3 py-2">
+            <span className="font-mono text-[10px] text-zinc-500">STEP:</span>
+            {[0, 0.5, 1].map((f) => (
+              <button
+                key={f}
+                type="button"
+                onClick={() => setT(total * f)}
+                className="border-2 border-white bg-black px-2 py-1 font-mono text-[10px] text-white hover:bg-zinc-900"
+              >
+                {f === 0 ? 'start' : f === 0.5 ? 'mid' : 'end'}
+              </button>
+            ))}
+          </div>
+        )}
+      </section>
+      <figcaption className="mt-2 text-center font-mono text-xs text-zinc-500">
+        Railway Oriented Programming — `bind` keeps you on the success rail; one
+        failure switches the track and short-circuits the rest.
+      </figcaption>
+    </figure>
+  );
+}

--- a/components/interactive/mapReduceModel.ts
+++ b/components/interactive/mapReduceModel.ts
@@ -1,0 +1,316 @@
+/**
+ * Pure model for the MapReduceViz interactive: a deterministic, seeded
+ * discrete-event simulation of an AWS-Batch-style pipeline flowing through a
+ * job queue into a slot-limited compute environment.
+ *
+ * The pipeline is three colour-coded job types with dependencies:
+ *   PREPARE (one job, splits the input) → MAP (an array job, one child per
+ *   chunk) → REDUCE (one job, depends on every map).
+ *
+ * The compute environment has a fixed number of vCPU slots, so with more map
+ * jobs than slots the queue is visible: jobs wait RUNNABLE until a slot
+ * frees. One map job can lose its spot instance mid-run — its attempt ends,
+ * it re-enters the queue, and it runs again later.
+ *
+ * All timing/randomness lives here so a run is reproducible and
+ * unit-testable; the component just renders `stateAt(plan, t)`.
+ */
+
+export type Phase = 'idle' | 'prepare' | 'map' | 'reduce' | 'done';
+
+export type JobKind = 'prepare' | 'map' | 'reduce';
+
+export type JobStatus =
+  | 'pending' // dependency not yet satisfied
+  | 'runnable' // in the queue, waiting for a slot
+  | 'running'
+  | 'requeued' // spot instance reclaimed; waiting to run again
+  | 'done';
+
+export interface JobSegment {
+  slot: number;
+  start: number;
+  end: number;
+  /** False when the segment ends in a spot reclaim instead of completion. */
+  completes: boolean;
+}
+
+export interface JobPlan {
+  id: string;
+  kind: JobKind;
+  /** Array index for map jobs. */
+  index?: number;
+  /** The time this job's dependencies are satisfied. */
+  readyAt: number;
+  segments: JobSegment[];
+  /** Completion time (end of the final segment). */
+  end: number;
+  /** True if this job suffers a spot reclaim. */
+  hasReclaim: boolean;
+}
+
+export interface JobFrame {
+  id: string;
+  kind: JobKind;
+  index?: number;
+  status: JobStatus;
+  /** 0..1 across the current/last attempt. */
+  progress: number;
+  /** Slot occupied while running, else undefined. */
+  slot?: number;
+  hasReclaim: boolean;
+}
+
+export interface Frame {
+  phase: Phase;
+  t: number;
+  jobs: JobFrame[];
+  /** Job ids currently waiting (runnable/requeued), in queue order. */
+  queue: string[];
+  /** Per-slot occupant job id (undefined = idle). */
+  slots: (string | undefined)[];
+  completedMaps: number;
+  /** 0..1 through the reduce job. */
+  reduceProgress: number;
+}
+
+export interface RunConfig {
+  mappers: number;
+  seed: number;
+  /** Compute-environment slots (max concurrent jobs). */
+  slots: number;
+  /** Simulate one map job losing its spot instance and retrying. */
+  spotReclaim: boolean;
+}
+
+export interface RunPlan {
+  config: RunConfig;
+  jobs: JobPlan[];
+  prepareEnd: number;
+  reduceStart: number;
+  reduceEnd: number;
+  total: number;
+}
+
+/** Small deterministic PRNG (mulberry32) so runs replay identically. */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const PICKUP = 0.2; // queue → slot latency
+const REQUEUE_DELAY = 0.5; // reclaim → back in the queue
+const DONE_HOLD = 1.0;
+
+interface Attempt {
+  jobIndex: number; // index into the jobs array
+  readyAt: number;
+  duration: number;
+  /** Fraction of duration at which this attempt is reclaimed (undefined = completes). */
+  reclaimFrac?: number;
+}
+
+export function buildRun(config: RunConfig): RunPlan {
+  const rand = mulberry32(config.seed);
+  const slots = Math.max(1, config.slots);
+
+  const prepareDuration = 1.2 + rand() * 0.6;
+  const reclaimIndex = config.spotReclaim
+    ? Math.floor(rand() * config.mappers)
+    : -1;
+
+  const jobs: JobPlan[] = [
+    {
+      id: 'prepare',
+      kind: 'prepare',
+      readyAt: 0,
+      segments: [],
+      end: 0,
+      hasReclaim: false,
+    },
+  ];
+  const mapDurations: number[] = [];
+  for (let i = 0; i < config.mappers; i++) {
+    mapDurations.push(1.3 + rand() * 1.6);
+    jobs.push({
+      id: `map-${i}`,
+      kind: 'map',
+      index: i,
+      readyAt: 0,
+      segments: [],
+      end: 0,
+      hasReclaim: i === reclaimIndex,
+    });
+  }
+  const reclaimFrac = 0.35 + rand() * 0.35;
+  jobs.push({
+    id: 'reduce',
+    kind: 'reduce',
+    readyAt: 0,
+    segments: [],
+    end: 0,
+    hasReclaim: false,
+  });
+
+  // Slot free-times for the greedy scheduler.
+  const freeAt: number[] = Array.from({ length: slots }, () => 0);
+  const runAttempt = (a: Attempt): JobSegment => {
+    let slot = 0;
+    for (let s = 1; s < slots; s++) {
+      if (freeAt[s] < freeAt[slot]) slot = s;
+    }
+    const start = Math.max(freeAt[slot], a.readyAt) + PICKUP;
+    const end =
+      a.reclaimFrac !== undefined
+        ? start + a.duration * a.reclaimFrac
+        : start + a.duration;
+    freeAt[slot] = end;
+    return { slot, start, end, completes: a.reclaimFrac === undefined };
+  };
+
+  // PREPARE runs alone.
+  const prepSeg = runAttempt({
+    jobIndex: 0,
+    readyAt: 0,
+    duration: prepareDuration,
+  });
+  jobs[0].segments.push(prepSeg);
+  jobs[0].end = prepSeg.end;
+  const prepareEnd = prepSeg.end;
+
+  // MAP array becomes ready when prepare succeeds; process attempts in
+  // enqueue order, re-enqueueing the reclaimed attempt at the back.
+  const attempts: Attempt[] = [];
+  for (let i = 0; i < config.mappers; i++) {
+    attempts.push({
+      jobIndex: 1 + i,
+      readyAt: prepareEnd,
+      duration: mapDurations[i],
+      reclaimFrac: i === reclaimIndex ? reclaimFrac : undefined,
+    });
+  }
+  for (let k = 0; k < attempts.length; k++) {
+    const a = attempts[k];
+    const job = jobs[a.jobIndex];
+    job.readyAt = prepareEnd;
+    const seg = runAttempt(a);
+    job.segments.push(seg);
+    if (seg.completes) {
+      job.end = seg.end;
+    } else {
+      attempts.push({
+        jobIndex: a.jobIndex,
+        readyAt: seg.end + REQUEUE_DELAY,
+        duration: a.duration * (0.9 + 0.2 * reclaimFrac),
+      });
+    }
+  }
+
+  // REDUCE depends on every map.
+  const mapsEnd = Math.max(
+    ...jobs.filter((j) => j.kind === 'map').map((j) => j.end),
+  );
+  const reduceJob = jobs[jobs.length - 1];
+  reduceJob.readyAt = mapsEnd;
+  const reduceSeg = runAttempt({
+    jobIndex: jobs.length - 1,
+    readyAt: mapsEnd,
+    duration: 1.5 + rand() * 0.5,
+  });
+  reduceJob.segments.push(reduceSeg);
+  reduceJob.end = reduceSeg.end;
+
+  return {
+    config: { ...config, slots },
+    jobs,
+    prepareEnd,
+    reduceStart: reduceSeg.start,
+    reduceEnd: reduceSeg.end,
+    total: reduceSeg.end + DONE_HOLD,
+  };
+}
+
+function clamp01(x: number): number {
+  return x < 0 ? 0 : x > 1 ? 1 : x;
+}
+
+function jobAt(job: JobPlan, t: number): JobFrame {
+  const base = {
+    id: job.id,
+    kind: job.kind,
+    index: job.index,
+    hasReclaim: job.hasReclaim,
+  };
+  if (t >= job.end && job.end > 0)
+    return { ...base, status: 'done', progress: 1 };
+  if (t < job.readyAt) return { ...base, status: 'pending', progress: 0 };
+
+  let lastFailedEnd: number | undefined;
+  for (const seg of job.segments) {
+    if (t >= seg.start && t < seg.end) {
+      return {
+        ...base,
+        status: 'running',
+        progress: clamp01((t - seg.start) / (seg.end - seg.start)),
+        slot: seg.slot,
+      };
+    }
+    if (!seg.completes && t >= seg.end) lastFailedEnd = seg.end;
+  }
+  // Not running: waiting for a slot — either first wait or post-reclaim.
+  if (lastFailedEnd !== undefined) {
+    return { ...base, status: 'requeued', progress: 0 };
+  }
+  return { ...base, status: 'runnable', progress: 0 };
+}
+
+export function stateAt(plan: RunPlan, t: number): Frame {
+  const jobs = plan.jobs.map((j) => jobAt(j, t));
+
+  const queue = jobs
+    .filter((j) => j.status === 'runnable' || j.status === 'requeued')
+    .map((j) => j.id);
+  const slots: (string | undefined)[] = Array.from(
+    { length: plan.config.slots },
+    () => undefined,
+  );
+  for (const j of jobs) {
+    if (j.status === 'running' && j.slot !== undefined) slots[j.slot] = j.id;
+  }
+  const completedMaps = jobs.filter(
+    (j) => j.kind === 'map' && j.status === 'done',
+  ).length;
+  const reduceProgress =
+    t >= plan.reduceEnd
+      ? 1
+      : t >= plan.reduceStart
+        ? clamp01((t - plan.reduceStart) / (plan.reduceEnd - plan.reduceStart))
+        : 0;
+
+  let phase: Phase;
+  if (t <= 0) phase = 'idle';
+  else if (t < plan.prepareEnd) phase = 'prepare';
+  else if (t < plan.reduceStart) phase = 'map';
+  else if (t < plan.reduceEnd) phase = 'reduce';
+  else phase = 'done';
+
+  return { phase, t, jobs, queue, slots, completedMaps, reduceProgress };
+}
+
+/** Phase boundary times, used by the reduced-motion stepper. */
+export function phaseTimes(
+  plan: RunPlan,
+): Record<Exclude<Phase, 'idle'>, number> {
+  return {
+    prepare: plan.prepareEnd * 0.55,
+    map: plan.prepareEnd + (plan.reduceStart - plan.prepareEnd) * 0.55,
+    reduce: plan.reduceStart + (plan.reduceEnd - plan.reduceStart) * 0.5,
+    done: plan.total,
+  };
+}

--- a/pages/experiments.tsx
+++ b/pages/experiments.tsx
@@ -1,4 +1,12 @@
-import { Beaker, Boxes, Palette, Sparkles, Terminal, Type } from 'lucide-react';
+import {
+  Beaker,
+  Boxes,
+  Palette,
+  Projector,
+  Sparkles,
+  Terminal,
+  Type,
+} from 'lucide-react';
 import Link from '@/components/Link';
 import { PageSEO } from '@/components/SEO';
 import siteMetadata from '@/data/siteMetadata';
@@ -38,6 +46,15 @@ const experiments = [
     icon: <Sparkles className="w-12 h-12" />,
     status: 'active',
     components: 6,
+  },
+  {
+    name: 'Talk Animations',
+    path: '/experiments/talk-animations',
+    description:
+      'Prototype interactive animations for the talk decks — map/reduce, ROP railway, MVU loop, dependency resolution',
+    icon: <Projector className="w-12 h-12" />,
+    status: 'active',
+    components: 5,
   },
 ];
 

--- a/pages/experiments/talk-animations.tsx
+++ b/pages/experiments/talk-animations.tsx
@@ -1,0 +1,149 @@
+import { Projector } from 'lucide-react';
+import dynamic from 'next/dynamic';
+import type { TerminalEvent } from '@/components/interactive/terminalEngine';
+import { PageSEO } from '@/components/SEO';
+import siteMetadata from '@/data/siteMetadata';
+
+// Client-only, mirroring how the interactives load in MDX. next/dynamic's SWC
+// transform requires the options to be an inline object literal — a shared
+// variable fails the build (tsc-clean, next build-red), so each call inlines
+// `{ ssr: false }`.
+const MapReduceViz = dynamic(
+  () => import('@/components/interactive/MapReduceViz'),
+  { ssr: false },
+);
+const RailwayTrack = dynamic(
+  () => import('@/components/interactive/RailwayTrack'),
+  { ssr: false },
+);
+const MvuLoop = dynamic(() => import('@/components/interactive/MvuLoop'), {
+  ssr: false,
+});
+const DepResolve = dynamic(
+  () => import('@/components/interactive/DepResolve'),
+  { ssr: false },
+);
+const Terminal = dynamic(() => import('@/components/interactive/Terminal'), {
+  ssr: false,
+});
+
+const PAKET_CONVERT: TerminalEvent[] = [
+  { cmd: 'paket convert-from-nuget --force' },
+  {
+    out: [
+      'Converting from NuGet',
+      '  - Analyzing packages.config files',
+      '  - Creating paket.dependencies',
+      '  - Creating paket.references per project',
+      '  - Resolving dependency graph',
+    ],
+    speed: 60,
+  },
+  {
+    out: ['{{cyan|Locked 47 packages to a single global version set}}'],
+    speed: 'instant',
+  },
+  { cmd: 'git add paket.* && git rm packages.config' },
+  {
+    out: [
+      '{{yellow|Reproducible builds: the lock file is now the source of truth}}',
+    ],
+    speed: 'instant',
+  },
+];
+
+function Prototype({
+  talk,
+  title,
+  note,
+  children,
+}: {
+  talk: string;
+  title: string;
+  note: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="border-b-2 border-white px-6 py-8">
+      <div className="mb-1 flex items-baseline gap-3">
+        <span className="bg-brutalist-cyan px-1.5 font-mono text-[10px] font-bold uppercase text-black">
+          {talk}
+        </span>
+        <h2 className="font-display text-2xl font-bold uppercase text-white">
+          {title}
+        </h2>
+      </div>
+      <p className="mb-3 max-w-3xl font-mono text-xs text-zinc-400">
+        <span className="text-brutalist-yellow">&gt;</span> {note}
+      </p>
+      {children}
+    </section>
+  );
+}
+
+export default function TalkAnimationsGallery() {
+  return (
+    <>
+      <PageSEO
+        title={`Talk Animations - ${siteMetadata.author}`}
+        description="Prototype interactive animations for the talk decks"
+      />
+      <div className="border-2 border-white bg-black">
+        <div className="border-b-2 border-white bg-zinc-900 px-6 pt-8 pb-8">
+          <div className="mb-4 flex items-center gap-4">
+            <Projector className="h-9 w-9 text-brutalist-cyan" />
+            <h1 className="font-display text-4xl font-bold uppercase text-white md:text-5xl">
+              [ TALK_ANIMATIONS ]
+            </h1>
+          </div>
+          <p className="max-w-3xl font-mono text-sm text-zinc-400">
+            <span className="text-brutalist-yellow">&gt;</span> Prototype
+            interactives for the talk decks — each replaces a static diagram
+            with a model-first animation (seeded/deterministic, reduced-motion
+            aware, dual-theme). Drop into a slide with the same MDX tag.
+          </p>
+        </div>
+
+        <Prototype
+          talk="AWS Batch"
+          title="Map/Reduce pipeline"
+          note="Jobs flow through a queue into a slot-limited compute environment: one PREPARE job, a MAP array draining through the slots (one loses its spot instance and re-queues), then REDUCE. Replaces the static map/reduce mermaid."
+        >
+          <MapReduceViz />
+        </Prototype>
+
+        <Prototype
+          talk="ROP"
+          title="Railway track"
+          note="A value rides the success rail through the pipeline; bind switches it to the failure rail at the failing step and short-circuits the rest. Pick which step fails."
+        >
+          <RailwayTrack />
+        </Prototype>
+
+        <Prototype
+          talk="SAFE"
+          title="Model-View-Update loop"
+          note="A message makes one lap — View emits it, Update produces a new Model, the View re-renders — and the model counter ticks each lap so the state change is visible."
+        >
+          <MvuLoop />
+        </Prototype>
+
+        <Prototype
+          talk="Paket"
+          title="Dependency resolution"
+          note="The diamond conflict — two packages pin different versions of one dependency — resolved globally to a single version across the solution, then locked."
+        >
+          <DepResolve />
+        </Prototype>
+
+        <Prototype
+          talk="Paket"
+          title="convert-from-nuget (Terminal)"
+          note="The 'let's convert a project' slide as a scripted terminal — reuses the existing Terminal interactive, no new component."
+        >
+          <Terminal title="paket" script={PAKET_CONVERT} />
+        </Prototype>
+      </div>
+    </>
+  );
+}

--- a/tests/map-reduce-model.test.ts
+++ b/tests/map-reduce-model.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildRun,
+  mulberry32,
+  phaseTimes,
+  stateAt,
+} from '../components/interactive/mapReduceModel';
+
+const CONFIG = { mappers: 8, seed: 42, slots: 4, spotReclaim: true };
+
+describe('mulberry32', () => {
+  it('is deterministic for a given seed', () => {
+    const a = mulberry32(7);
+    const b = mulberry32(7);
+    expect([a(), a(), a()]).toEqual([b(), b(), b()]);
+  });
+
+  it('stays within [0, 1)', () => {
+    const rand = mulberry32(123);
+    for (let i = 0; i < 1000; i++) {
+      const x = rand();
+      expect(x).toBeGreaterThanOrEqual(0);
+      expect(x).toBeLessThan(1);
+    }
+  });
+});
+
+describe('buildRun', () => {
+  const plan = buildRun(CONFIG);
+
+  it('is reproducible for the same config', () => {
+    expect(buildRun(CONFIG)).toEqual(buildRun(CONFIG));
+  });
+
+  it('creates prepare + N maps + reduce', () => {
+    expect(plan.jobs).toHaveLength(CONFIG.mappers + 2);
+    expect(plan.jobs[0].kind).toBe('prepare');
+    expect(plan.jobs.filter((j) => j.kind === 'map')).toHaveLength(
+      CONFIG.mappers,
+    );
+    expect(plan.jobs[plan.jobs.length - 1].kind).toBe('reduce');
+  });
+
+  it('runs prepare alone before any map starts', () => {
+    const firstMapStart = Math.min(
+      ...plan.jobs
+        .filter((j) => j.kind === 'map')
+        .map((j) => j.segments[0].start),
+    );
+    expect(firstMapStart).toBeGreaterThan(plan.prepareEnd - 1e-9);
+  });
+
+  it('starts the reduce only after every map has finished', () => {
+    const lastMapEnd = Math.max(
+      ...plan.jobs.filter((j) => j.kind === 'map').map((j) => j.end),
+    );
+    expect(plan.reduceStart).toBeGreaterThan(lastMapEnd - 1e-9);
+    expect(plan.total).toBeGreaterThan(plan.reduceEnd - 1e-9);
+  });
+
+  it('never runs more jobs than there are slots', () => {
+    const segments = plan.jobs.flatMap((j) => j.segments);
+    for (let t = 0; t <= plan.total; t += 0.05) {
+      const running = segments.filter((s) => t >= s.start && t < s.end);
+      expect(running.length).toBeLessThanOrEqual(CONFIG.slots);
+      // No two concurrent segments share a slot.
+      const usedSlots = running.map((s) => s.slot);
+      expect(new Set(usedSlots).size).toBe(usedSlots.length);
+    }
+  });
+
+  it('reclaims exactly one map when spotReclaim is on, none when off', () => {
+    const reclaimed = plan.jobs.filter((j) => j.hasReclaim);
+    expect(reclaimed).toHaveLength(1);
+    expect(reclaimed[0].kind).toBe('map');
+    expect(reclaimed[0].segments).toHaveLength(2);
+    expect(reclaimed[0].segments[0].completes).toBe(false);
+    expect(reclaimed[0].segments[1].completes).toBe(true);
+    expect(reclaimed[0].segments[1].start).toBeGreaterThan(
+      reclaimed[0].segments[0].end,
+    );
+
+    const without = buildRun({ ...CONFIG, spotReclaim: false });
+    expect(without.jobs.filter((j) => j.hasReclaim)).toHaveLength(0);
+    for (const j of without.jobs) {
+      expect(j.segments).toHaveLength(1);
+      expect(j.segments[0].completes).toBe(true);
+    }
+  });
+
+  it('queues maps when there are more maps than slots', () => {
+    // With 8 maps and 4 slots at least one map must wait for a slot: its
+    // start is later than its readyAt + pickup latency.
+    const waits = plan.jobs
+      .filter((j) => j.kind === 'map')
+      .map((j) => j.segments[0].start - j.readyAt);
+    expect(Math.max(...waits)).toBeGreaterThan(0.5);
+  });
+});
+
+describe('stateAt', () => {
+  const plan = buildRun(CONFIG);
+
+  it('walks phases in order: idle → prepare → map → reduce → done', () => {
+    expect(stateAt(plan, 0).phase).toBe('idle');
+    expect(stateAt(plan, plan.prepareEnd / 2).phase).toBe('prepare');
+    expect(stateAt(plan, (plan.prepareEnd + plan.reduceStart) / 2).phase).toBe(
+      'map',
+    );
+    expect(stateAt(plan, (plan.reduceStart + plan.reduceEnd) / 2).phase).toBe(
+      'reduce',
+    );
+    expect(stateAt(plan, plan.total).phase).toBe('done');
+  });
+
+  it('marks maps pending until prepare completes', () => {
+    const mid = stateAt(plan, plan.prepareEnd / 2);
+    for (const j of mid.jobs) {
+      if (j.kind === 'map') expect(j.status).toBe('pending');
+    }
+  });
+
+  it('never occupies a slot with two jobs and never exceeds capacity', () => {
+    for (let t = 0; t <= plan.total; t += 0.05) {
+      const frame = stateAt(plan, t);
+      const occupants = frame.slots.filter((s) => s !== undefined);
+      expect(new Set(occupants).size).toBe(occupants.length);
+      const running = frame.jobs.filter((j) => j.status === 'running');
+      expect(running.length).toBeLessThanOrEqual(plan.config.slots);
+      for (const j of running) {
+        expect(j.slot).toBeDefined();
+        if (j.slot !== undefined) expect(frame.slots[j.slot]).toBe(j.id);
+      }
+    }
+  });
+
+  it('never lets reduce progress start before all maps are done', () => {
+    for (let t = 0; t <= plan.total; t += 0.05) {
+      const frame = stateAt(plan, t);
+      if (frame.reduceProgress > 0) {
+        expect(frame.completedMaps).toBe(CONFIG.mappers);
+      }
+    }
+  });
+
+  it('surfaces the reclaim as running → requeued → running → done', () => {
+    const reclaimed = plan.jobs.find((j) => j.hasReclaim);
+    expect(reclaimed).toBeDefined();
+    if (!reclaimed) return;
+    const [fail, retry] = reclaimed.segments;
+    const at = (t: number) =>
+      stateAt(plan, t).jobs.find((j) => j.id === reclaimed.id)?.status;
+    expect(at((fail.start + fail.end) / 2)).toBe('running');
+    expect(at(fail.end + 0.05)).toBe('requeued');
+    expect(at((retry.start + retry.end) / 2)).toBe('running');
+    expect(at(reclaimed.end)).toBe('done');
+  });
+
+  it('ends with everything done and the queue empty', () => {
+    const frame = stateAt(plan, plan.total);
+    expect(frame.jobs.every((j) => j.status === 'done')).toBe(true);
+    expect(frame.queue).toHaveLength(0);
+    expect(frame.completedMaps).toBe(CONFIG.mappers);
+    expect(frame.reduceProgress).toBe(1);
+  });
+});
+
+describe('phaseTimes', () => {
+  it('returns times that land inside their phase', () => {
+    const plan = buildRun(CONFIG);
+    const times = phaseTimes(plan);
+    expect(stateAt(plan, times.prepare).phase).toBe('prepare');
+    expect(stateAt(plan, times.map).phase).toBe('map');
+    expect(stateAt(plan, times.reduce).phase).toBe('reduce');
+    expect(stateAt(plan, times.done).phase).toBe('done');
+  });
+});

--- a/tests/talk-animations.test.ts
+++ b/tests/talk-animations.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { depFrameAt, depTotal } from '../components/interactive/DepResolve';
+import { mvuFrameAt } from '../components/interactive/MvuLoop';
+import {
+  type RailConfig,
+  railFrameAt,
+  railTotal,
+} from '../components/interactive/RailwayTrack';
+
+describe('railFrameAt', () => {
+  const cfg: RailConfig = {
+    steps: [
+      { label: 'validate', op: 'bind' },
+      { label: 'parse', op: 'bind' },
+      { label: 'save', op: 'bind' },
+      { label: 'format', op: 'map' },
+    ],
+    failAt: 2,
+  };
+
+  it('stays on the success rail before the failing step', () => {
+    const f = railFrameAt(0.3, cfg);
+    expect(f.rail).toBe('success');
+    expect(f.value).toBe('Ok');
+  });
+
+  it('switches to the failure rail at the failing step and stays there', () => {
+    const total = railTotal(cfg);
+    const end = railFrameAt(total, cfg);
+    expect(end.rail).toBe('failure');
+    expect(end.value).toBe('Error');
+    expect(end.done).toBe(true);
+  });
+
+  it('never leaves the success rail for an all-success run', () => {
+    const ok: RailConfig = { ...cfg, failAt: -1 };
+    for (let t = 0; t <= railTotal(ok); t += 0.1) {
+      expect(railFrameAt(t, ok).rail).toBe('success');
+    }
+  });
+
+  it('advances the active step monotonically', () => {
+    let prev = -1;
+    for (let t = 0; t <= railTotal(cfg); t += 0.1) {
+      const s = railFrameAt(t, cfg).activeStep;
+      expect(s).toBeGreaterThanOrEqual(prev - 1e-9);
+      prev = Math.max(prev, s);
+    }
+  });
+});
+
+describe('mvuFrameAt', () => {
+  it('cycles model -> view -> update -> model', () => {
+    expect(mvuFrameAt(0.1).active).toBe('view'); // model->view edge
+    expect(mvuFrameAt(1.3).active).toBe('update'); // view->update
+    expect(mvuFrameAt(2.5).active).toBe('model'); // update->model
+  });
+
+  it('increments the model once per lap', () => {
+    const lapStartValue = mvuFrameAt(0.1).modelValue;
+    const nextLapValue = mvuFrameAt(3.4).modelValue; // into second lap
+    expect(nextLapValue).toBeGreaterThan(lapStartValue);
+  });
+
+  it('carries a message only on the view->update edge', () => {
+    expect(mvuFrameAt(1.3).message).not.toBeNull();
+    expect(mvuFrameAt(0.1).message).toBeNull();
+  });
+});
+
+describe('depFrameAt', () => {
+  it('walks phases graph -> conflict -> resolve -> locked', () => {
+    expect(depFrameAt(0.5).phase).toBe('graph');
+    expect(depFrameAt(2.5).phase).toBe('conflict');
+    expect(depFrameAt(4.5).phase).toBe('resolve');
+    expect(depFrameAt(depTotal()).phase).toBe('locked');
+  });
+
+  it('ramps resolveProgress 0 -> 1 across the resolve phase', () => {
+    expect(depFrameAt(2.5).resolveProgress).toBe(0);
+    const mid = depFrameAt(4.4).resolveProgress;
+    expect(mid).toBeGreaterThan(0);
+    expect(mid).toBeLessThanOrEqual(1);
+    expect(depFrameAt(depTotal()).resolveProgress).toBe(1);
+  });
+
+  it('writes the lock only once locked', () => {
+    expect(depFrameAt(4.5).lockWritten).toBe(false);
+    expect(depFrameAt(depTotal()).lockWritten).toBe(true);
+  });
+});


### PR DESCRIPTION
Phase 3 of splitting #84. Four model-first interactive animations for the talk decks, **confined to the experiments area** — no embed in any published post (the earlier cookbook embed is dropped, so the published AWS Batch post is unchanged vs `main`).

- **MapReduceViz** — AWS-Batch pipeline: jobs flow through a queue into a slot-limited compute env (PREPARE → MAP array with a spot-reclaim/re-queue → REDUCE).
- **RailwayTrack** — ROP: a value rides the success rail; `bind` switches it to the failure rail and short-circuits.
- **MvuLoop** — Elmish Model→View→Update loop; the model counter ticks each lap.
- **DepResolve** — Paket diamond version conflict resolved to one global version, then locked.

Each has a pure `frameAt()`/`stateAt()` model (unit-tested — 23 tests across two files), a reduced-motion phase-stepper fallback, dual-theme `var()` colours, and autoplay-on-view + replay. Mounted on `/experiments/talk-animations` (+ an index card) and registered in `MDXComponents` so they can drop into a talk/post later. Kept as-is to evolve in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jgc8xvrNmyAW35qLUEExDc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jgc8xvrNmyAW35qLUEExDc)_