### PR TITLE
ci: daily main-backup branch workflow

### DIFF
--- a/.github/workflows/backup-main.yml
+++ b/.github/workflows/backup-main.yml
@@ -1,0 +1,49 @@
+name: Backup main branch
+
+# Daily recovery point for main: mirrors main to main-backup, force-pushing
+# over whatever is there. Cheap by design — a single API comparison decides
+# whether anything moved; the checkout + push only run on drift.
+# Restore path: git push origin main-backup:main (via PR or temporarily
+# lifted ruleset, since main is protected).
+
+on:
+  schedule:
+    - cron: "17 2 * * *" # daily, 02:17 UTC (off the whole-hour rush)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: backup-main
+  cancel-in-progress: false
+
+jobs:
+  backup:
+    name: Repoint main-backup if main moved
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect drift between main and main-backup
+        id: drift
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          main_sha=$(gh api "repos/${GITHUB_REPOSITORY}/branches/main" -q .commit.sha)
+          backup_sha=$(gh api "repos/${GITHUB_REPOSITORY}/branches/main-backup" -q .commit.sha 2>/dev/null || echo "none")
+          echo "main=$main_sha backup=$backup_sha"
+          if [ "$main_sha" = "$backup_sha" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout main (full history)
+        if: steps.drift.outputs.changed == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Force-push to main-backup
+        if: steps.drift.outputs.changed == 'true'
+        run: git push --force origin main:refs/heads/main-backup


### PR DESCRIPTION
Adds a scheduled workflow that repoints `main-backup` to `main` daily — a cheap API SHA comparison first, checkout + force-push only when main moved. Recovery point in case an agent damages main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)