### PR TITLE
feat(storybook): add a storybook-site root for the blog-storybook Vercel project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ node_modules/
 
 *storybook.log
 storybook-static
+# Where the blog-storybook Vercel project builds to (see storybook-site/README.md).
+storybook-site/dist
 
 # temporary working files
 /temp/

--- a/storybook-site/README.md
+++ b/storybook-site/README.md
@@ -1,0 +1,60 @@
+# storybook-site
+
+This directory exists so a **second** Vercel project can deploy this repo's
+Storybook while the root project keeps deploying the Next.js site.
+
+It contains no source. Vercel reads the `vercel.json` belonging to a project's
+**root directory**, and the one at the repo root declares `framework: "nextjs"`.
+A second project pointed at the repo root would therefore be forced to build the
+blog, not Storybook. Giving the Storybook project its own root directory gives it
+its own `vercel.json` — which is the only way two projects on one repo can build
+differently.
+
+The stories themselves live where they always did (`stories/`, `components/`,
+`.storybook/`), so the build reaches back up to the repo root:
+
+- `installCommand` and `buildCommand` both `cd ..` first
+- `-o storybook-site/dist` puts the output back inside this directory, where
+  `outputDirectory: "dist"` (resolved relative to the root directory) finds it
+
+## Why the headers matter
+
+This Storybook is **composed into** the design system's sidebar, and Storybook
+resolves composition in the *browser*: the design system's manager fetches
+`/index.json` from this origin cross-origin. Without
+`Access-Control-Allow-Origin` on that route the ref fails as a CORS error and
+shows up as a permanently-erroring sidebar entry, with nothing wrong on this side
+in isolation. `index.json` is also served `must-revalidate` so a fresh deploy is
+picked up rather than composed from a cached index.
+
+`cleanUrls: false` is load-bearing for the same reason it is in the design
+system's `vercel.json`: clean URLs rewrite `/iframe.html` to `/iframe`, which
+breaks Storybook's asset preloading and yields an empty preview pane. Storybook
+is one of the few static sites where clean URLs are actively wrong.
+
+The manager also probes `stories.json` and `metadata.json`; 404s there are
+expected and harmless.
+
+## Required manual step
+
+Vercel must be told to check out the whole repository rather than just this
+directory:
+
+> Project Settings → Build & Development → **Include source files outside of the
+> Root Directory in the Build Step** → on
+
+Without it the build fails immediately: `cd ..` finds nothing. **This flag is not
+exposed by the Vercel Terraform/Pulumi provider**, so it cannot be declared in
+the `shared-utilities` infra stack alongside the project and its domains — it has
+to be ticked by hand once, per project.
+
+## Which project is which
+
+| Vercel project | Root directory | Builds |
+| --- | --- | --- |
+| `my-blog-0j5s` | repo root | the Next.js blog, at `ryankelly.dev` |
+| `blog-storybook` | `storybook-site` | this Storybook |
+
+`blog-storybook` is served on its generated `*.vercel.app` URL and composed into
+the design system's Storybook sidebar — see `STORYBOOK_REF_BLOG_URL` in
+`shared-utilities/infra/vercel/sites.ts`.

--- a/storybook-site/vercel.json
+++ b/storybook-site/vercel.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "cd .. && pnpm install --frozen-lockfile",
+  "buildCommand": "cd .. && pnpm build-storybook -o storybook-site/dist",
+  "outputDirectory": "dist",
+  "cleanUrls": false,
+  "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/index.json",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/sb-addons/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/sb-manager/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/sb-common-assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Lets a **second** Vercel project deploy this repo's Storybook while the root project keeps deploying the Next.js site. Companion to rtkelly13/design-system#27 (now merged), which composes this Storybook into the design system's sidebar.

## Why a separate directory rather than a second config

Vercel reads the `vercel.json` belonging to a project's **root directory**, and the one at the repo root declares `framework: "nextjs"`. A second project pointed at the repo root would therefore be forced to build the blog. Giving the Storybook project its own root directory gives it its own `vercel.json` — the only way two projects on one repo can build differently.

The directory holds no source. Stories stay in `stories/`, `components/` and `.storybook/`, so install and build both `cd ..` first, and `-o storybook-site/dist` writes the output back inside this directory where `outputDirectory` finds it.

| Vercel project | Root directory | Builds |
| --- | --- | --- |
| `my-blog-0j5s` | repo root | the Next.js blog, at `ryankelly.dev` |
| `blog-storybook` | `storybook-site` | this Storybook |

## The headers are load-bearing

Storybook resolves composition **in the browser**: the design system's manager fetches `/index.json` from this origin cross-origin. Without `Access-Control-Allow-Origin` on that route the ref fails as a CORS error and renders as a permanently-erroring sidebar entry — while this site looks perfectly healthy on its own, which makes it an annoying thing to debug from the other end. `index.json` is also `must-revalidate` so a fresh deploy is composed rather than a cached index.

`cleanUrls: false` matters for the same reason it does in the design system's `vercel.json`: clean URLs rewrite `/iframe.html` to `/iframe`, breaking Storybook's asset preloading and yielding an empty preview pane.

## Required manual step

The `blog-storybook` Vercel project needs **Settings → Build & Development → "Include source files outside of the Root Directory in the Build Step"** enabled, or `cd ..` finds nothing. That flag is not exposed by the Vercel Pulumi provider, so it cannot be declared in the `shared-utilities` stack alongside the project and its domains. `storybook-site/README.md` records it.

## Verification

The exact `buildCommand` was run locally: it produces `storybook-site/dist` with a complete `index.json` — **79 entries across 17 titles, index format v5**, matching the design system's own v5 index now that both repos are on Storybook 10.

`storybook-site/dist` is gitignored. The header behaviour can only be confirmed once deployed, since `vercel.json` headers are not applied by a local static server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)