### PR TITLE
feat(storybook): deploy this Storybook and compose it into the design system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ when you work there:
 | Components / layouts | `components/`, `layouts/` | [components/AGENTS.md](./components/AGENTS.md) |
 | Colours, shadows, themes | `css/tailwind.css` (tokens come from `@rtkelly13/design-system/theme.css`) | [design-system.md](./docs/design-system.md) |
 | Design-system package dev | `pnpm ds:link` / `pnpm ds:unlink` (never commit the `link:` override) | [design-system.md](./docs/design-system.md#package-source--local-development) |
+| Deploying this Storybook | `storybook-site/vercel.json` (second Vercel project) | [storybook-site/README.md](./storybook-site/README.md) |
 | MDX / remark plugins | `lib/mdx.ts`, `lib/remark-*.ts` | [lib/AGENTS.md](./lib/AGENTS.md) |
 | Realtime backend | `convex/` | [convex/AGENTS.md](./convex/AGENTS.md) |
 | Talk / live routes | `pages/talks/`, `pages/live/`, `pages/admin.tsx` | [talks.md](./docs/talks.md) |

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -115,3 +115,19 @@ per-section accent rule, diagrams, search, talk widgets) lives in
 **[components/AGENTS.md](../components/AGENTS.md)**. Live component variations
 render in the **design sandbox** (`/design-sandbox`) and in Storybook
 (`pnpm storybook`, :6006).
+
+## Hosted Storybooks
+
+| URL | Shows |
+| --- | --- |
+| [design-system.ryankelly.dev](https://design-system.ryankelly.dev) | The package's Storybook, with this repo's composed in as `ryankelly.dev (site)` |
+| [preview.design-system.ryankelly.dev](https://preview.design-system.ryankelly.dev) | The same, built from the package repo's `preview` branch |
+
+This repo's Storybook is deployed by a second Vercel project reading
+[`storybook-site/vercel.json`](../storybook-site/README.md); the root `vercel.json`
+still owns the blog's own deploy. Both domains and both projects are declared in the
+design-system repo's `infra/` Pulumi program.
+
+> The package repo's own audit — including why this repo's `"^0.0.5"` dependency
+> range can never resolve past `0.0.5` — is in
+> [`docs/evaluation.md`](https://github.com/rtkelly13/design-system/blob/main/docs/evaluation.md).

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -125,8 +125,10 @@ render in the **design sandbox** (`/design-sandbox`) and in Storybook
 
 This repo's Storybook is deployed by a second Vercel project reading
 [`storybook-site/vercel.json`](../storybook-site/README.md); the root `vercel.json`
-still owns the blog's own deploy. Both domains and both projects are declared in the
-design-system repo's `infra/` Pulumi program.
+still owns the blog's own deploy. Both projects and both domains are declared in
+`rtkelly13/shared-utilities` at
+[`infra/vercel/`](https://github.com/rtkelly13/shared-utilities/tree/main/infra/vercel) —
+one Pulumi stack covering every ryankelly.dev site (site key `blog-storybook`).
 
 > The package repo's own audit — including why this repo's `"^0.0.5"` dependency
 > range can never resolve past `0.0.5` — is in

--- a/stories/README.md
+++ b/stories/README.md
@@ -14,6 +14,18 @@ pnpm build-storybook
 
 Storybook runs on http://localhost:6006 in development mode.
 
+## Where it's hosted
+
+This Storybook is deployed by its own Vercel project (config in
+[`storybook-site/`](../storybook-site/README.md), so the blog's own deploy is
+untouched) and is **composed into the design system's Storybook** at
+[design-system.ryankelly.dev](https://design-system.ryankelly.dev), where it appears
+in the sidebar as **`ryankelly.dev (site)`**.
+
+That split mirrors the tiers: `@rtkelly13/design-system` publishes the tokens and
+primitives, and this Storybook documents what the site composes on top of them. If a
+story here belongs to the system rather than the site, it belongs in the package repo.
+
 ## Theme toolbar
 
 The toolbar (paintbrush icon) cycles **HIGH (dark) / DIM / SKETCH** by setting

--- a/storybook-site/README.md
+++ b/storybook-site/README.md
@@ -38,5 +38,7 @@ it Vercel uploads only this directory and the build fails immediately. The Verce
 Pulumi provider does not expose that toggle, so it is the one setting that must be
 ticked by hand.
 
-The project itself is declared in the design-system repo's `infra/` Pulumi program
-(resource `blog-storybook`), alongside the domains for the composed Storybook.
+The project itself is declared in `rtkelly13/shared-utilities` at
+[`infra/vercel/sites.ts`](https://github.com/rtkelly13/shared-utilities/tree/main/infra/vercel)
+(site key `blog-storybook`) — one Pulumi stack covering every ryankelly.dev site,
+alongside the domains for the composed Storybook.

--- a/storybook-site/README.md
+++ b/storybook-site/README.md
@@ -1,0 +1,42 @@
+# storybook-site — Vercel config for the blog's Storybook
+
+This directory contains **only** a `vercel.json`. It exists so one repo can back two
+Vercel projects with different builds.
+
+The repo root's `vercel.json` configures the Next.js site (`ryankelly.dev`). Vercel
+reads `vercel.json` from a project's **Root Directory**, and its settings take
+precedence over dashboard project settings — so a second project pointed at the repo
+root would inherit `"framework": "nextjs"` and try to deploy the blog again. Pointing
+that project's Root Directory at `storybook-site/` makes Vercel read *this* config
+instead, leaving the blog's deploy untouched.
+
+## Why the blog's Storybook is deployed at all
+
+The design system's Storybook (`design-system.ryankelly.dev`) **composes** this one
+into its sidebar via `refs` in
+[`rtkelly13/design-system`](https://github.com/rtkelly13/design-system)'s
+`.storybook/main.ts`. Storybook composition is resolved in the browser by fetching
+`<url>/index.json` — it cannot bundle another repo's stories at build time, so the
+blog's Storybook needs a URL of its own.
+
+Hence the `Access-Control-Allow-Origin` header: the fetch is cross-origin. It is set
+to `*` because this is a public documentation site with no credentials or private
+data; there is nothing here that same-origin policy is protecting.
+
+`"cleanUrls": false` is load-bearing. Clean URLs rewrite `/iframe.html` to `/iframe`,
+which breaks Storybook's asset preloading and renders an empty preview pane.
+
+## Build commands run from the repo root
+
+The Storybook build needs the whole repo — `components/`, `stories/`, `css/`,
+`.storybook/` — not just this directory, so both commands `cd ..` first and the build
+writes back into `storybook-site/storybook-static`.
+
+That requires **"Include source files outside of the Root Directory in the Build
+Step"** to be enabled on the Vercel project (Settings → Build & Deployment). Without
+it Vercel uploads only this directory and the build fails immediately. The Vercel
+Pulumi provider does not expose that toggle, so it is the one setting that must be
+ticked by hand.
+
+The project itself is declared in the design-system repo's `infra/` Pulumi program
+(resource `blog-storybook`), alongside the domains for the composed Storybook.

--- a/storybook-site/vercel.json
+++ b/storybook-site/vercel.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "cd .. && pnpm install --frozen-lockfile",
+  "buildCommand": "cd .. && pnpm build-storybook -o storybook-site/storybook-static",
+  "outputDirectory": "storybook-static",
+  "cleanUrls": false,
+  "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/index.json",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Gives this repo's Storybook its own Vercel deployment so the design system's Storybook can compose it into the sidebar.

Part of a three-repo change. Companions: rtkelly13/design-system (the composing Storybook) and rtkelly13/shared-utilities (the Pulumi stack).

**The blog's own deploy is untouched** — the root `vercel.json` is unchanged and no application code is modified. Everything here is a new directory plus docs.

## Why a second project

Composition resolves in the browser by fetching `<url>/index.json`, so this Storybook needs a URL of its own — Storybook can't bundle another repo's stories at build time.

`storybook-site/` exists solely to hold that project's `vercel.json`. Vercel reads `vercel.json` from a project's **Root Directory** and it overrides dashboard settings, so a second project pointed at the repo root would inherit `"framework": "nextjs"` and redeploy the blog. Pointing its Root Directory here leaves the blog alone.

## Details worth reviewing

- **Build commands `cd ..`** — the Storybook build needs the whole repo, not just `storybook-site/`. That requires **"Include source files outside of the Root Directory in the Build Step"** on the Vercel project, ticked by hand; the Vercel Pulumi provider doesn't expose that flag.
- **`Access-Control-Allow-Origin: *`** — the composing manager fetches `index.json` cross-origin. Set to `*` because this is a public documentation site with no credentials or private data.
- **`"cleanUrls": false`** — clean URLs rewrite `/iframe.html` to `/iframe` and break Storybook's asset preloading, yielding an empty preview pane.

The project itself is declared in the shared stack as site key `blog-storybook`.

## Not verified locally

`pnpm build-storybook` was **not run**. This repo's dependencies can't be installed in the authoring environment — `@rtkelly/mermaid-toolkit` is fetched from `codeload.github.com`, which the sandbox proxy blocks (403). That's an environment limit, not a repo problem; it installs fine on Vercel.

Composition itself *was* verified in Chromium against a stand-in ref serving the same `index.json` v5 format, so the wiring is sound — but the first deploy of this project is the real test of the build command.

## Related finding

The design-system audit turned up something affecting this repo directly: `package.json` depends on `"@rtkelly13/design-system": "^0.0.5"`, and under semver a caret range on `0.0.x` matches **only** `0.0.5`. This repo is pinned two minor versions behind the published `0.1.1` and will never resolve forward. Almost certainly unintentional — left alone here since it's out of scope for a hosting change, but worth a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH92J1GpWfv2rdgCRRU3R1)_