### PR TITLE
chore(dev): VS Code full-stack dev setup + preview bypass docs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "Next.js: Debug Server-side",
       "type": "node-terminal",
       "request": "launch",
-      "command": "pnpm dev",
+      "command": "pnpm dev --port 3002",
       "serverReadyAction": {
         "pattern": "- Local:.+(https?://.+)",
         "uriFormat": "%s",
@@ -16,7 +16,7 @@
       "name": "Next.js: Debug Client-side",
       "type": "chrome",
       "request": "launch",
-      "url": "http://localhost:3000",
+      "url": "http://localhost:3002",
       "webRoot": "${workspaceFolder}",
       "sourceMaps": true
     },
@@ -24,7 +24,7 @@
       "name": "Next.js: Debug Full Stack",
       "type": "node-terminal",
       "request": "launch",
-      "command": "pnpm dev",
+      "command": "pnpm dev --port 3002",
       "serverReadyAction": {
         "pattern": "- Local:.+(https?://.+)",
         "uriFormat": "%s",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,9 +2,30 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "Convex Dev",
+      "type": "shell",
+      "command": "npx convex dev",
+      "problemMatcher": [],
+      "isBackground": true,
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev"
+      },
+      "runOptions": {
+        "instanceLimit": 1
+      }
+    },
+    {
+      "label": "Blog: Full Stack",
+      "dependsOn": ["Convex Dev", "Dev Server"],
+      "dependsOrder": "parallel",
+      "problemMatcher": []
+    },
+    {
       "label": "Dev Server",
       "type": "shell",
-      "command": "pnpm dev",
+      "command": "pnpm dev --port 3002",
       "group": {
         "kind": "build",
         "isDefault": true
@@ -23,7 +44,7 @@
     {
       "label": "Dev Server (Debug)",
       "type": "shell",
-      "command": "NODE_OPTIONS='--inspect' pnpm dev",
+      "command": "NODE_OPTIONS='--inspect' pnpm dev --port 3002",
       "group": "build",
       "problemMatcher": ["$tsc-watch"],
       "isBackground": true,

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -246,6 +246,7 @@ Gotchas:
 | GitHub OAuth (prod + dev) | ✅ live |
 | `e2e` bypass provider + guards | ✅ shipped (PR #48), prod-verified inert |
 | Harness headless bypass mode | ✅ shipped (button-based) |
+| UI bypass button on Vercel previews | ✅ `NEXT_PUBLIC_E2E_BYPASS_SECRET` set in Vercel Preview env (2026-07-22); matches dev deployment + `secrets/` files |
 | CI live-e2e workflow | ✅ merged; awaiting secrets (todo 33a) |
 | Session-init CLI (§5) | 📐 designed, not built |
 | Button + `NEXT_PUBLIC_*` removal | pending the CLI |


### PR DESCRIPTION
VS Code tasks/launch configs to run Convex + Next dev together on port 3002 (the `SITE_URL` OAuth constraint), plus doc updates recording that `NEXT_PUBLIC_E2E_BYPASS_SECRET` is now set in the Vercel Preview environment. Secret values live only in the gitignored `secrets/` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)