### PR TITLE
ci: convex-preview schema train for preview subdomains

### DIFF
--- a/.github/workflows/convex-deploy-preview.yml
+++ b/.github/workflows/convex-deploy-preview.yml
@@ -1,0 +1,53 @@
+name: Deploy Convex (preview)
+
+# Push Convex functions to the shared PREVIEW deployment whenever the
+# `convex-preview` branch moves. Every Vercel preview slot shares this one
+# Convex backend, so `convex-preview` is the schema train: it always exists,
+# defaults to identical to main, and is the only branch that deploys here.
+# Slot branches (`slot/1..3`) are `convex-preview` plus a PR's commits, which
+# keeps their frontends compatible with the deployed preview schema.
+#
+# Requires the `CONVEX_DEPLOY_KEY_PREVIEW` repo secret — a *Preview* deploy key
+# from the Convex dashboard (Project Settings → Deploy Keys). Absent the
+# secret, the job warns and exits cleanly, so this workflow is safe to merge
+# before the key exists.
+
+on:
+  push:
+    branches: [convex-preview]
+    paths:
+      - 'convex/**'
+      - '.github/workflows/convex-deploy-preview.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: convex-deploy-preview
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy Convex functions (preview)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          path: blog
+      - uses: ./blog/.github/actions/setup-blog
+
+      - name: Deploy to Convex preview
+        working-directory: blog
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY_PREVIEW }}
+        run: |
+          if [ -z "$CONVEX_DEPLOY_KEY" ]; then
+            echo "::warning::CONVEX_DEPLOY_KEY_PREVIEW is not set — skipping Convex preview deploy. Add the secret (Convex dashboard → Deploy Keys → Preview) to enable."
+            exit 0
+          fi
+          # A stable, named preview deployment: --preview-name reuses the same
+          # deployment on every push, so its URL (NEXT_PUBLIC_CONVEX_URL for
+          # Vercel's Preview environment) never changes. Never use
+          # --preview-create here — it deletes and recreates, wiping data.
+          pnpm exec convex deploy --preview-name preview

--- a/scripts/preview-slot.sh
+++ b/scripts/preview-slot.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Claim a preview slot: point pN.ryankelly.dev at the current branch's work.
+#
+#   scripts/preview-slot.sh 2          # slot/2 = convex-preview + HEAD
+#   scripts/preview-slot.sh 2 my-ref   # slot/2 = convex-preview + my-ref
+#   scripts/preview-slot.sh 2 --release  # slot/2 = convex-preview (idle)
+#
+# A slot is always `convex-preview` plus the work under review — never the raw
+# head — so the deployed frontend stays compatible with the shared preview
+# Convex schema. Releasing a slot resets it to `convex-preview`, not main, for
+# the same reason. Slot branches are disposable and never merged back, so the
+# merge commit and the force-push are both fine.
+set -euo pipefail
+
+n="${1:?usage: preview-slot.sh <1|2|3> [ref|--release]}"
+ref="${2:-HEAD}"
+
+git fetch origin --quiet
+
+if [ "$ref" = "--release" ]; then
+  git push -f origin origin/convex-preview:refs/heads/"slot/$n"
+  echo "released: https://p$n.ryankelly.dev now tracks convex-preview"
+  exit 0
+fi
+
+sha=$(git rev-parse "$ref")
+tmp=$(mktemp -d)
+trap 'git worktree remove --force "$tmp" 2>/dev/null || true' EXIT
+
+git worktree add --quiet --detach "$tmp" origin/convex-preview
+if ! git -C "$tmp" merge --no-edit --quiet "$sha"; then
+  echo "error: $ref does not merge cleanly onto convex-preview — resolve there first" >&2
+  exit 1
+fi
+
+git push -f origin "$(git -C "$tmp" rev-parse HEAD)":refs/heads/"slot/$n"
+echo "claimed: https://p$n.ryankelly.dev"


### PR DESCRIPTION
Implements the preview-subdomain design from `docs/CONTINUATION.md` §5 (the parts that live in the repo):

- **`convex-deploy-preview.yml`** — deploys `convex/` to a stable, named Convex preview deployment (`--preview-name preview`) on every push to `convex-preview`. Skips with a warning until the `CONVEX_DEPLOY_KEY_PREVIEW` secret exists, so this is safe to merge now.
- **`scripts/preview-slot.sh`** — claims a slot (`slot/N` = `convex-preview` + your ref, merged, never the raw head) or releases it back to `convex-preview`.

Branches `convex-preview` and `slot/1..3` already exist on origin, all currently equal to main.

Remaining setup outside the repo: Convex preview deploy key → repo secret, Vercel Preview-env `NEXT_PUBLIC_CONVEX_URL`, three project domains bound to slot branches, and DNS CNAMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)