### PR TITLE
fix(css): keep nested dark panels legible under a sketch root

### DIFF
--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -125,6 +125,20 @@ html {
 }
 
 .dark {
+  /* Nested theme panels: a `.dark` panel inside a `.sketch` root (e.g. the
+     design-sandbox component library) must not inherit sketch's inverted zinc
+     scale, so reset it to Tailwind's defaults here. Redundant when `.dark` is
+     on <html> (these ARE the defaults), load-bearing when nested. */
+  --color-zinc-950: #09090b;
+  --color-zinc-900: #18181b;
+  --color-zinc-800: #27272a;
+  --color-zinc-700: #3f3f46;
+  --color-zinc-600: #52525b;
+  --color-zinc-500: #71717a;
+  --color-zinc-400: #a1a1aa;
+  --color-zinc-300: #d4d4d8;
+  --color-zinc-200: #e4e4e7;
+
   --diagram-bg: #000000;
   --diagram-bg-secondary: #18181b;
   --diagram-stroke: #ffffff;
@@ -332,8 +346,12 @@ html {
 
 /* Light-grey text utilities (used as primary text on the dark themes) are
    inlined literals, so re-point the light end of the grey scale to ink under
-   sketch so it stays legible on paper. */
-.sketch :is(.text-gray-100, .text-gray-200, .text-gray-300, .text-gray-400) {
+   sketch so it stays legible on paper. Excludes nested `.dark`/`.dim` theme
+   panels (design-sandbox component library), where light grey is correct. */
+.sketch
+  :is(.text-gray-100, .text-gray-200, .text-gray-300, .text-gray-400):not(
+    .sketch :is(.dark, .dim) *
+  ) {
   color: #33373f;
 }
 

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -349,9 +349,9 @@ html {
    sketch so it stays legible on paper. Excludes nested `.dark`/`.dim` theme
    panels (design-sandbox component library), where light grey is correct. */
 .sketch
-  :is(.text-gray-100, .text-gray-200, .text-gray-300, .text-gray-400):not(
-    .sketch :is(.dark, .dim) *
-  ) {
+:is(.text-gray-100, .text-gray-200, .text-gray-300, .text-gray-400):not(
+  .sketch :is(.dark, .dim) *
+) {
   color: #33373f;
 }
 


### PR DESCRIPTION
Companion to rtkelly13/design-system#25 (nearest-ancestor theming for nested theme panels).

Two blog-level overrides leaked the root sketch theme into `.dark` panels nested below it on the design-sandbox component-library page:

- `.sketch` inverts the `--color-zinc-*` scale for paper surfaces; nested dark panels inherited the inversion, dimming the idea-badge borders/text. The `.dark` block now resets the scale to Tailwind defaults (a no-op when `.dark` is on `<html>`).
- The `.sketch .text-gray-*` → ink re-point matched content inside nested dark panels; it now excludes `.sketch :is(.dark, .dim)` subtrees, while still applying inside a sketch panel under a dark root.

Verified with Playwright against `/design-sandbox/component-library` under both root themes with the design-system fix linked: all specimens render their panel's theme in both nesting directions. Full effect on the buttons/tags/badges/links specimens also needs design-system#25 released and bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)