### PR TITLE
docs(storybook): document the hosting, and widen the composed-origin CORS header

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ when you work there:
 | Components / layouts | `components/`, `layouts/` | [components/AGENTS.md](./components/AGENTS.md) |
 | Colours, shadows, themes | `css/tailwind.css` (tokens come from `@rtkelly13/design-system/theme.css`) | [design-system.md](./docs/design-system.md) |
 | Design-system package dev | `pnpm ds:link` / `pnpm ds:unlink` (never commit the `link:` override) | [design-system.md](./docs/design-system.md#package-source--local-development) |
+| Deploying this Storybook | `storybook-site/vercel.json` (second Vercel project) | [storybook-site/README.md](./storybook-site/README.md) |
 | MDX / remark plugins | `lib/mdx.ts`, `lib/remark-*.ts` | [lib/AGENTS.md](./lib/AGENTS.md) |
 | Realtime backend | `convex/` | [convex/AGENTS.md](./convex/AGENTS.md) |
 | Talk / live routes | `pages/talks/`, `pages/live/`, `pages/admin.tsx` | [talks.md](./docs/talks.md) |

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -115,3 +115,25 @@ per-section accent rule, diagrams, search, talk widgets) lives in
 **[components/AGENTS.md](../components/AGENTS.md)**. Live component variations
 render in the **design sandbox** (`/design-sandbox`) and in Storybook
 (`pnpm storybook`, :6006).
+
+## Hosted Storybooks
+
+| URL | Shows |
+| --- | --- |
+| [design-system.ryankelly.dev](https://design-system.ryankelly.dev) | The package's Storybook, with this repo's composed in as `ryankelly.dev (site)` |
+| [preview.design-system.ryankelly.dev](https://preview.design-system.ryankelly.dev) | The same, built from the package repo's `preview` branch |
+
+This repo's Storybook is deployed by a second Vercel project reading
+[`storybook-site/vercel.json`](../storybook-site/README.md); the root `vercel.json`
+still owns the blog's own deploy. Both projects and all their domains are declared in
+`rtkelly13/shared-utilities` at
+[`infra/vercel/`](https://github.com/rtkelly13/shared-utilities/tree/main/infra/vercel) —
+one Pulumi stack covering every ryankelly.dev site (site keys `blog-storybook` and
+`design-system-storybook`).
+
+> The package repo keeps an audit of the system in
+> [`docs/evaluation.md`](https://github.com/rtkelly13/design-system/blob/main/docs/evaluation.md).
+> One of its findings was this repo's `"@rtkelly13/design-system": "^0.0.5"` range,
+> which under semver matched *only* `0.0.5` and so could never resolve a release.
+> Fixed in #98 — the dependency now tracks `^0.1.3`.
+

--- a/stories/README.md
+++ b/stories/README.md
@@ -33,6 +33,18 @@ the theme class on `<html>`, exactly as `next-themes` does on the site. Every
 story must read as intentional in both HIGH and SKETCH — see
 `Foundations/Paper & Ink` for the paper ↔ terminal token analogy.
 
+## Where it's hosted
+
+This Storybook is deployed by its own Vercel project (config in
+[`storybook-site/`](../storybook-site/README.md), so the blog's own deploy is
+untouched) and is **composed into the design system's Storybook** at
+[design-system.ryankelly.dev](https://design-system.ryankelly.dev), where it appears
+in the sidebar as **`ryankelly.dev (site)`**.
+
+That split mirrors the tiers: `@rtkelly13/design-system` publishes the tokens and
+primitives, and this Storybook documents what the site composes on top of them. If a
+story here belongs to the system rather than the site, it belongs in the package repo.
+
 ## Organization (composition tiers)
 
 - **Foundations** (`stories/foundations/`) — the tokens themselves:

--- a/storybook-site/README.md
+++ b/storybook-site/README.md
@@ -22,10 +22,17 @@ The stories themselves live where they always did (`stories/`, `components/`,
 This Storybook is **composed into** the design system's sidebar, and Storybook
 resolves composition in the *browser*: the design system's manager fetches
 `/index.json` from this origin cross-origin. Without
-`Access-Control-Allow-Origin` on that route the ref fails as a CORS error and
-shows up as a permanently-erroring sidebar entry, with nothing wrong on this side
-in isolation. `index.json` is also served `must-revalidate` so a fresh deploy is
-picked up rather than composed from a cached index.
+`Access-Control-Allow-Origin` the ref fails as a CORS error and shows up as a
+permanently-erroring sidebar entry, with nothing wrong on this side in isolation.
+`index.json` is also served `must-revalidate` so a fresh deploy is picked up
+rather than composed from a cached index.
+
+The CORS header is set on **all paths**, not just `/index.json`. The manager also
+probes `stories.json` and `metadata.json`, which Storybook 10 no longer emits.
+Those requests are expected to fail and composition works without them — but
+scoped to `/index.json` they fail as *CORS errors* rather than 404s, because the
+browser blocks the response before the status can be read, and each one logs an
+error in the console of every page that composes this Storybook.
 
 `cleanUrls: false` is load-bearing for the same reason it is in the design
 system's `vercel.json`: clean URLs rewrite `/iframe.html` to `/iframe`, which

--- a/storybook-site/vercel.json
+++ b/storybook-site/vercel.json
@@ -8,9 +8,12 @@
   "trailingSlash": false,
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [{ "key": "Access-Control-Allow-Origin", "value": "*" }]
+    },
+    {
       "source": "/index.json",
       "headers": [
-        { "key": "Access-Control-Allow-Origin", "value": "*" },
         {
           "key": "Cache-Control",
           "value": "public, max-age=0, must-revalidate"


### PR DESCRIPTION
Salvages the documentation from #104, and fixes a header #104 had right that #105 got wrong. Closes out #104.

## The header fix

`storybook-site/vercel.json` scoped `Access-Control-Allow-Origin` to `/index.json`. #104 set it on all paths, which is correct: the design system's manager also probes `stories.json` and `metadata.json`, which Storybook 10 no longer emits.

Those failures are harmless — composition works from `index.json` alone — but scoped to one route they surface as **CORS errors rather than 404s**, because the browser blocks the response before the status can be read. The result was two console errors on every page composing this Storybook. Confirmed in a browser against the live site.

`index.json` keeps its `must-revalidate` so a fresh deploy is composed rather than a cached index.

## The docs

Three additions, from #104:

| File | Adds |
| --- | --- |
| `AGENTS.md` | a row pointing at `storybook-site/` |
| `docs/design-system.md` | a Hosted Storybooks section — both URLs, and where the projects are declared |
| `stories/README.md` | where this Storybook is hosted and how it composes |

**Applied as additions, not by taking #104's copies of those files.** Its `stories/README.md` predates two sections `main` has since gained — "Why Storybook is here" (that the stories are load-bearing tests) and the note that visual regression is Playwright rather than Chromatic — so replacing the file wholesale would have silently dropped both.

Its `docs/design-system.md` text also repeated the `"@rtkelly13/design-system": "^0.0.5"` finding. #98 has since fixed that, so the paragraph now records the fix — the dependency tracks `^0.1.3` — rather than restating the bug.

## Verification

`biome check` clean across 313 files. The remaining checks and both Vercel builds run on this PR.

After merge, the composed sidebar should load with a clean console; the two probe errors were the only ones attributable to composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)