### PR TITLE
docs: design-system consumption + local dev flow in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ components, diagrams, assets, tooling, tests). Full policy:
 
 | Domain | Guide | Covers |
 | ------ | ----- | ------ |
-| **Design system** | [docs/design-system.md](./docs/design-system.md) | Brutalist tokens, dual-mode (neon-terminal + sketch) theming, anti-patterns, Tailwind v4 |
+| **Design system** | [docs/design-system.md](./docs/design-system.md) | Brutalist tokens, dual-mode (neon-terminal + sketch) theming, anti-patterns, Tailwind v4, the `@rtkelly13/design-system` npm package + `ds:link` local dev |
 | **Technical guide** | [docs/technical-guide.md](./docs/technical-guide.md) | Stack, commands, build pipeline, CI/CD, branch workflow, browser control, deps |
 | **Posting** | [docs/posting.md](./docs/posting.md) | Authorship policy, MDX frontmatter, citations/OG, the ideas workbench |
 | **Talks** | [docs/talks.md](./docs/talks.md) | Deck MDX, live/present/admin routes, Convex backend, auth, live E2E |
@@ -42,7 +42,8 @@ when you work there:
 | Evolve an idea pre-draft | `data/ideas/<slug>.mdx`, `/ideas` | [posting.md](./docs/posting.md#ideas-workbench-pre-drafting) |
 | Site config | `data/siteMetadata.js` | — |
 | Components / layouts | `components/`, `layouts/` | [components/AGENTS.md](./components/AGENTS.md) |
-| Colours, shadows, themes | `tailwind.config.js`, `css/tailwind.css` | [design-system.md](./docs/design-system.md) |
+| Colours, shadows, themes | `css/tailwind.css` (tokens come from `@rtkelly13/design-system/theme.css`) | [design-system.md](./docs/design-system.md) |
+| Design-system package dev | `pnpm ds:link` / `pnpm ds:unlink` (never commit the `link:` override) | [design-system.md](./docs/design-system.md#package-source--local-development) |
 | MDX / remark plugins | `lib/mdx.ts`, `lib/remark-*.ts` | [lib/AGENTS.md](./lib/AGENTS.md) |
 | Realtime backend | `convex/` | [convex/AGENTS.md](./convex/AGENTS.md) |
 | Talk / live routes | `pages/talks/`, `pages/live/`, `pages/admin.tsx` | [talks.md](./docs/talks.md) |

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -25,8 +25,11 @@ repo, so the path doesn't exist there and every deploy fails at `pnpm install`.
 
 ## Tokens
 
-Defined in `tailwind.config.js` (accents read through CSS variables so themes
-can re-point them in one place — see `css/tailwind.css`).
+Defined in the design-system package's `theme.css` (`@theme` block; accents
+read through CSS variables so themes can re-point them in one place). The
+blog's `css/tailwind.css` overrides where its behavior deliberately diverges —
+e.g. `.dim` pins the accents back to the dark values, where the DS softens
+them (see `tests/theme-toggle.spec.ts`).
 
 | Token              | Value (dark)      | Usage               |
 | ------------------ | ----------------- | ------------------- |
@@ -54,8 +57,9 @@ can re-point them in one place — see `css/tailwind.css`).
 ```css
 /* css/tailwind.css — NOT @tailwind directives */
 @import "tailwindcss";
+@import "@rtkelly13/design-system/theme.css"; /* brutalist tokens, .dark/.dim variant, @source */
 @plugin "@tailwindcss/typography";
-@config "../tailwind.config.js";
+@config "../tailwind.config.js"; /* only for the typography() callback now */
 ```
 
 PostCSS uses `@tailwindcss/postcss` (not `tailwindcss`). Never use the v3


### PR DESCRIPTION
Documents in AGENTS.md / docs/design-system.md:
- tokens now come from `@rtkelly13/design-system/theme.css` (public npm, trusted publishing)
- `pnpm ds:link` / `ds:unlink` local dev flow and the never-commit-`link:`-override rule
- updated Tailwind v4 entrypoint snippet (`@config` scoped to the typography callback)
- the deliberate `.dim` accent divergence from the DS

🤖 Generated with [Claude Code](https://claude.com/claude-code)