### PR TITLE
feat(sandbox): hero lab — WebGL research, and six generative heroes judged in both themes

### DIFF
--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -9,6 +9,7 @@ React components: UI primitives, feature modules (diagrams, search, comments), a
 ```
 components/
 ├── diagrams/         # Diagram renderers (Mermaid, SVG, ReactFlow)
+├── hero/             # Shader hero harness + the lab's generative ideas
 ├── search/           # KBar command palette (Cmd+K)
 ├── comments/         # Comment providers (Giscus, Utterances, Disqus)
 ├── social-icons/     # SVG social icons
@@ -25,6 +26,7 @@ components/
 Use these for imports:
 
 - `diagrams/index.ts` → Diagram, MermaidDiagram, SvgDiagram, ReactFlowDiagram
+- `hero/index.ts` → ShaderStage, HERO_IDEAS, readColor, SHADER_PRELUDE/POSTLUDE
 - `social-icons/index.tsx` → SocialIcon
 - `comments/index.tsx` → Comments (auto-selects provider)
 - `analytics/index.tsx` → Analytics (auto-selects provider)
@@ -140,6 +142,32 @@ Both are registered in `MDXComponents.tsx` via `next/dynamic` (`ssr: false`) so
 motion/@xyflow/react ship as lazy chunks only on pages that mount them.
 `IdeaSlide` is the exception — a dependency-free static marker component.
 Both respect `prefers-reduced-motion` via `useReducedMotion`.
+
+## HERO SHADERS (hero/)
+
+`ShaderStage` is the harness every generative hero runs on: it owns the WebGL2
+context, the full-screen triangle, DPR-aware sizing, the clock, reduced motion
+(one still frame, no rAF), pausing when off-screen or backgrounded, and the
+CSS fallback. An idea supplies only a `vec4 hero(vec2 uv, float t, Theme th)`
+— `SHADER_PRELUDE` provides the uniforms, the `Theme` struct and noise/line
+helpers, `SHADER_POSTLUDE` the `main()`.
+
+- **`th.ink` is the whole dual-mode contract**: 0 on the lit surface, 1 on
+  paper. Shaders branch their *shading model* on it, not just their palette —
+  bloom becomes ink weight, a smooth fade becomes a hard stamp. A glow is added
+  light, and added light on paper reads as a thumbprint.
+- **Palettes are measured, never hardcoded**: `ShaderStage` reads the
+  `--hero-*` tokens off real DOM probes carrying `.dark` and `.sketch`. Note
+  the dark themes leave those tokens unset and lean on inline `var()` fallbacks
+  (as `CyberHero` does), so the fallbacks are the neon palette, not a safety
+  net — and `getComputedStyle` returns 8-digit hex (`#23262e24`), not the
+  `rgba()` the stylesheet was written in.
+- `mode="split"` renders both themes in one pass either side of `uSplit`;
+  `mode="follow"` renders whichever theme the page is in.
+- Ideas and their two readings live in `hero/ideas.ts`; they render at
+  `/design-sandbox/hero-lab`, with the cost research at
+  `/design-sandbox/webgl-heroes` and
+  [docs/hero-webgl-research.md](../docs/hero-webgl-research.md).
 
 ## DIAGRAMS
 

--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -162,8 +162,17 @@ helpers, `SHADER_POSTLUDE` the `main()`.
   (as `CyberHero` does), so the fallbacks are the neon palette, not a safety
   net — and `getComputedStyle` returns 8-digit hex (`#23262e24`), not the
   `rgba()` the stylesheet was written in.
+- **The type safe area is part of the harness, not each idea.** The postlude
+  fades every shader's own field to 13% inside a feathered box across the
+  middle of the frame, because a hero has to earn its text legibility:
+  accent-coloured type at 12px loses to a bright line crossing the same pixels,
+  in either theme. Because the output is premultiplied, scaling the whole
+  `vec4` fades toward the backdrop — darker on black, lighter on paper — with
+  no hue shift. `safe={false}` shows the raw field.
 - `mode="split"` renders both themes in one pass either side of `uSplit`;
   `mode="follow"` renders whichever theme the page is in.
+- Ideas may carry **variants** (`ideas.ts`) — alternative treatments of the same
+  direction, selectable per card. Changing variant recompiles the program.
 - Ideas and their two readings live in `hero/ideas.ts`; they render at
   `/design-sandbox/hero-lab`, with the cost research at
   `/design-sandbox/webgl-heroes` and

--- a/components/hero/ShaderStage.tsx
+++ b/components/hero/ShaderStage.tsx
@@ -41,6 +41,7 @@ uniform vec2  uRes;
 uniform float uTime;
 uniform float uMotion;   // 1 = animated, 0 = reduced motion (still frame)
 uniform float uSplit;    // x split in 0..1; left = terminal, right = paper
+uniform float uSafe;     // how hard the field is knocked back behind the type
 uniform vec3  uTermGrid;
 uniform vec3  uTermRing;
 uniform vec3  uTermBg;
@@ -103,6 +104,16 @@ float stroke(float v, float weight) {
   return 1.0 - smoothstep(0.0, fwidth(v) * weight + 1e-6, abs(v));
 }
 
+// The type safe area: a feathered rounded box across the middle of the frame.
+// Every idea knocks its own field back inside it, because a hero has to earn
+// its text legibility — accent-coloured type at 12px loses to a bright line
+// crossing the same pixels, in either theme.
+float safeArea(vec2 uv) {
+  vec2 d = abs(uv) - vec2(0.44, 0.105);
+  float box = length(max(d, vec2(0.0))) + min(max(d.x, d.y), 0.0);
+  return 1.0 - smoothstep(-0.03, 0.17, box);
+}
+
 // Ruled lines every whole unit of v. The width comes from fwidth(v) rather
 // than fwidth(fract(v)) — the derivative of a sawtooth explodes at the wrap,
 // which is what puts a row of dark dots through a naive hatch.
@@ -130,7 +141,9 @@ void main() {
   th.bg = mix(uTermBg, uPaperBg, side);
   th.ink = side;
 
-  outColor = hero(uv, t, th);
+  // Premultiplied, so scaling the whole vec4 fades the field toward the
+  // backdrop — darker on black, lighter on paper — without touching its hue.
+  outColor = hero(uv, t, th) * mix(1.0, 0.13, safeArea(uv) * uSafe);
 }`;
 
 /**
@@ -228,6 +241,8 @@ type Props = {
   mode?: 'split' | 'follow';
   /** Split position in 0..1. Ignored in `follow` mode. */
   split?: number;
+  /** Knock the field back behind the lockup. Off shows the raw field. */
+  safe?: boolean;
   className?: string;
   onStatus?: (status: ShaderStatus) => void;
 };
@@ -236,6 +251,7 @@ export default function ShaderStage({
   hero,
   mode = 'split',
   split = 0.5,
+  safe = true,
   className,
   onStatus,
 }: Props) {
@@ -243,7 +259,9 @@ export default function ShaderStage({
   const termProbe = useRef<HTMLDivElement>(null);
   const paperProbe = useRef<HTMLDivElement>(null);
   const splitRef = useRef(split);
+  const safeRef = useRef(safe);
   const setSplitUniform = useRef<((value: number) => void) | null>(null);
+  const setSafeUniform = useRef<((value: boolean) => void) | null>(null);
   const [status, setStatus] = useState<ShaderStatus>('pending');
 
   useEffect(() => {
@@ -256,6 +274,11 @@ export default function ShaderStage({
     splitRef.current = split;
     setSplitUniform.current?.(split);
   }, [split]);
+
+  useEffect(() => {
+    safeRef.current = safe;
+    setSafeUniform.current?.(safe);
+  }, [safe]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -298,6 +321,7 @@ export default function ShaderStage({
     const uTime = loc('uTime');
     const uMotion = loc('uMotion');
     const uSplit = loc('uSplit');
+    const uSafe = loc('uSafe');
     const uTermGrid = loc('uTermGrid');
     const uTermRing = loc('uTermRing');
     const uTermBg = loc('uTermBg');
@@ -310,11 +334,21 @@ export default function ShaderStage({
       // on one side, and let the page's own theme decide which side that is.
       if (mode === 'split') {
         gl.uniform1f(uSplit, value);
+        redrawIfIdle();
         return;
       }
       const bg = readPalette(document.documentElement).bg;
       const luminance = 0.2126 * bg[0] + 0.7152 * bg[1] + 0.0722 * bg[2];
       gl.uniform1f(uSplit, luminance > 0.5 ? -1 : 2);
+    };
+
+    // Reassigned once the clock exists. Uniform changes that arrive while the
+    // loop is parked — a drag under reduced motion, say — still need a frame.
+    let redrawIfIdle: () => void = () => {};
+
+    const applySafe = (value: boolean) => {
+      gl.uniform1f(uSafe, value ? 1 : 0);
+      redrawIfIdle();
     };
 
     const applyPalettes = () => {
@@ -335,7 +369,9 @@ export default function ShaderStage({
       applySplit(splitRef.current);
     };
     applyPalettes();
+    applySafe(safeRef.current);
     setSplitUniform.current = applySplit;
+    setSafeUniform.current = applySafe;
 
     const themeObserver = new MutationObserver(applyPalettes);
     themeObserver.observe(document.documentElement, {
@@ -358,15 +394,21 @@ export default function ShaderStage({
     const resizeObserver = new ResizeObserver(resize);
     resizeObserver.observe(canvas);
 
+    let lastSeconds = 0;
     const draw = (seconds: number) => {
+      lastSeconds = seconds;
       gl.uniform1f(uTime, seconds);
       gl.clearColor(0, 0, 0, 0);
       gl.clear(gl.COLOR_BUFFER_BIT);
       gl.drawArrays(gl.TRIANGLES, 0, 3);
     };
 
-    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
     let raf = 0;
+    redrawIfIdle = () => {
+      if (!raf) draw(lastSeconds);
+    };
+
+    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
     let visible = true;
     let start = performance.now();
 
@@ -423,6 +465,7 @@ export default function ShaderStage({
     return () => {
       stop();
       setSplitUniform.current = null;
+      setSafeUniform.current = null;
       themeObserver.disconnect();
       resizeObserver.disconnect();
       intersectionObserver.disconnect();

--- a/components/hero/ShaderStage.tsx
+++ b/components/hero/ShaderStage.tsx
@@ -1,0 +1,473 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * The shared harness every hero idea in the lab runs on.
+ *
+ * An idea supplies one function — `vec4 hero(vec2 uv, float t, Theme th)` —
+ * and this component supplies everything around it: the GL context, the
+ * full-screen triangle, DPR-aware sizing, the clock, and the two design-system
+ * palettes handed in as uniforms.
+ *
+ * The interesting part is `mode`:
+ *
+ * - `split` renders **both** themes in one pass. `uSplit` is an x position in
+ *   0..1; pixels left of it get the neon-terminal palette with `ink = 0`,
+ *   pixels right of it get the sketch palette with `ink = 1`. One canvas, one
+ *   context, both readings side by side — which is the whole point of the lab.
+ * - `follow` renders whichever theme the page is actually in, the way a shipped
+ *   hero would.
+ *
+ * Both palettes are measured off real DOM probes carrying the `.dark` and
+ * `.sketch` classes, so the shaders never hardcode a colour: whatever
+ * `css/tailwind.css` says those themes are is what reaches the GPU.
+ */
+
+export type ShaderStatus = 'pending' | 'running' | 'still' | 'unsupported';
+
+type Rgb = [number, number, number];
+
+const VERT = `#version 300 es
+in vec2 aPos;
+void main() { gl_Position = vec4(aPos, 0.0, 1.0); }`;
+
+/**
+ * Uniforms, helpers and the `Theme` struct every idea can rely on. Concatenated
+ * ahead of the idea's own source, so an idea is just its `hero()`.
+ */
+export const SHADER_PRELUDE = `#version 300 es
+precision highp float;
+
+uniform vec2  uRes;
+uniform float uTime;
+uniform float uMotion;   // 1 = animated, 0 = reduced motion (still frame)
+uniform float uSplit;    // x split in 0..1; left = terminal, right = paper
+uniform vec3  uTermGrid;
+uniform vec3  uTermRing;
+uniform vec3  uTermBg;
+uniform vec3  uPaperGrid;
+uniform vec3  uPaperRing;
+uniform vec3  uPaperBg;
+
+out vec4 outColor;
+
+// grid/ring are the --hero-* tokens; ink is 0 on a lit surface, 1 on paper.
+struct Theme {
+  vec3  grid;
+  vec3  ring;
+  vec3  bg;
+  float ink;
+};
+
+float hash21(vec2 p) {
+  p = fract(p * vec2(123.34, 456.21));
+  p += dot(p, p + 45.32);
+  return fract(p.x * p.y);
+}
+
+uint hashU(uvec2 p) {
+  uint h = p.x * 374761393u + p.y * 668265263u;
+  h = (h ^ (h >> 13u)) * 1274126177u;
+  return h ^ (h >> 16u);
+}
+
+float valueNoise(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  vec2 u = f * f * (3.0 - 2.0 * f);
+  float a = hash21(i);
+  float b = hash21(i + vec2(1.0, 0.0));
+  float c = hash21(i + vec2(0.0, 1.0));
+  float d = hash21(i + vec2(1.0, 1.0));
+  return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+
+float fbm(vec2 p) {
+  float v = 0.0;
+  float a = 0.5;
+  for (int i = 0; i < 5; i++) {
+    v += a * valueNoise(p);
+    p *= 2.02;
+    a *= 0.5;
+  }
+  return v;
+}
+
+mat2 rot(float a) {
+  float c = cos(a);
+  float s = sin(a);
+  return mat2(c, -s, s, c);
+}
+
+// Anti-aliased stroke around v == 0, one pixel wide times \`weight\`.
+float stroke(float v, float weight) {
+  return 1.0 - smoothstep(0.0, fwidth(v) * weight + 1e-6, abs(v));
+}
+
+// Ruled lines every whole unit of v. The width comes from fwidth(v) rather
+// than fwidth(fract(v)) — the derivative of a sawtooth explodes at the wrap,
+// which is what puts a row of dark dots through a naive hatch.
+float ruled(float v, float weight) {
+  float w = fwidth(v) * weight + 1e-6;
+  return 1.0 - smoothstep(0.0, w, abs(fract(v) - 0.5));
+}
+`;
+
+/**
+ * `hero()` returns **premultiplied** colour — rgb already scaled by coverage —
+ * so ideas can just add their layers together and hand back the total.
+ */
+export const SHADER_POSTLUDE = `
+void main() {
+  vec2 uv = (gl_FragCoord.xy - 0.5 * uRes) / uRes.y;
+  float t = uTime * uMotion;
+
+  // No branch: the side selector is mixed into the theme, keeping the whole
+  // shader in uniform control flow so fwidth() stays well defined.
+  float side = step(uSplit * uRes.x, gl_FragCoord.x);
+  Theme th;
+  th.grid = mix(uTermGrid, uPaperGrid, side);
+  th.ring = mix(uTermRing, uPaperRing, side);
+  th.bg = mix(uTermBg, uPaperBg, side);
+  th.ink = side;
+
+  outColor = hero(uv, t, th);
+}`;
+
+/**
+ * Turn a computed CSS colour into 0..1 RGB, dropping alpha — the shader owns
+ * opacity. Browsers do not hand these back in the form the stylesheet wrote
+ * them: `rgba(35, 38, 46, 0.14)` comes out of `getComputedStyle` as the
+ * 8-digit hex `#23262e24`, so every notation has to be handled or the token
+ * silently falls through to the fallback.
+ */
+export function readColor(value: string, fallback: Rgb): Rgb {
+  const hex = value.trim().match(/^#([0-9a-f]{3,8})$/i);
+  if (hex) {
+    const h = hex[1];
+    const full =
+      h.length <= 4
+        ? h
+            .slice(0, 3)
+            .split('')
+            .map((c) => c + c)
+            .join('')
+        : h.slice(0, 6);
+    return [0, 2, 4].map(
+      (i) => Number.parseInt(full.slice(i, i + 2), 16) / 255,
+    ) as Rgb;
+  }
+  const rgb = value.match(/rgba?\(([^)]+)\)/i);
+  if (rgb) {
+    const parts = rgb[1]
+      .split(/[,\s/]+/)
+      .filter(Boolean)
+      .map(Number);
+    if (
+      parts.length >= 3 &&
+      parts.slice(0, 3).every((n) => Number.isFinite(n))
+    ) {
+      return [parts[0] / 255, parts[1] / 255, parts[2] / 255];
+    }
+  }
+  return fallback;
+}
+
+// The neon values live as inline var() fallbacks rather than in the .dark
+// block (CyberHero does the same), so these are the palette, not a safety net.
+const NEON_GRID: Rgb = [0.22, 1.0, 0.08];
+const NEON_RING: Rgb = [0.53, 0.94, 0.68];
+const NEON_BG: Rgb = [0.04, 0.04, 0.1];
+
+function readPalette(el: Element) {
+  const styles = getComputedStyle(el);
+  return {
+    grid: readColor(styles.getPropertyValue('--hero-grid-strong'), NEON_GRID),
+    ring: readColor(styles.getPropertyValue('--hero-ring'), NEON_RING),
+    bg: readColor(styles.getPropertyValue('--brutalist-darkBg'), NEON_BG),
+  };
+}
+
+function compile(gl: WebGL2RenderingContext, type: number, src: string) {
+  const shader = gl.createShader(type);
+  if (!shader) return null;
+  gl.shaderSource(shader, src);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(gl.getShaderInfoLog(shader));
+    }
+    gl.deleteShader(shader);
+    return null;
+  }
+  return shader;
+}
+
+/** Compile, link and activate the pair; null on any failure, so the caller
+ *  can drop straight to the CSS fallback. */
+function createProgram(gl: WebGL2RenderingContext, frag: string) {
+  const program = gl.createProgram();
+  const vs = compile(gl, gl.VERTEX_SHADER, VERT);
+  const fs = compile(gl, gl.FRAGMENT_SHADER, frag);
+  if (!program || !vs || !fs) return null;
+
+  gl.attachShader(program, vs);
+  gl.attachShader(program, fs);
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    gl.deleteProgram(program);
+    return null;
+  }
+  // biome-ignore lint/correctness/useHookAtTopLevel: gl.useProgram is a WebGL call, not a React hook
+  gl.useProgram(program);
+  return { program, vs, fs };
+}
+
+type Props = {
+  /** The idea's source: a single `vec4 hero(vec2 uv, float t, Theme th)`. */
+  hero: string;
+  mode?: 'split' | 'follow';
+  /** Split position in 0..1. Ignored in `follow` mode. */
+  split?: number;
+  className?: string;
+  onStatus?: (status: ShaderStatus) => void;
+};
+
+export default function ShaderStage({
+  hero,
+  mode = 'split',
+  split = 0.5,
+  className,
+  onStatus,
+}: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const termProbe = useRef<HTMLDivElement>(null);
+  const paperProbe = useRef<HTMLDivElement>(null);
+  const splitRef = useRef(split);
+  const setSplitUniform = useRef<((value: number) => void) | null>(null);
+  const [status, setStatus] = useState<ShaderStatus>('pending');
+
+  useEffect(() => {
+    onStatus?.(status);
+  }, [status, onStatus]);
+
+  // Push split changes straight at the uniform: re-running the whole GL setup
+  // on every drag frame would rebuild the program sixty times a second.
+  useEffect(() => {
+    splitRef.current = split;
+    setSplitUniform.current?.(split);
+  }, [split]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const gl = canvas.getContext('webgl2', {
+      alpha: true,
+      antialias: false,
+      powerPreference: 'low-power',
+    });
+    if (!gl) {
+      setStatus('unsupported');
+      return;
+    }
+
+    const built = createProgram(gl, SHADER_PRELUDE + hero + SHADER_POSTLUDE);
+    if (!built) {
+      setStatus('unsupported');
+      return;
+    }
+    const { program, vs, fs } = built;
+
+    // One full-screen triangle — cheaper than a quad and needs no index buffer.
+    const buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array([-1, -1, 3, -1, -1, 3]),
+      gl.STATIC_DRAW,
+    );
+    const aPos = gl.getAttribLocation(program, 'aPos');
+    gl.enableVertexAttribArray(aPos);
+    gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0);
+
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+
+    const loc = (name: string) => gl.getUniformLocation(program, name);
+    const uRes = loc('uRes');
+    const uTime = loc('uTime');
+    const uMotion = loc('uMotion');
+    const uSplit = loc('uSplit');
+    const uTermGrid = loc('uTermGrid');
+    const uTermRing = loc('uTermRing');
+    const uTermBg = loc('uTermBg');
+    const uPaperGrid = loc('uPaperGrid');
+    const uPaperRing = loc('uPaperRing');
+    const uPaperBg = loc('uPaperBg');
+
+    const applySplit = (value: number) => {
+      // follow mode has no seam: park the split off-canvas so every pixel lands
+      // on one side, and let the page's own theme decide which side that is.
+      if (mode === 'split') {
+        gl.uniform1f(uSplit, value);
+        return;
+      }
+      const bg = readPalette(document.documentElement).bg;
+      const luminance = 0.2126 * bg[0] + 0.7152 * bg[1] + 0.0722 * bg[2];
+      gl.uniform1f(uSplit, luminance > 0.5 ? -1 : 2);
+    };
+
+    const applyPalettes = () => {
+      const term =
+        mode === 'split' && termProbe.current
+          ? readPalette(termProbe.current)
+          : readPalette(document.documentElement);
+      const paper =
+        mode === 'split' && paperProbe.current
+          ? readPalette(paperProbe.current)
+          : term;
+      gl.uniform3fv(uTermGrid, term.grid);
+      gl.uniform3fv(uTermRing, term.ring);
+      gl.uniform3fv(uTermBg, term.bg);
+      gl.uniform3fv(uPaperGrid, paper.grid);
+      gl.uniform3fv(uPaperRing, paper.ring);
+      gl.uniform3fv(uPaperBg, paper.bg);
+      applySplit(splitRef.current);
+    };
+    applyPalettes();
+    setSplitUniform.current = applySplit;
+
+    const themeObserver = new MutationObserver(applyPalettes);
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style', 'data-theme'],
+    });
+
+    const resize = () => {
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const w = Math.max(1, Math.round(canvas.clientWidth * dpr));
+      const h = Math.max(1, Math.round(canvas.clientHeight * dpr));
+      if (canvas.width !== w || canvas.height !== h) {
+        canvas.width = w;
+        canvas.height = h;
+        gl.viewport(0, 0, w, h);
+      }
+      gl.uniform2f(uRes, canvas.width, canvas.height);
+    };
+    resize();
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(canvas);
+
+    const draw = (seconds: number) => {
+      gl.uniform1f(uTime, seconds);
+      gl.clearColor(0, 0, 0, 0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+    };
+
+    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    let raf = 0;
+    let visible = true;
+    let start = performance.now();
+
+    const stop = () => {
+      if (raf) cancelAnimationFrame(raf);
+      raf = 0;
+    };
+
+    const loop = (now: number) => {
+      draw((now - start) / 1000);
+      raf = requestAnimationFrame(loop);
+    };
+
+    const sync = () => {
+      stop();
+      if (motionQuery.matches) {
+        // Reduced motion: one still frame, no clock, no rAF at all.
+        gl.uniform1f(uMotion, 0);
+        draw(0);
+        setStatus('still');
+        return;
+      }
+      gl.uniform1f(uMotion, 1);
+      setStatus('running');
+      if (!visible || document.hidden) {
+        draw((performance.now() - start) / 1000);
+        return;
+      }
+      start = performance.now();
+      raf = requestAnimationFrame(loop);
+    };
+
+    // Idle when scrolled away or backgrounded — a gallery of heroes all
+    // spinning the GPU at once is exactly how this gets a bad reputation.
+    const intersectionObserver = new IntersectionObserver(
+      ([entry]) => {
+        visible = entry.isIntersecting;
+        sync();
+      },
+      { threshold: 0 },
+    );
+    intersectionObserver.observe(canvas);
+
+    const onContextLost = (event: Event) => {
+      event.preventDefault();
+      stop();
+      setStatus('unsupported');
+    };
+    canvas.addEventListener('webglcontextlost', onContextLost);
+    document.addEventListener('visibilitychange', sync);
+    motionQuery.addEventListener('change', sync);
+    sync();
+
+    return () => {
+      stop();
+      setSplitUniform.current = null;
+      themeObserver.disconnect();
+      resizeObserver.disconnect();
+      intersectionObserver.disconnect();
+      canvas.removeEventListener('webglcontextlost', onContextLost);
+      document.removeEventListener('visibilitychange', sync);
+      motionQuery.removeEventListener('change', sync);
+      gl.deleteProgram(program);
+      gl.deleteShader(vs);
+      gl.deleteShader(fs);
+      gl.deleteBuffer(buffer);
+    };
+  }, [hero, mode]);
+
+  return (
+    <>
+      {/* Palette probes: real elements carrying the theme classes, so the
+          shaders read whatever the stylesheet currently says those themes are. */}
+      <div
+        ref={termProbe}
+        className="dark"
+        aria-hidden
+        style={{
+          position: 'absolute',
+          width: 0,
+          height: 0,
+          overflow: 'hidden',
+        }}
+      />
+      <div
+        ref={paperProbe}
+        className="sketch"
+        aria-hidden
+        style={{
+          position: 'absolute',
+          width: 0,
+          height: 0,
+          overflow: 'hidden',
+        }}
+      />
+      <canvas
+        ref={canvasRef}
+        aria-hidden
+        className={className}
+        style={{ display: status === 'unsupported' ? 'none' : 'block' }}
+      />
+    </>
+  );
+}

--- a/components/hero/ideas.ts
+++ b/components/hero/ideas.ts
@@ -1,0 +1,257 @@
+/**
+ * The hero lab's ideas.
+ *
+ * Each is one `hero()` function running on the ShaderStage harness, and each
+ * is chosen for the same reason: it has a *second* reading on paper, not just
+ * a recoloured one. That is the thing worth testing — the site's two
+ * aesthetics are meant to be equals, so an idea that only works in neon is a
+ * failed idea however good it looks on black.
+ *
+ * `th.ink` is 0 on the lit surface and 1 on paper, and it is what each shader
+ * branches its *shading model* on: bloom against ink weight, smooth falloff
+ * against stamped levels, coarse LED cells against a fine halftone screen.
+ */
+
+export type HeroIdea = {
+  id: string;
+  name: string;
+  tagline: string;
+  /** How it reads on black. */
+  terminal: string;
+  /** How it reads on paper. */
+  sketch: string;
+  /** What flips between the two — the interesting column. */
+  pivot: string;
+  hero: string;
+};
+
+const SYNTHWAVE = `
+float floorGrid(vec2 uv, float t) {
+  // Clamp rather than early-return: a conditional return here would put
+  // fwidth() inside non-uniform control flow.
+  float horizon = min(uv.y + 0.16, -0.001);
+  vec2 plane = vec2(uv.x / -horizon, (0.5 / -horizon) + t * 0.25);
+  vec2 cell = abs(fract(plane) - 0.5);
+  vec2 w = fwidth(plane) * 1.5;
+  vec2 line = smoothstep(w, vec2(0.0), cell);
+  float mask = step(uv.y + 0.16, 0.0);
+  return max(line.x, line.y) * smoothstep(0.0, 0.22, -horizon) * mask;
+}
+
+vec4 hero(vec2 uv, float t, Theme th) {
+  float g = floorGrid(uv, t) * mix(0.55, 0.75, th.ink);
+
+  float d = abs(length(uv * vec2(1.0, 1.25)) - 0.30);
+  float core = smoothstep(mix(0.010, 0.016, th.ink), 0.002, d);
+  float pulse = 0.75 + 0.25 * sin(t * 1.2);
+  float bloom = smoothstep(0.18, 0.0, d) * 0.35 * (1.0 - th.ink) * pulse;
+
+  float horizonGlow =
+    smoothstep(0.12, 0.0, abs(uv.y + 0.16)) * 0.25 * (1.0 - th.ink);
+
+  vec3 col = th.grid * (g + horizonGlow) + th.ring * (core + bloom);
+  float a = clamp(g + horizonGlow + core + bloom, 0.0, 1.0);
+  return vec4(col, a);
+}`;
+
+const CONTOUR = `
+vec4 hero(vec2 uv, float t, Theme th) {
+  vec2 p = uv * 1.5 + vec2(t * 0.035, t * 0.018);
+  float h = fbm(p);
+  float bands = h * 17.0;
+
+  // Every fifth contour is an index line, drawn heavier — the convention a
+  // real map uses, and the thing that stops it reading as wallpaper.
+  float major = 1.0 - step(0.5, mod(floor(bands), 5.0));
+  float weight = mix(1.5, 0.85, th.ink) * mix(1.0, 2.1, major);
+  float line = ruled(bands, weight);
+
+  // Paper gets a whisper of tone between the lines; black gets a bloom.
+  float w = fwidth(bands);
+  float bloom = (1.0 - smoothstep(0.0, w * 7.0, abs(fract(bands) - 0.5)))
+    * 0.22 * (1.0 - th.ink);
+  float wash = smoothstep(0.35, 0.85, h) * 0.10 * th.ink;
+
+  float body = line * mix(0.6, 0.8, th.ink) + wash;
+  vec3 col = th.grid * body + th.ring * bloom;
+  return vec4(col, clamp(body + bloom, 0.0, 1.0));
+}`;
+
+const CROSSHATCH = `
+float hatch(vec2 uv, float ang, float freq, float weight) {
+  return ruled((rot(ang) * uv).y * freq, weight);
+}
+
+vec4 hero(vec2 uv, float t, Theme th) {
+  // One tonal field, three hatch passes gated on it — darker regions earn more
+  // layers, exactly the way pen shading builds up.
+  float shade = fbm(uv * 1.7 + vec2(t * 0.05, -t * 0.03));
+  shade = smoothstep(0.28, 0.78, shade);
+
+  float weight = mix(1.6, 1.0, th.ink);
+  float l1 = hatch(uv, 0.55, 40.0, weight) * step(0.12, shade);
+  float l2 = hatch(uv, -0.75, 36.0, weight) * step(0.42, shade);
+  float l3 = hatch(uv, 1.75, 32.0, weight) * step(0.70, shade);
+
+  float ink = clamp(l1 + l2 * 0.9 + l3 * 0.8, 0.0, 1.0);
+  float body = ink * mix(0.5, 0.78, th.ink);
+  float bloom = ink * shade * 0.20 * (1.0 - th.ink);
+
+  vec3 col = th.grid * body + th.ring * bloom;
+  return vec4(col, clamp(body + bloom, 0.0, 1.0));
+}`;
+
+const DOTMATRIX = `
+vec4 hero(vec2 uv, float t, Theme th) {
+  // The screen itself is the tell: an LED panel sits square and coarse, a
+  // print halftone sits at 45 degrees and much finer.
+  float ang = mix(0.0, 0.785, th.ink);
+  float cells = mix(30.0, 46.0, th.ink);
+  vec2 p = rot(ang) * uv * cells;
+  vec2 f = fract(p) - 0.5;
+
+  // Sample the image once per cell, not per pixel — that is what makes it a
+  // dot screen rather than a blurred picture.
+  vec2 q = rot(-ang) * ((floor(p) + 0.5) / cells);
+  float focus = smoothstep(0.52, 0.10, length(q));
+  float wave = 0.5 + 0.5 * sin(length(q) * 17.0 - t * 2.2);
+  float ground = smoothstep(0.34, 0.78, fbm(q * 2.0 + vec2(t * 0.05, t * 0.02)));
+  float amp = clamp(max(wave * focus, ground * 0.42) + 0.03, 0.0, 1.0);
+
+  float d = length(f) - amp * 0.46;
+  float dot = 1.0 - smoothstep(-0.04, 0.04, d);
+
+  float body = dot * mix(0.85, 0.8, th.ink);
+  float bloom = smoothstep(0.30, 0.0, length(f)) * amp * 0.30 * (1.0 - th.ink);
+
+  vec3 col = th.grid * body + th.ring * bloom;
+  return vec4(col, clamp(body + bloom, 0.0, 1.0));
+}`;
+
+const SCOPE = `
+vec4 hero(vec2 uv, float t, Theme th) {
+  float graticule = max(
+    ruled(uv.x * 10.0, mix(1.3, 0.9, th.ink)),
+    ruled(uv.y * 10.0, mix(1.3, 0.9, th.ink))
+  ) * mix(0.14, 0.30, th.ink);
+
+  // The roles swap. On black the graticule is dim and the beam is the accent;
+  // on chart paper the stock is tinted and the pen is plain ink.
+  vec3 gridCol = mix(th.grid, th.ring, th.ink * 0.8);
+  vec3 penCol = mix(th.ring, th.grid, th.ink);
+
+  vec3 col = gridCol * graticule;
+  float a = graticule;
+
+  for (int i = 0; i < 3; i++) {
+    float fi = float(i);
+    float y = 0.15 * sin(uv.x * 3.1 + t * 1.05 + fi * 2.2)
+                   * (0.55 + 0.45 * sin(t * 0.6 + fi * 1.7))
+            + 0.045 * sin(uv.x * 12.0 - t * 2.3 + fi * 4.0);
+    // A pen drags and wobbles; a phosphor beam does not.
+    y += 0.006 * (valueNoise(vec2(uv.x * 26.0 + fi * 12.0, t * 0.6)) - 0.5) * th.ink;
+
+    float d = abs(uv.y - y);
+    float core = 1.0 - smoothstep(0.0, mix(0.0055, 0.0038, th.ink), d);
+    float after = exp(-d * 20.0) * 0.32 * (1.0 - th.ink);
+
+    col += penCol * (core * mix(0.9, 0.85, th.ink)) + th.ring * after;
+    a += core * mix(0.9, 0.85, th.ink) + after;
+  }
+
+  return vec4(col, clamp(a, 0.0, 1.0));
+}`;
+
+const GLYPHRAIN = `
+vec4 hero(vec2 uv, float t, Theme th) {
+  float cols = mix(40.0, 32.0, th.ink);
+  vec2 p = uv * cols;
+  vec2 cellId = floor(p);
+  vec2 f = fract(p);
+
+  float speed = 0.35 + hash21(vec2(cellId.x, 7.0)) * 0.95;
+  float offset = hash21(vec2(cellId.x, 3.0)) * 11.0;
+  float head = 9.0 - fract(t * speed * 0.13 + offset) * 26.0;
+  float behind = head - cellId.y;
+  float trail = exp(-max(behind, 0.0) * mix(0.22, 0.34, th.ink)) * step(0.0, behind);
+
+  // No font atlas: hash each cell into a 5x6 bitmap. They read as glyphs from
+  // an alphabet nobody knows, which is the effect anyway.
+  uint frame = uint(floor(t * 7.0 + hash21(cellId) * 9.0));
+  uint bits = hashU(uvec2(cellId + 128.0) + uvec2(frame, frame * 3u));
+  uvec2 g = uvec2(floor(f * vec2(5.0, 6.0)));
+  float on = float((bits >> (g.x + g.y * 5u)) & 1u);
+
+  // Keep the glyphs off each other in the cell.
+  float inset = step(0.10, f.x) * step(f.x, 0.90)
+              * step(0.06, f.y) * step(f.y, 0.94);
+  float lit = on * inset * trail;
+
+  // Phosphor fades continuously; a struck letter is either inked or it is not.
+  float body = mix(lit, step(0.16, lit), th.ink) * mix(0.9, 0.8, th.ink);
+  float headGlow = smoothstep(1.4, 0.0, abs(behind)) * on * inset * (1.0 - th.ink);
+
+  vec3 col = th.grid * body + th.ring * headGlow;
+  return vec4(col, clamp(body + headGlow, 0.0, 1.0));
+}`;
+
+export const HERO_IDEAS: HeroIdea[] = [
+  {
+    id: 'synthwave',
+    name: 'HORIZON',
+    tagline: 'Perspective floor grid running to a ring on the horizon.',
+    terminal:
+      'Neon grid receding into black, ring blooming like a light source.',
+    sketch: 'Drafting-paper perspective study — ruled ink lines, no glow.',
+    pivot: 'The bloom. On paper it becomes a heavier ink stroke instead.',
+    hero: SYNTHWAVE,
+  },
+  {
+    id: 'contour',
+    name: 'CONTOUR',
+    tagline: 'A drifting noise field read as elevation lines.',
+    terminal: 'Isolines glowing off a radar sweep.',
+    sketch: 'Ordnance-survey contours, every fifth line inked heavier.',
+    pivot:
+      'Line weight carries the depth on paper; brightness carries it on black.',
+    hero: CONTOUR,
+  },
+  {
+    id: 'crosshatch',
+    name: 'CROSSHATCH',
+    tagline: 'Pen shading: three hatch passes gated on one tonal field.',
+    terminal: 'Angled neon rules, dense where the field is dark.',
+    sketch: 'Native. This is how a pen actually shades — it starts here.',
+    pivot:
+      'The paper-first idea. Black mode is the inversion, not the default.',
+    hero: CROSSHATCH,
+  },
+  {
+    id: 'dotmatrix',
+    name: 'DOT_MATRIX',
+    tagline: 'One image, sampled once per cell, drawn as dots.',
+    terminal: 'Coarse square LED panel, each dot blooming.',
+    sketch: 'Fine 45° print halftone — the screen a newspaper uses.',
+    pivot:
+      'The screen geometry itself: square and coarse against angled and fine.',
+    hero: DOTMATRIX,
+  },
+  {
+    id: 'scope',
+    name: 'TRACE',
+    tagline: 'Three waveforms over a graticule.',
+    terminal: 'Oscilloscope phosphor, each trace smearing an afterglow.',
+    sketch: 'Seismograph pen on chart paper, complete with a wobble.',
+    pivot: 'Afterglow against pen wobble — each medium’s own imprecision.',
+    hero: SCOPE,
+  },
+  {
+    id: 'glyphrain',
+    name: 'GLYPH_RAIN',
+    tagline: 'Columns of hashed 5×6 bitmap glyphs falling.',
+    terminal: 'Terminal rain, bright head, phosphor tail.',
+    sketch: 'Typewriter strike — inked or not, no half-tones, slower.',
+    pivot: 'Continuous fade against a hard stamp threshold.',
+    hero: GLYPHRAIN,
+  },
+];

--- a/components/hero/ideas.ts
+++ b/components/hero/ideas.ts
@@ -10,7 +10,17 @@
  * `th.ink` is 0 on the lit surface and 1 on paper, and it is what each shader
  * branches its *shading model* on: bloom against ink weight, smooth falloff
  * against stamped levels, coarse LED cells against a fine halftone screen.
+ *
+ * CONTOUR and CROSSHATCH carry variants — they are the two directions worth
+ * pushing, so each gets three treatments rather than one.
  */
+
+export type HeroVariant = {
+  id: string;
+  name: string;
+  note: string;
+  hero: string;
+};
 
 export type HeroIdea = {
   id: string;
@@ -22,8 +32,198 @@ export type HeroIdea = {
   sketch: string;
   /** What flips between the two — the interesting column. */
   pivot: string;
-  hero: string;
+  /** First entry is the default. */
+  variants: HeroVariant[];
 };
+
+/* ---------------------------------------------------------------- CONTOUR */
+
+const CONTOUR_DRIFT = `
+vec4 hero(vec2 uv, float t, Theme th) {
+  vec2 p = uv * 1.5 + vec2(t * 0.035, t * 0.018);
+  float h = fbm(p);
+  float bands = h * 17.0;
+
+  // Every fifth contour is an index line, drawn heavier — the convention a
+  // real map uses, and the thing that stops it reading as wallpaper.
+  float major = 1.0 - step(0.5, mod(floor(bands), 5.0));
+  float weight = mix(1.5, 0.85, th.ink) * mix(1.0, 2.1, major);
+  float line = ruled(bands, weight);
+
+  // Paper gets a whisper of tone between the lines; black gets a bloom.
+  float w = fwidth(bands);
+  float bloom = (1.0 - smoothstep(0.0, w * 7.0, abs(fract(bands) - 0.5)))
+    * 0.22 * (1.0 - th.ink);
+  float wash = smoothstep(0.35, 0.85, h) * 0.10 * th.ink;
+
+  float body = line * mix(0.6, 0.8, th.ink) + wash;
+  vec3 col = th.grid * body + th.ring * bloom;
+  return vec4(col, clamp(body + bloom, 0.0, 1.0));
+}`;
+
+const CONTOUR_RIDGE = `
+// Ridged noise: fold each octave about its midpoint so the maxima come to a
+// crest instead of a dome. Contoured, that reads as mountain rather than dune.
+float ridged(vec2 p) {
+  float v = 0.0;
+  float a = 0.5;
+  for (int i = 0; i < 5; i++) {
+    float n = 1.0 - abs(valueNoise(p) * 2.0 - 1.0);
+    v += a * n * n;
+    p *= 2.03;
+    a *= 0.5;
+  }
+  return v;
+}
+
+vec4 hero(vec2 uv, float t, Theme th) {
+  vec2 p = uv * 0.95 + vec2(t * 0.02, t * 0.012);
+  float h = ridged(p);
+  float bands = h * 13.0;
+
+  float major = 1.0 - step(0.5, mod(floor(bands), 5.0));
+  float weight = mix(1.4, 0.8, th.ink) * mix(1.0, 2.2, major);
+  float line = ruled(bands, weight);
+
+  // Crowded lines mean steep ground: shade the gradient so the relief reads
+  // even where the contours merge.
+  float slope = clamp(length(vec2(dFdx(h), dFdy(h))) * 130.0, 0.0, 1.0);
+  float relief = slope * mix(0.13, 0.11, th.ink);
+
+  float w = fwidth(bands);
+  float bloom = (1.0 - smoothstep(0.0, w * 6.0, abs(fract(bands) - 0.5)))
+    * 0.24 * (1.0 - th.ink);
+
+  float body = line * mix(0.6, 0.82, th.ink) + relief;
+  vec3 col = th.grid * body + th.ring * bloom;
+  return vec4(col, clamp(body + bloom, 0.0, 1.0));
+}`;
+
+const CONTOUR_ISOBAR = `
+vec4 hero(vec2 uv, float t, Theme th) {
+  // Fewer, wider bands with pressure centres pushed through them: a synoptic
+  // chart rather than a survey map. The whole field advects sideways.
+  vec2 p = uv * 0.95 + vec2(t * 0.055, 0.0);
+  float h = fbm(p);
+
+  vec2 lowC = vec2(-0.36 + 0.05 * sin(t * 0.21), 0.10);
+  vec2 highC = vec2(0.40 + 0.05 * cos(t * 0.17), -0.08);
+  h -= 0.34 * exp(-dot(uv - lowC, uv - lowC) * 9.0);
+  h += 0.30 * exp(-dot(uv - highC, uv - highC) * 11.0);
+
+  float bands = h * 9.0;
+  float major = 1.0 - step(0.5, mod(floor(bands), 4.0));
+  float weight = mix(1.7, 1.0, th.ink) * mix(1.0, 2.4, major);
+  float line = ruled(bands, weight);
+
+  // Tight isobars mean wind: hatch the gradient lightly where they bunch up.
+  float pack = clamp(fwidth(bands) * 2.6, 0.0, 1.0);
+  float gust = ruled((rot(0.9) * uv).y * 90.0, 1.0) * pack * mix(0.20, 0.26, th.ink);
+
+  float w = fwidth(bands);
+  float bloom = (1.0 - smoothstep(0.0, w * 8.0, abs(fract(bands) - 0.5)))
+    * 0.20 * (1.0 - th.ink);
+
+  float body = line * mix(0.62, 0.84, th.ink) + gust;
+  vec3 col = th.grid * body + th.ring * bloom;
+  return vec4(col, clamp(body + bloom, 0.0, 1.0));
+}`;
+
+/* ------------------------------------------------------------- CROSSHATCH */
+
+const CROSSHATCH_PEN = `
+float hatch(vec2 uv, float ang, float freq, float weight) {
+  return ruled((rot(ang) * uv).y * freq, weight);
+}
+
+vec4 hero(vec2 uv, float t, Theme th) {
+  // One tonal field, three hatch passes gated on it — darker regions earn more
+  // layers, exactly the way pen shading builds up.
+  float shade = fbm(uv * 1.7 + vec2(t * 0.05, -t * 0.03));
+  shade = smoothstep(0.28, 0.78, shade);
+
+  float weight = mix(1.6, 1.0, th.ink);
+  float l1 = hatch(uv, 0.55, 40.0, weight) * step(0.12, shade);
+  float l2 = hatch(uv, -0.75, 36.0, weight) * step(0.42, shade);
+  float l3 = hatch(uv, 1.75, 32.0, weight) * step(0.70, shade);
+
+  float ink = clamp(l1 + l2 * 0.9 + l3 * 0.8, 0.0, 1.0);
+  float body = ink * mix(0.5, 0.78, th.ink);
+  float bloom = ink * shade * 0.20 * (1.0 - th.ink);
+
+  vec3 col = th.grid * body + th.ring * bloom;
+  return vec4(col, clamp(body + bloom, 0.0, 1.0));
+}`;
+
+const CROSSHATCH_ETCH = `
+vec4 hero(vec2 uv, float t, Theme th) {
+  // Engraving, not hatching: one direction throughout, and tone carried by how
+  // fat each line swells rather than by how many layers pile up. This is the
+  // banknote / line-engraving idiom, and it holds much finer detail.
+  float tone = fbm(uv * 1.5 + vec2(t * 0.045, -t * 0.02));
+  tone = smoothstep(0.22, 0.80, tone);
+
+  // Lines bow around the tonal field so the ruling describes a form.
+  float v = (rot(0.42) * uv).y * 46.0 + tone * 3.4;
+  float w = fwidth(v) * mix(0.35, 2.6, tone) * mix(1.3, 0.9, th.ink);
+  float line = 1.0 - smoothstep(0.0, w + 1e-6, abs(fract(v) - 0.5));
+
+  // A second ruling crosses only in the deepest darks, as an engraver would.
+  float cross = 1.0 - smoothstep(
+    0.0,
+    fwidth((rot(-1.15) * uv).y * 44.0) * 1.4 + 1e-6,
+    abs(fract((rot(-1.15) * uv).y * 44.0) - 0.5)
+  );
+  cross *= smoothstep(0.72, 0.95, tone);
+
+  float ink = clamp(line + cross * 0.85, 0.0, 1.0);
+  float body = ink * mix(0.55, 0.8, th.ink);
+  float bloom = ink * tone * 0.18 * (1.0 - th.ink);
+
+  vec3 col = th.grid * body + th.ring * bloom;
+  return vec4(col, clamp(body + bloom, 0.0, 1.0));
+}`;
+
+const CROSSHATCH_TOOTH = `
+float toothHatch(vec2 uv, float ang, float freq, float weight, float grain) {
+  // Push the ruling coordinate around with noise: the stroke wanders the way a
+  // nib does when it catches the tooth of the paper.
+  vec2 j = uv + grain * vec2(
+    valueNoise(uv * 7.0) - 0.5,
+    valueNoise(uv * 7.0 + 31.4) - 0.5
+  );
+  float v = (rot(ang) * j).y * freq;
+  float line = ruled(v, weight);
+
+  // Strokes lift off and land again instead of running edge to edge.
+  float along = (rot(ang) * j).x * freq * 0.32;
+  float breaks = smoothstep(0.30, 0.55, valueNoise(vec2(along, floor(v) * 3.1)));
+  return line * breaks;
+}
+
+vec4 hero(vec2 uv, float t, Theme th) {
+  float shade = fbm(uv * 1.6 + vec2(t * 0.04, -t * 0.025));
+  shade = smoothstep(0.26, 0.76, shade);
+
+  float weight = mix(1.7, 1.1, th.ink);
+  float grain = mix(0.010, 0.016, th.ink);
+  float l1 = toothHatch(uv, 0.50, 34.0, weight, grain) * step(0.14, shade);
+  float l2 = toothHatch(uv, -0.82, 30.0, weight, grain) * step(0.46, shade);
+  float l3 = toothHatch(uv, 1.66, 27.0, weight, grain) * step(0.74, shade);
+
+  float ink = clamp(l1 + l2 * 0.9 + l3 * 0.85, 0.0, 1.0);
+
+  // Paper takes a faint speckle in the untouched areas; black stays black.
+  float speck = step(0.965, hash21(floor(uv * 420.0))) * 0.20 * th.ink;
+
+  float body = ink * mix(0.52, 0.8, th.ink) + speck;
+  float bloom = ink * shade * 0.20 * (1.0 - th.ink);
+
+  vec3 col = th.grid * body + th.ring * bloom;
+  return vec4(col, clamp(body + bloom, 0.0, 1.0));
+}`;
+
+/* --------------------------------------------------------------- THE REST */
 
 const SYNTHWAVE = `
 float floorGrid(vec2 uv, float t) {
@@ -52,53 +252,6 @@ vec4 hero(vec2 uv, float t, Theme th) {
   vec3 col = th.grid * (g + horizonGlow) + th.ring * (core + bloom);
   float a = clamp(g + horizonGlow + core + bloom, 0.0, 1.0);
   return vec4(col, a);
-}`;
-
-const CONTOUR = `
-vec4 hero(vec2 uv, float t, Theme th) {
-  vec2 p = uv * 1.5 + vec2(t * 0.035, t * 0.018);
-  float h = fbm(p);
-  float bands = h * 17.0;
-
-  // Every fifth contour is an index line, drawn heavier — the convention a
-  // real map uses, and the thing that stops it reading as wallpaper.
-  float major = 1.0 - step(0.5, mod(floor(bands), 5.0));
-  float weight = mix(1.5, 0.85, th.ink) * mix(1.0, 2.1, major);
-  float line = ruled(bands, weight);
-
-  // Paper gets a whisper of tone between the lines; black gets a bloom.
-  float w = fwidth(bands);
-  float bloom = (1.0 - smoothstep(0.0, w * 7.0, abs(fract(bands) - 0.5)))
-    * 0.22 * (1.0 - th.ink);
-  float wash = smoothstep(0.35, 0.85, h) * 0.10 * th.ink;
-
-  float body = line * mix(0.6, 0.8, th.ink) + wash;
-  vec3 col = th.grid * body + th.ring * bloom;
-  return vec4(col, clamp(body + bloom, 0.0, 1.0));
-}`;
-
-const CROSSHATCH = `
-float hatch(vec2 uv, float ang, float freq, float weight) {
-  return ruled((rot(ang) * uv).y * freq, weight);
-}
-
-vec4 hero(vec2 uv, float t, Theme th) {
-  // One tonal field, three hatch passes gated on it — darker regions earn more
-  // layers, exactly the way pen shading builds up.
-  float shade = fbm(uv * 1.7 + vec2(t * 0.05, -t * 0.03));
-  shade = smoothstep(0.28, 0.78, shade);
-
-  float weight = mix(1.6, 1.0, th.ink);
-  float l1 = hatch(uv, 0.55, 40.0, weight) * step(0.12, shade);
-  float l2 = hatch(uv, -0.75, 36.0, weight) * step(0.42, shade);
-  float l3 = hatch(uv, 1.75, 32.0, weight) * step(0.70, shade);
-
-  float ink = clamp(l1 + l2 * 0.9 + l3 * 0.8, 0.0, 1.0);
-  float body = ink * mix(0.5, 0.78, th.ink);
-  float bloom = ink * shade * 0.20 * (1.0 - th.ink);
-
-  vec3 col = th.grid * body + th.ring * bloom;
-  return vec4(col, clamp(body + bloom, 0.0, 1.0));
 }`;
 
 const DOTMATRIX = `
@@ -195,7 +348,69 @@ vec4 hero(vec2 uv, float t, Theme th) {
   return vec4(col, clamp(body + headGlow, 0.0, 1.0));
 }`;
 
+const only = (hero: string): HeroVariant[] => [
+  { id: 'default', name: 'DEFAULT', note: '', hero },
+];
+
 export const HERO_IDEAS: HeroIdea[] = [
+  {
+    id: 'contour',
+    name: 'CONTOUR',
+    tagline: 'A drifting field read as elevation lines.',
+    terminal: 'Isolines glowing off a radar sweep.',
+    sketch: 'Ordnance-survey contours, index lines inked heavier.',
+    pivot:
+      'Line weight carries the depth on paper; brightness carries it on black.',
+    variants: [
+      {
+        id: 'drift',
+        name: 'DRIFT',
+        note: 'Smooth fbm, evenly spaced. The calm one.',
+        hero: CONTOUR_DRIFT,
+      },
+      {
+        id: 'ridge',
+        name: 'RIDGE',
+        note: 'Ridged noise — crests instead of domes, plus slope shading where the lines crowd.',
+        hero: CONTOUR_RIDGE,
+      },
+      {
+        id: 'isobar',
+        name: 'ISOBAR',
+        note: 'Synoptic chart: pressure centres, wider bands, wind hatching where isobars bunch.',
+        hero: CONTOUR_ISOBAR,
+      },
+    ],
+  },
+  {
+    id: 'crosshatch',
+    name: 'CROSSHATCH',
+    tagline: 'Pen shading driven by one tonal field.',
+    terminal: 'Angled neon rules, dense where the field is dark.',
+    sketch: 'Native. This is how a pen actually shades — it starts here.',
+    pivot:
+      'The paper-first idea. Black mode is the inversion, not the default.',
+    variants: [
+      {
+        id: 'pen',
+        name: 'PEN',
+        note: 'Three passes at fixed angles, gated on tone. Classic crosshatch.',
+        hero: CROSSHATCH_PEN,
+      },
+      {
+        id: 'etch',
+        name: 'ETCH',
+        note: 'Line engraving: one ruling whose strokes swell with tone, crossed only in the deepest darks.',
+        hero: CROSSHATCH_ETCH,
+      },
+      {
+        id: 'tooth',
+        name: 'TOOTH',
+        note: 'Strokes wander and break as a nib catches the paper, with a speckle in the untouched areas.',
+        hero: CROSSHATCH_TOOTH,
+      },
+    ],
+  },
   {
     id: 'synthwave',
     name: 'HORIZON',
@@ -204,27 +419,7 @@ export const HERO_IDEAS: HeroIdea[] = [
       'Neon grid receding into black, ring blooming like a light source.',
     sketch: 'Drafting-paper perspective study — ruled ink lines, no glow.',
     pivot: 'The bloom. On paper it becomes a heavier ink stroke instead.',
-    hero: SYNTHWAVE,
-  },
-  {
-    id: 'contour',
-    name: 'CONTOUR',
-    tagline: 'A drifting noise field read as elevation lines.',
-    terminal: 'Isolines glowing off a radar sweep.',
-    sketch: 'Ordnance-survey contours, every fifth line inked heavier.',
-    pivot:
-      'Line weight carries the depth on paper; brightness carries it on black.',
-    hero: CONTOUR,
-  },
-  {
-    id: 'crosshatch',
-    name: 'CROSSHATCH',
-    tagline: 'Pen shading: three hatch passes gated on one tonal field.',
-    terminal: 'Angled neon rules, dense where the field is dark.',
-    sketch: 'Native. This is how a pen actually shades — it starts here.',
-    pivot:
-      'The paper-first idea. Black mode is the inversion, not the default.',
-    hero: CROSSHATCH,
+    variants: only(SYNTHWAVE),
   },
   {
     id: 'dotmatrix',
@@ -234,24 +429,25 @@ export const HERO_IDEAS: HeroIdea[] = [
     sketch: 'Fine 45° print halftone — the screen a newspaper uses.',
     pivot:
       'The screen geometry itself: square and coarse against angled and fine.',
-    hero: DOTMATRIX,
+    variants: only(DOTMATRIX),
   },
   {
     id: 'scope',
     name: 'TRACE',
     tagline: 'Three waveforms over a graticule.',
     terminal: 'Oscilloscope phosphor, each trace smearing an afterglow.',
-    sketch: 'Seismograph pen on chart paper, complete with a wobble.',
-    pivot: 'Afterglow against pen wobble — each medium’s own imprecision.',
-    hero: SCOPE,
+    sketch: 'Seismograph pen on tinted chart stock, complete with a wobble.',
+    pivot:
+      'Accent and ink swap roles: lit beam on a dim grid, ink pen on tinted paper.',
+    variants: only(SCOPE),
   },
   {
     id: 'glyphrain',
     name: 'GLYPH_RAIN',
     tagline: 'Columns of hashed 5×6 bitmap glyphs falling.',
     terminal: 'Terminal rain, bright head, phosphor tail.',
-    sketch: 'Typewriter strike — inked or not, no half-tones, slower.',
+    sketch: 'Typewriter strike — inked or not, no half-tones.',
     pivot: 'Continuous fade against a hard stamp threshold.',
-    hero: GLYPHRAIN,
+    variants: only(GLYPHRAIN),
   },
 ];

--- a/components/hero/index.ts
+++ b/components/hero/index.ts
@@ -1,4 +1,4 @@
-export { HERO_IDEAS, type HeroIdea } from './ideas';
+export { HERO_IDEAS, type HeroIdea, type HeroVariant } from './ideas';
 export {
   default as ShaderStage,
   readColor,

--- a/components/hero/index.ts
+++ b/components/hero/index.ts
@@ -1,0 +1,8 @@
+export { HERO_IDEAS, type HeroIdea } from './ideas';
+export {
+  default as ShaderStage,
+  readColor,
+  SHADER_POSTLUDE,
+  SHADER_PRELUDE,
+  type ShaderStatus,
+} from './ShaderStage';

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -116,6 +116,11 @@ per-section accent rule, diagrams, search, talk widgets) lives in
 render in the **design sandbox** (`/design-sandbox`) and in Storybook
 (`pnpm storybook`, :6006).
 
+Whether the homepage hero should be drawn on the GPU — and what three.js /
+react-three-fiber would cost against a plain fragment shader — is measured in
+**[docs/hero-webgl-research.md](./hero-webgl-research.md)**, with a working
+prototype at `/design-sandbox/webgl-heroes`.
+
 ## Hosted Storybooks
 
 | URL | Shows |

--- a/docs/hero-webgl-research.md
+++ b/docs/hero-webgl-research.md
@@ -162,6 +162,27 @@ console errors, and the still-frame path confirmed by the status line.
 snapshot-tested. Constraint 3 above is the work that stands between this page
 and `pages/index.tsx`.
 
+## The lab
+
+[`pages/design-sandbox/hero-lab.tsx`](../pages/design-sandbox/hero-lab.tsx)
+takes the harness the prototype proved out and runs six generative ideas on it
+— HORIZON, CONTOUR, CROSSHATCH, DOT_MATRIX, TRACE, GLYPH_RAIN — each rendered
+so both themes are visible **at once**, split by a seam you can drag across the
+frame. One canvas draws both: the shader picks its palette *and its shading
+model* per pixel from which side of the seam it lands on.
+
+Judging a hero one theme at a time is how the grey-smudge version got as far as
+it did. Simultaneous is the only honest comparison when the two aesthetics are
+meant to be equals, and it turns the rule above into something you can see: on
+black the depth is carried by brightness, on paper by line weight; bloom
+becomes ink, a continuous fade becomes a hard stamp, a coarse LED screen
+becomes a fine 45° halftone. An idea that only survives on black is a failed
+idea for this site, however good it looks there.
+
+The shared harness is `components/hero/` — `ShaderStage` plus `ideas.ts`. Both
+sandbox pages run on it, so there is one implementation of the lifecycle
+concerns rather than one per prototype.
+
 ## If we adopt it
 
 1. Lift the shader hero out of the sandbox page into `components/`, loaded from

--- a/docs/hero-webgl-research.md
+++ b/docs/hero-webgl-research.md
@@ -1,0 +1,187 @@
+# Hero: WebGL research
+
+**Question.** The homepage hero (`components/CyberHero.tsx`) is a CSS/SVG
+perspective grid with a glowing ring. Should it be rebuilt on a 3D engine —
+three.js, or react-three-fiber on top of it — and what would that cost?
+
+**Verdict.** Not for the hero we have. The look is a *backdrop*, not a scene:
+one WebGL2 fragment shader reproduces it — with better lines than CSS
+transforms manage — for **0.8 KB gzip and no dependency**, against **127 KB
+gzip** for the smallest useful three.js. The working prototype is at
+[`/design-sandbox/webgl-heroes`](../pages/design-sandbox/webgl-heroes.tsx).
+three.js earns its weight the moment the hero wants *things in space* — loaded
+models, lighting, cameras that move, post-processing. Until it does, it is a
+56% increase in homepage JS for a background.
+
+## What the hero has to do here
+
+This is where the decision actually gets made; the bytes only break the tie.
+Any replacement inherits five constraints from the repo:
+
+1. **Dual-mode theming is non-negotiable.** `dark` / `dim` / `sketch` remap the
+   colour tokens themselves ([components/AGENTS.md](../components/AGENTS.md)),
+   and `CyberHero` already reads `--hero-grid`, `--hero-grid-strong`,
+   `--hero-ring`, `--hero-ring-glow`. A renderer that bakes its palette into
+   materials breaks sketch mode. Whatever draws the hero has to read the same
+   custom properties at runtime and re-read them when the theme class flips.
+2. **`prefers-reduced-motion` means *no loop*, not a slower one.** Every
+   interactive in `components/interactive/` honours it via `useReducedMotion`.
+   A hero should draw one still frame and never schedule a rAF.
+3. **The homepage is snapshot-tested** in four themes plus mobile and tablet
+   (`tests/visual.spec.ts`, `tests/visual-responsive.spec.ts`, 0.2% pixel
+   tolerance). An animated canvas is not deterministic across those runs. Any
+   shipped WebGL hero needs a time freeze (or a still first frame) under test —
+   this is the single largest piece of work in adopting one, and it is the same
+   work for every option below.
+4. **CSP already allows it.** WebGL needs no change to the policy in
+   `next.config.js`; there is no `blob:` worker and no external origin. A
+   loader-based three.js hero *would* need `connect-src`/`img-src` review if
+   assets came from anywhere but `self`.
+5. **Client-only.** The hero must load through `next/dynamic` with
+   `ssr: false`, like `SpectacleDeck` and the MDX interactives, so nothing
+   reaches the server render.
+
+## Measured cost
+
+Two independent measurements, both on this repo, August 2026 —
+`three@0.185.1`, `@react-three/fiber@9.7.0`, `ogl@1.0.11`.
+
+**Isolated library cost.** Each approach implements the same hero (grid, ring,
+animated glow); bundled with esbuild, minified, `react`/`react-dom` external:
+
+| Approach | minified | gzip | brotli |
+| --- | ---: | ---: | ---: |
+| raw WebGL2, no library | 1.3 KB | **0.8 KB** | 0.7 KB |
+| `ogl` | 44.1 KB | **13.0 KB** | 11.0 KB |
+| `three` | 511.9 KB | **129.6 KB** | 106.8 KB |
+| `@react-three/fiber` + `three` | 878.5 KB | **237.9 KB** | 195.7 KB |
+
+**In the real build.** A three.js hero wired onto `pages/index.tsx` through
+`next/dynamic({ ssr: false })` and built with `next build` (Turbopack):
+
+| Build | Homepage first-load JS | Lazy hero chunk |
+| --- | ---: | ---: |
+| `main` today | 229.9 KB gzip (747.8 KB raw) | — |
+| + three.js hero, named imports | 231.3 KB gzip | **127.2 KB gzip** (514 KB raw) |
+| + three.js hero, `import * as THREE` | 231.3 KB gzip | **178.9 KB gzip** (708 KB raw) |
+
+Three things fall out of that table:
+
+- **`next/dynamic` moves the cost, it does not remove it.** First-load JS barely
+  changes (+1.4 KB, the loader stub) because the chunk is deferred — but it is
+  requested on the homepage immediately after hydration, by every visitor, on
+  the one route where bounce matters most. Deferred is not free.
+- **`import * as THREE` costs 52 KB gzip for nothing.** Turbopack tree-shakes
+  three respectably (127 KB) when you destructure named exports, and not at all
+  when you take the namespace. If three.js is ever adopted here, that is a lint
+  rule waiting to be written.
+- **three barely shrinks with scene complexity.** The 127 KB is the renderer
+  core; the grid and ring in the prototype are rounding error against it. There
+  is no "small three.js" for a small scene.
+
+Reproduce with `scripts/`-free steps: bundle the four entry points in
+`docs/` order with esbuild (`--bundle --minify --format=esm`), and for the
+in-app numbers sum the gzip of `.next/build-manifest.json`'s entries for `/`.
+
+## What three.js would actually buy
+
+Worth being fair to it — the reasons to pay 127 KB are real, they are just not
+present in the current design:
+
+- A **loaded model** (`GLTFLoader`) — a logo, a mesh, anything authored outside
+  the shader. Reimplementing glTF parsing is not a trade anyone should make.
+- **Lighting and materials** you want to reason about physically, rather than
+  hand-rolling in GLSL.
+- **A camera that moves** through a scene with depth sorting, or an
+  `OrbitControls`-style interaction.
+- **Post-processing chains** (bloom on the ring, film grain) — `EffectComposer`
+  is a lot of machinery to rebuild.
+- **Ecosystem**: drei's helpers, and the fact that the next person to touch it
+  will have seen react-three-fiber before, but not this shader.
+
+react-three-fiber adds a further ~108 KB gzip on top of three (its own React
+reconciler, `zustand`, `suspend-react`). It pays for itself when the scene is a
+component tree that reacts to state — not for a fire-and-forget backdrop. It is
+current with the stack here: r3f v9 pairs with React 19, which this repo is on.
+
+`ogl` is the sensible middle: a thin, tree-shakeable WebGL wrapper at 13 KB
+gzip. Reach for it if the hero grows real geometry, buffers and transforms but
+still doesn't need a renderer with a scene graph, materials and loaders.
+
+## The prototype
+
+[`pages/design-sandbox/webgl-heroes.tsx`](../pages/design-sandbox/webgl-heroes.tsx)
+— one WebGL2 fragment shader drawing a perspective floor grid, a horizon glow
+and a pulsing ring, plus the cost table above rendered from the same numbers.
+
+It deliberately carries the production-shaped concerns, not just the pretty
+part, because those are what any of these options would have to solve:
+
+- Colours come from `--hero-grid-strong` and `--hero-ring` as uniforms, re-read
+  through a `MutationObserver` on the theme class — so HIGH / DIM / SKETCH all
+  work off the design system rather than a baked palette.
+- `prefers-reduced-motion` draws a single still frame and never starts a rAF;
+  the media query is watched, so toggling it mid-session takes effect.
+- An `IntersectionObserver` and `visibilitychange` park the loop when the hero
+  scrolls away or the tab is backgrounded.
+- DPR-aware sizing capped at 2×, via `ResizeObserver`.
+- No WebGL2, a failed shader compile, or a lost context falls back to the CSS
+  grid backdrop, and the canvas is `aria-hidden` throughout.
+
+Anti-aliased grid lines use `fwidth()` derivatives, which is why the receding
+lines stay one pixel wide instead of shimmering the way the CSS
+`perspective()` transform does at the horizon.
+
+### Three things building it turned up
+
+These apply to *any* of the options above, three.js included — they are
+properties of this design system meeting a GPU, not of the shader:
+
+- **Recolouring is not enough to theme a hero; the shading model has to
+  change.** A glow is additive light, and light on paper reads as a smudge. The
+  first sketch-mode render was a grey blob around the ring. The prototype now
+  takes an `uInk` uniform off the background token's luminance and swaps bloom
+  for a weightier ink stroke. In three.js the same problem arrives as
+  "which material", and is more work, not less.
+- **Design tokens do not come back in the form they were written.**
+  `--hero-grid-strong` is authored as `rgba(35, 38, 46, 0.14)` and
+  `getComputedStyle` returns `#23262e24`. A parser that only knows 3- and
+  6-digit hex plus `rgb()` silently falls through to its fallback — which is
+  precisely how the paper grid came out neon green for one build.
+- **The dark themes leave `--hero-*` unset on purpose.** `CyberHero` carries the
+  neon values as inline `var()` fallbacks and `.sketch` is the mode that
+  overrides them. Anything reading these tokens has to carry the same
+  fallbacks, or dark mode gets nothing.
+
+**Verified**, not asserted: rendered in headless Chromium (SwiftShader) at
+1280×900 on the production build, in the default dark theme, in `.sketch`, and
+under `prefers-reduced-motion: reduce` — WebGL2 context in all three, no
+console errors, and the still-frame path confirmed by the status line.
+
+**What it is not:** it is not wired into the homepage, and it is not
+snapshot-tested. Constraint 3 above is the work that stands between this page
+and `pages/index.tsx`.
+
+## If we adopt it
+
+1. Lift the shader hero out of the sandbox page into `components/`, loaded from
+   `pages/index.tsx` via `next/dynamic` with `ssr: false`.
+2. Solve the visual-regression problem: freeze the clock under test (a
+   `?static` query param, or draw the still frame whenever
+   `navigator.webdriver`), then regenerate the homepage snapshots on CI —
+   `pnpm test:snapshots:remote`, never locally.
+3. Story it, since a story is a test here
+   ([tests/AGENTS.md](../tests/AGENTS.md)) — mount it in both themes and let the
+   a11y addon check the fallback.
+4. Keep `CyberHero` as the no-WebGL fallback rather than deleting it; the CSS
+   backdrop in the prototype is a stand-in for exactly that.
+5. Re-measure. The claim is that the hero gets *cheaper*, and that should be
+   visible in first-load JS, not asserted.
+
+## Open
+
+- Whether the hero should change at all is a design call, not a technical one —
+  this documents what it would cost, not that it is wanted.
+- If a 3D *object* (a rotating logo, say) is the actual goal, this verdict
+  flips: that is `ogl` at minimum, and three.js if the object is authored
+  anywhere but in code.

--- a/docs/hero-webgl-research.md
+++ b/docs/hero-webgl-research.md
@@ -183,6 +183,17 @@ The shared harness is `components/hero/` — `ShaderStage` plus `ideas.ts`. Both
 sandbox pages run on it, so there is one implementation of the lifecycle
 concerns rather than one per prototype.
 
+**A fourth finding came out of running six of them.** A generative field is not
+a flat backdrop, and hero type will lose to it: the subtitle is
+`--brutalist-cyan`, which measures 10:1 against the hero background on black
+and 5.5:1 on paper — comfortably legible on paper stock, and completely
+unreadable where a bright contour line crosses the same pixels. Contrast
+against the *background colour* says nothing about contrast against the
+*content*. So the knock-back is in the harness rather than in each idea: every
+shader fades its own field to 13% inside a feathered box across the middle. It
+is a property of putting words on generated imagery, so it belongs to whatever
+draws it — a three.js hero would need exactly the same thing.
+
 ## If we adopt it
 
 1. Lift the shader hero out of the sandbox page into `components/`, loaded from

--- a/pages/design-sandbox/hero-lab.tsx
+++ b/pages/design-sandbox/hero-lab.tsx
@@ -88,13 +88,24 @@ function useDragSplit(initial: number) {
   return { split, setSplit, frameRef, onPointerDown, onKeyDown };
 }
 
-function IdeaCard({ idea, index }: { idea: HeroIdea; index: number }) {
+function IdeaCard({
+  idea,
+  index,
+  safe,
+}: {
+  idea: HeroIdea;
+  index: number;
+  safe: boolean;
+}) {
   // Stagger the openings so a page of cards does not read as one grid of
   // identical wipes.
   const { split, frameRef, onPointerDown, onKeyDown } = useDragSplit(
     0.42 + ((index * 0.07) % 0.18),
   );
   const [status, setStatus] = useState<ShaderStatus>('pending');
+  const [variantId, setVariantId] = useState(idea.variants[0].id);
+  const variant =
+    idea.variants.find((v) => v.id === variantId) ?? idea.variants[0];
   const pct = `${(split * 100).toFixed(2)}%`;
 
   return (
@@ -105,6 +116,30 @@ function IdeaCard({ idea, index }: { idea: HeroIdea; index: number }) {
         </h2>
         <p className="font-mono text-xs text-zinc-400">{idea.tagline}</p>
       </header>
+
+      {idea.variants.length > 1 && (
+        <div className="flex flex-wrap items-center gap-2 border-b-2 border-white px-4 py-3">
+          {idea.variants.map((v) => {
+            const active = v.id === variant.id;
+            return (
+              <button
+                key={v.id}
+                type="button"
+                onClick={() => setVariantId(v.id)}
+                aria-pressed={active}
+                className={`border-2 px-3 py-1 font-mono text-xs uppercase tracking-widest transition-colors ${
+                  active
+                    ? 'border-brutalist-cyan bg-brutalist-cyan text-black'
+                    : 'border-zinc-700 text-zinc-400 hover:border-brutalist-cyan hover:text-white'
+                }`}
+              >
+                {v.name}
+              </button>
+            );
+          })}
+          <p className="font-mono text-xs text-zinc-400">{variant.note}</p>
+        </div>
+      )}
 
       <div
         ref={frameRef}
@@ -129,9 +164,10 @@ function IdeaCard({ idea, index }: { idea: HeroIdea; index: number }) {
         />
 
         <ShaderStage
-          hero={idea.hero}
+          hero={variant.hero}
           mode="split"
           split={split}
+          safe={safe}
           onStatus={setStatus}
           className="absolute inset-0 h-full w-full"
         />
@@ -230,6 +266,8 @@ function HeroLockup() {
 }
 
 export default function HeroLab() {
+  const [safe, setSafe] = useState(true);
+
   return (
     <>
       <PageSEO
@@ -280,8 +318,28 @@ export default function HeroLab() {
             </p>
           </div>
 
+          <div className="flex flex-wrap items-center gap-3 border-2 border-white bg-zinc-900 p-4">
+            <button
+              type="button"
+              onClick={() => setSafe((s) => !s)}
+              aria-pressed={safe}
+              className={`border-2 px-3 py-1 font-mono text-xs uppercase tracking-widest transition-colors ${
+                safe
+                  ? 'border-brutalist-yellow bg-brutalist-yellow text-black'
+                  : 'border-zinc-700 text-zinc-400 hover:border-brutalist-yellow hover:text-white'
+              }`}
+            >
+              type safe area: {safe ? 'on' : 'off'}
+            </button>
+            <p className="font-mono text-xs text-zinc-400">
+              {'>'} Each shader fades its own field to 13% behind the lockup.
+              Turn it off to see the raw field — and to see why accent-coloured
+              type at this size loses to a bright line crossing the same pixels.
+            </p>
+          </div>
+
           {HERO_IDEAS.map((idea, index) => (
-            <IdeaCard key={idea.id} idea={idea} index={index} />
+            <IdeaCard key={idea.id} idea={idea} index={index} safe={safe} />
           ))}
 
           <div className="border-2 border-brutalist-yellow bg-zinc-900 p-6">

--- a/pages/design-sandbox/hero-lab.tsx
+++ b/pages/design-sandbox/hero-lab.tsx
@@ -1,0 +1,307 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  HERO_IDEAS,
+  type HeroIdea,
+  ShaderStage,
+  type ShaderStatus,
+} from '@/components/hero';
+import Link from '@/components/Link';
+import PageHeader from '@/components/PageHeader';
+import { PageSEO } from '@/components/SEO';
+import siteMetadata from '@/data/siteMetadata';
+
+/**
+ * Hero lab.
+ *
+ * Six generative hero ideas, each rendered so that the neon-terminal reading
+ * and the sketch reading are visible *at the same time*, split by a divider you
+ * can drag across the frame.
+ *
+ * That framing is the point. Judging a hero one theme at a time is how you end
+ * up with a design that looks great on black and like a smudge on paper — the
+ * two aesthetics here are meant to be equals, so the comparison has to be
+ * simultaneous. One canvas draws both: the shader picks its palette *and its
+ * shading model* per pixel from which side of the split it lands on.
+ *
+ * Costs and the case against a 3D engine: docs/hero-webgl-research.md.
+ */
+
+const CLAMP = (n: number) => Math.min(0.95, Math.max(0.05, n));
+
+function useDragSplit(initial: number) {
+  const [split, setSplit] = useState(initial);
+  const frameRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef(false);
+
+  const fromClientX = useCallback((clientX: number) => {
+    const rect = frameRef.current?.getBoundingClientRect();
+    if (!rect || rect.width === 0) return null;
+    return CLAMP((clientX - rect.left) / rect.width);
+  }, []);
+
+  useEffect(() => {
+    const move = (event: PointerEvent) => {
+      if (!draggingRef.current) return;
+      const next = fromClientX(event.clientX);
+      if (next !== null) setSplit(next);
+    };
+    const up = () => {
+      draggingRef.current = false;
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+    window.addEventListener('pointercancel', up);
+    return () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+      window.removeEventListener('pointercancel', up);
+    };
+  }, [fromClientX]);
+
+  const onPointerDown = useCallback(
+    (event: React.PointerEvent) => {
+      draggingRef.current = true;
+      const next = fromClientX(event.clientX);
+      if (next !== null) setSplit(next);
+    },
+    [fromClientX],
+  );
+
+  const onKeyDown = useCallback((event: React.KeyboardEvent) => {
+    const step =
+      event.key === 'ArrowLeft' ? -0.04 : event.key === 'ArrowRight' ? 0.04 : 0;
+    if (step !== 0) {
+      event.preventDefault();
+      setSplit((s) => CLAMP(s + step));
+      return;
+    }
+    if (event.key === 'Home') {
+      event.preventDefault();
+      setSplit(0.05);
+    }
+    if (event.key === 'End') {
+      event.preventDefault();
+      setSplit(0.95);
+    }
+  }, []);
+
+  return { split, setSplit, frameRef, onPointerDown, onKeyDown };
+}
+
+function IdeaCard({ idea, index }: { idea: HeroIdea; index: number }) {
+  // Stagger the openings so a page of cards does not read as one grid of
+  // identical wipes.
+  const { split, frameRef, onPointerDown, onKeyDown } = useDragSplit(
+    0.42 + ((index * 0.07) % 0.18),
+  );
+  const [status, setStatus] = useState<ShaderStatus>('pending');
+  const pct = `${(split * 100).toFixed(2)}%`;
+
+  return (
+    <section className="border-2 border-white bg-black">
+      <header className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 border-b-2 border-white px-4 py-3">
+        <h2 className="font-display text-xl font-bold uppercase text-white">
+          [ {idea.name} ]
+        </h2>
+        <p className="font-mono text-xs text-zinc-400">{idea.tagline}</p>
+      </header>
+
+      <div
+        ref={frameRef}
+        className="relative h-[42vh] min-h-[260px] w-full touch-none overflow-hidden select-none"
+      >
+        {/* Two backdrops, clipped to meet at the split. The theme classes carry
+            the token remap, so everything inside each half — background, text,
+            accents — is genuinely that theme rather than an approximation. */}
+        <div
+          className="dark absolute inset-0"
+          style={{
+            background: 'var(--brutalist-darkBg, #0a0a1a)',
+            clipPath: `inset(0 ${100 - split * 100}% 0 0)`,
+          }}
+        />
+        <div
+          className="sketch absolute inset-0"
+          style={{
+            background: 'var(--brutalist-darkBg, #eceadf)',
+            clipPath: `inset(0 0 0 ${pct})`,
+          }}
+        />
+
+        <ShaderStage
+          hero={idea.hero}
+          mode="split"
+          split={split}
+          onStatus={setStatus}
+          className="absolute inset-0 h-full w-full"
+        />
+
+        {/* The hero's own words, drawn twice and clipped to match, so the type
+            is judged in the same breath as the background behind it. */}
+        <div
+          className="dark pointer-events-none absolute inset-0"
+          style={{ clipPath: `inset(0 ${100 - split * 100}% 0 0)` }}
+        >
+          <HeroLockup />
+          <span className="absolute left-3 top-3 font-mono text-[10px] uppercase tracking-widest text-zinc-400">
+            terminal
+          </span>
+        </div>
+        <div
+          className="sketch pointer-events-none absolute inset-0"
+          style={{ clipPath: `inset(0 0 0 ${pct})` }}
+        >
+          <HeroLockup />
+          <span className="absolute right-3 top-3 font-mono text-[10px] uppercase tracking-widest text-zinc-400">
+            sketch
+          </span>
+        </div>
+
+        {/* A full-height drag seam over a canvas; a range input cannot be
+            shaped like this, so it carries the slider role by hand. */}
+        <div
+          role="slider"
+          tabIndex={0}
+          aria-label={`${idea.name}: terminal / sketch split`}
+          aria-valuemin={5}
+          aria-valuemax={95}
+          aria-valuenow={Math.round(split * 100)}
+          aria-valuetext={`${Math.round(split * 100)}% terminal`}
+          onPointerDown={onPointerDown}
+          onKeyDown={onKeyDown}
+          className="absolute inset-y-0 z-10 w-8 -translate-x-1/2 cursor-ew-resize focus:outline-none"
+          style={{ left: pct }}
+        >
+          <span className="absolute inset-y-0 left-1/2 w-0.5 -translate-x-1/2 bg-white mix-blend-difference" />
+          <span className="absolute left-1/2 top-1/2 h-8 w-8 -translate-x-1/2 -translate-y-1/2 border-2 border-white bg-black" />
+          <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 font-mono text-[11px] leading-none text-white">
+            {'<>'}
+          </span>
+        </div>
+
+        {status === 'unsupported' && (
+          <p className="absolute bottom-3 left-3 font-mono text-xs text-brutalist-yellow">
+            {'>'} no webgl2 — a shipped hero falls back to CSS here
+          </p>
+        )}
+      </div>
+
+      <dl className="grid gap-x-6 gap-y-2 px-4 py-4 font-mono text-sm sm:grid-cols-3">
+        <Reading term="ON BLACK" value={idea.terminal} />
+        <Reading term="ON PAPER" value={idea.sketch} />
+        <Reading term="WHAT FLIPS" value={idea.pivot} accent />
+      </dl>
+    </section>
+  );
+}
+
+function Reading({
+  term,
+  value,
+  accent,
+}: {
+  term: string;
+  value: string;
+  accent?: boolean;
+}) {
+  return (
+    <div>
+      <dt
+        className={`text-xs uppercase tracking-widest ${accent ? 'text-brutalist-yellow' : 'text-brutalist-cyan'}`}
+      >
+        {term}
+      </dt>
+      <dd className="mt-1 text-zinc-400">{value}</dd>
+    </div>
+  );
+}
+
+function HeroLockup() {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
+      <p className="font-display text-3xl font-bold uppercase text-white md:text-5xl">
+        RYAN KELLY
+      </p>
+      <p className="mt-2 font-mono text-xs text-brutalist-cyan md:text-sm">
+        FULL_STACK_ENGINEER.exe
+      </p>
+    </div>
+  );
+}
+
+export default function HeroLab() {
+  return (
+    <>
+      <PageSEO
+        title={`Hero Lab - ${siteMetadata.author}`}
+        description="Generative hero ideas, each judged in neon-terminal and sketch at the same time"
+      />
+      <div className="divide-y divide-white border-2 border-white bg-black">
+        <PageHeader
+          title="HERO_LAB"
+          subtitle="Generative hero ideas, both themes at once — drag the seam"
+        />
+
+        <div className="container space-y-10 py-12">
+          <div className="border-2 border-brutalist-cyan bg-zinc-900 p-6">
+            <p className="font-mono text-sm leading-relaxed text-white">
+              {'>'} Every frame below is <strong>one</strong> canvas. The shader
+              picks its palette and its shading model per pixel, from which side
+              of the seam that pixel lands on — left is neon-terminal, right is
+              sketch.
+            </p>
+            <p className="mt-3 font-mono text-sm leading-relaxed text-zinc-400">
+              {'>'} Drag the seam (or focus it and use ←/→) to slide one theme
+              over the other.
+              <br />
+              {'>'} Colours are measured off real elements carrying the{' '}
+              <span className="text-white">.dark</span> and{' '}
+              <span className="text-white">.sketch</span> classes, so these are
+              the actual design-system tokens, not approximations of them.
+              <br />
+              {'>'} Reduced motion draws one still frame with no animation loop;
+              each canvas parks itself when scrolled out of view.
+              <br />
+              {'>'} Weights and the case against a 3D engine live in{' '}
+              <Link
+                href="https://github.com/rtkelly13/blog/blob/main/docs/hero-webgl-research.md"
+                className="text-brutalist-cyan"
+              >
+                docs/hero-webgl-research.md
+              </Link>
+              ; the single-hero prototype is at{' '}
+              <Link
+                href="/design-sandbox/webgl-heroes"
+                className="text-brutalist-cyan"
+              >
+                webgl-heroes
+              </Link>
+              .
+            </p>
+          </div>
+
+          {HERO_IDEAS.map((idea, index) => (
+            <IdeaCard key={idea.id} idea={idea} index={index} />
+          ))}
+
+          <div className="border-2 border-brutalist-yellow bg-zinc-900 p-6">
+            <h2 className="mb-4 font-display text-xl font-bold uppercase text-brutalist-yellow">
+              [ THE_RULE_THESE_TEST ]
+            </h2>
+            <p className="font-mono text-sm leading-relaxed text-zinc-400">
+              {'>'} Recolouring is not theming. A glow is <em>added light</em>,
+              and added light on paper reads as a thumbprint — so every idea
+              here swaps its shading model at the seam, not just its palette:
+              bloom becomes ink weight, a continuous fade becomes a hard stamp,
+              a coarse LED screen becomes a fine 45° halftone.
+              <br />
+              {'>'} An idea that only survives on black is a failed idea for
+              this site, however good it looks there. Drag the seam past the
+              middle and see which ones hold.
+            </p>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/pages/design-sandbox/index.tsx
+++ b/pages/design-sandbox/index.tsx
@@ -8,6 +8,7 @@ import {
   Image as ImageIcon,
   type LucideIcon,
   MousePointerClick,
+  Orbit,
   Tags as TagsIcon,
   Type,
 } from 'lucide-react';
@@ -33,6 +34,13 @@ const components: {
     path: '/design-sandbox/homepage-heroes',
     description: 'Synth wave heroes for landing pages',
     icon: ImageIcon,
+  },
+  {
+    name: 'WebGL Heroes',
+    path: '/design-sandbox/webgl-heroes',
+    description:
+      'Shader-driven hero prototype, and what a 3D engine would cost',
+    icon: Orbit,
   },
   {
     name: 'Article Heroes',

--- a/pages/design-sandbox/index.tsx
+++ b/pages/design-sandbox/index.tsx
@@ -9,6 +9,7 @@ import {
   type LucideIcon,
   MousePointerClick,
   Orbit,
+  Rows3,
   Tags as TagsIcon,
   Type,
 } from 'lucide-react';
@@ -34,6 +35,12 @@ const components: {
     path: '/design-sandbox/homepage-heroes',
     description: 'Synth wave heroes for landing pages',
     icon: ImageIcon,
+  },
+  {
+    name: 'Hero Lab',
+    path: '/design-sandbox/hero-lab',
+    description: 'Generative hero ideas, neon-terminal and sketch side by side',
+    icon: Rows3,
   },
   {
     name: 'WebGL Heroes',

--- a/pages/design-sandbox/webgl-heroes.tsx
+++ b/pages/design-sandbox/webgl-heroes.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
+import { HERO_IDEAS, ShaderStage, type ShaderStatus } from '@/components/hero';
 import Link from '@/components/Link';
 import PageHeader from '@/components/PageHeader';
 import { PageSEO } from '@/components/SEO';
@@ -13,331 +14,12 @@ import siteMetadata from '@/data/siteMetadata';
  * a fraction of the bytes? Measurements and the verdict live in
  * docs/hero-webgl-research.md; this page is the working end of it.
  *
- * The prototype deliberately carries the production-shaped concerns rather
- * than just the pretty part, because those are what the comparison turns on:
- * design-system tokens read at runtime (so dark / dim / sketch all work), a
- * reduced-motion path that renders one still frame, pausing when off-screen or
- * backgrounded, DPR-aware resize, and a CSS fallback when WebGL is missing or
- * the context is lost.
+ * Here the hero follows the page's own theme, the way a shipped one would.
+ * To see an idea's two readings side by side, and five more ideas besides,
+ * go to /design-sandbox/hero-lab.
  */
 
-const VERT = `#version 300 es
-in vec2 aPos;
-void main() { gl_Position = vec4(aPos, 0.0, 1.0); }`;
-
-/**
- * Grid + horizon glow + ring, all procedural. Colours arrive as uniforms so the
- * shader never hardcodes the palette — the theme owns it.
- */
-const FRAG = `#version 300 es
-precision highp float;
-
-uniform vec2  uRes;
-uniform float uTime;
-uniform vec3  uGrid;
-uniform vec3  uRing;
-uniform float uMotion;   // 1 = animated, 0 = reduced motion (still frame)
-uniform float uInk;      // 0 = glow on a dark surface, 1 = ink on paper
-
-out vec4 outColor;
-
-// Perspective floor grid: project screen space onto a plane below the horizon,
-// then draw anti-aliased lines with derivative-based width so the lines stay
-// one pixel wide as they recede instead of aliasing into noise.
-float floorGrid(vec2 uv, float t) {
-  float horizon = uv.y + 0.16;
-  if (horizon >= -0.001) return 0.0;
-
-  vec2 plane = vec2(uv.x / -horizon, (0.5 / -horizon) + t * 0.25);
-  vec2 cell = abs(fract(plane) - 0.5);
-  vec2 w = fwidth(plane);
-  vec2 line = smoothstep(w * 1.5, vec2(0.0), cell);
-  float g = max(line.x, line.y);
-
-  // Fade the far field so the grid dissolves into the background.
-  return g * smoothstep(0.0, 0.22, -horizon);
-}
-
-// On a dark surface the ring is a light source, so it blooms. On paper a bloom
-// reads as a smudge — there the ring becomes a weightier ink stroke instead.
-float ring(vec2 uv, float pulse, float ink) {
-  float d = abs(length(uv * vec2(1.0, 1.25)) - 0.30);
-  float core = smoothstep(mix(0.010, 0.016, ink), 0.002, d);
-  float glow = smoothstep(0.180, 0.0, d) * 0.35 * (1.0 - ink);
-  return core + glow * pulse;
-}
-
-void main() {
-  vec2 uv = (gl_FragCoord.xy - 0.5 * uRes) / uRes.y;
-  float t = uTime * uMotion;
-
-  float g = floorGrid(uv, t) * mix(0.55, 0.75, uInk);
-  float pulse = 0.75 + 0.25 * sin(t * 1.2);
-  float r = ring(uv, pulse, uInk);
-
-  // A soft band of light sitting on the horizon line, tying grid to ring —
-  // light only, so paper gets none of it.
-  float horizonGlow =
-    smoothstep(0.12, 0.0, abs(uv.y + 0.16)) * 0.25 * (1.0 - uInk);
-
-  vec3 col = uGrid * (g + horizonGlow) + uRing * r;
-  float alpha = clamp(g + horizonGlow + r, 0.0, 1.0);
-  outColor = vec4(col * alpha, alpha);
-}`;
-
-/**
- * Turn a computed CSS colour into 0..1 RGB, dropping alpha — the shader owns
- * opacity. Browsers do not hand these back in the form the stylesheet wrote
- * them: `rgba(35, 38, 46, 0.14)` comes out of `getComputedStyle` as the
- * 8-digit hex `#23262e24`, so every notation has to be handled or the token
- * silently falls through to the fallback.
- */
-function readColor(value: string, fallback: [number, number, number]) {
-  const hex = value.trim().match(/^#([0-9a-f]{3,8})$/i);
-  if (hex) {
-    const h = hex[1];
-    const full =
-      h.length <= 4
-        ? h
-            .slice(0, 3)
-            .split('')
-            .map((c) => c + c)
-            .join('')
-        : h.slice(0, 6);
-    return [0, 2, 4].map(
-      (i) => Number.parseInt(full.slice(i, i + 2), 16) / 255,
-    ) as [number, number, number];
-  }
-  const rgb = value.match(/rgba?\(([^)]+)\)/i);
-  if (rgb) {
-    const parts = rgb[1]
-      .split(/[,\s/]+/)
-      .filter(Boolean)
-      .map(Number);
-    if (
-      parts.length >= 3 &&
-      parts.slice(0, 3).every((n) => Number.isFinite(n))
-    ) {
-      return [parts[0] / 255, parts[1] / 255, parts[2] / 255] as [
-        number,
-        number,
-        number,
-      ];
-    }
-  }
-  return fallback;
-}
-
-function compile(gl: WebGL2RenderingContext, type: number, src: string) {
-  const shader = gl.createShader(type);
-  if (!shader) return null;
-  gl.shaderSource(shader, src);
-  gl.compileShader(shader);
-  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-    gl.deleteShader(shader);
-    return null;
-  }
-  return shader;
-}
-
-/**
- * Compile, link and activate the shader pair. Returns null on any failure so
- * the caller can drop straight to the CSS fallback.
- */
-function createProgram(gl: WebGL2RenderingContext) {
-  const program = gl.createProgram();
-  const vs = compile(gl, gl.VERTEX_SHADER, VERT);
-  const fs = compile(gl, gl.FRAGMENT_SHADER, FRAG);
-  if (!program || !vs || !fs) return null;
-
-  gl.attachShader(program, vs);
-  gl.attachShader(program, fs);
-  gl.linkProgram(program);
-  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-    gl.deleteProgram(program);
-    return null;
-  }
-  // biome-ignore lint/correctness/useHookAtTopLevel: gl.useProgram is a WebGL call, not a React hook
-  gl.useProgram(program);
-  return { program, vs, fs };
-}
-
-type Status = 'pending' | 'running' | 'still' | 'unsupported';
-
-function useShaderHero(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
-  const [status, setStatus] = useState<Status>('pending');
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-
-    const gl = canvas.getContext('webgl2', {
-      alpha: true,
-      antialias: false,
-      powerPreference: 'low-power',
-    });
-    if (!gl) {
-      setStatus('unsupported');
-      return;
-    }
-
-    const built = createProgram(gl);
-    if (!built) {
-      setStatus('unsupported');
-      return;
-    }
-    const { program, vs, fs } = built;
-
-    // One full-screen triangle — cheaper than a quad and needs no index buffer.
-    const buffer = gl.createBuffer();
-    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-    gl.bufferData(
-      gl.ARRAY_BUFFER,
-      new Float32Array([-1, -1, 3, -1, -1, 3]),
-      gl.STATIC_DRAW,
-    );
-    const aPos = gl.getAttribLocation(program, 'aPos');
-    gl.enableVertexAttribArray(aPos);
-    gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0);
-
-    gl.enable(gl.BLEND);
-    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
-
-    const uRes = gl.getUniformLocation(program, 'uRes');
-    const uTime = gl.getUniformLocation(program, 'uTime');
-    const uGrid = gl.getUniformLocation(program, 'uGrid');
-    const uRing = gl.getUniformLocation(program, 'uRing');
-    const uMotion = gl.getUniformLocation(program, 'uMotion');
-    const uInk = gl.getUniformLocation(program, 'uInk');
-
-    // The design system owns the palette: read the same custom properties
-    // CyberHero uses, and re-read them when the theme class flips.
-    // The dark themes deliberately leave --hero-* unset and lean on the inline
-    // fallbacks (CyberHero does the same); sketch is the mode that overrides
-    // them. So the fallbacks below are the neon palette, not a safety net.
-    const applyTheme = () => {
-      const styles = getComputedStyle(document.documentElement);
-      const grid = readColor(
-        styles.getPropertyValue('--hero-grid-strong'),
-        [0.22, 1.0, 0.08],
-      );
-      const ring = readColor(
-        styles.getPropertyValue('--hero-ring'),
-        [0.53, 0.94, 0.68],
-      );
-      const bg = readColor(
-        styles.getPropertyValue('--brutalist-darkBg'),
-        [0.04, 0.04, 0.04],
-      );
-      gl.uniform3f(uGrid, grid[0], grid[1], grid[2]);
-      gl.uniform3f(uRing, ring[0], ring[1], ring[2]);
-      // Sketch mode remaps the hero background to paper. Glow is a dark-surface
-      // idiom, so the luminance of that token decides which one we draw.
-      const luminance = 0.2126 * bg[0] + 0.7152 * bg[1] + 0.0722 * bg[2];
-      gl.uniform1f(uInk, luminance > 0.5 ? 1 : 0);
-    };
-    applyTheme();
-
-    const themeObserver = new MutationObserver(applyTheme);
-    themeObserver.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['class', 'style', 'data-theme'],
-    });
-
-    const resize = () => {
-      const dpr = Math.min(window.devicePixelRatio || 1, 2);
-      const w = Math.max(1, Math.round(canvas.clientWidth * dpr));
-      const h = Math.max(1, Math.round(canvas.clientHeight * dpr));
-      if (canvas.width !== w || canvas.height !== h) {
-        canvas.width = w;
-        canvas.height = h;
-        gl.viewport(0, 0, w, h);
-      }
-      gl.uniform2f(uRes, canvas.width, canvas.height);
-    };
-    resize();
-    const resizeObserver = new ResizeObserver(resize);
-    resizeObserver.observe(canvas);
-
-    const draw = (seconds: number) => {
-      gl.uniform1f(uTime, seconds);
-      gl.clearColor(0, 0, 0, 0);
-      gl.clear(gl.COLOR_BUFFER_BIT);
-      gl.drawArrays(gl.TRIANGLES, 0, 3);
-    };
-
-    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    let raf = 0;
-    let visible = true;
-    let start = performance.now();
-
-    const stop = () => {
-      if (raf) cancelAnimationFrame(raf);
-      raf = 0;
-    };
-
-    const loop = (now: number) => {
-      draw((now - start) / 1000);
-      raf = requestAnimationFrame(loop);
-    };
-
-    const sync = () => {
-      stop();
-      if (motionQuery.matches) {
-        // Reduced motion: one still frame, no clock, no rAF at all.
-        gl.uniform1f(uMotion, 0);
-        draw(0);
-        setStatus('still');
-        return;
-      }
-      gl.uniform1f(uMotion, 1);
-      setStatus('running');
-      if (!visible || document.hidden) {
-        draw((performance.now() - start) / 1000);
-        return;
-      }
-      start = performance.now();
-      raf = requestAnimationFrame(loop);
-    };
-
-    // Idle when scrolled away or the tab is backgrounded — a hero that keeps a
-    // GPU busy below the fold is the main reason WebGL heroes get a bad name.
-    const intersectionObserver = new IntersectionObserver(
-      ([entry]) => {
-        visible = entry.isIntersecting;
-        sync();
-      },
-      { threshold: 0 },
-    );
-    intersectionObserver.observe(canvas);
-
-    const onContextLost = (event: Event) => {
-      event.preventDefault();
-      stop();
-      setStatus('unsupported');
-    };
-    canvas.addEventListener('webglcontextlost', onContextLost);
-    document.addEventListener('visibilitychange', sync);
-    motionQuery.addEventListener('change', sync);
-    sync();
-
-    return () => {
-      stop();
-      themeObserver.disconnect();
-      resizeObserver.disconnect();
-      intersectionObserver.disconnect();
-      canvas.removeEventListener('webglcontextlost', onContextLost);
-      document.removeEventListener('visibilitychange', sync);
-      motionQuery.removeEventListener('change', sync);
-      gl.deleteProgram(program);
-      gl.deleteShader(vs);
-      gl.deleteShader(fs);
-      gl.deleteBuffer(buffer);
-    };
-  }, [canvasRef]);
-
-  return status;
-}
+const SYNTHWAVE = HERO_IDEAS[0];
 
 /**
  * The CSS backdrop that shows through when WebGL is unavailable — and that the
@@ -361,18 +43,24 @@ function HeroBackdrop({ flat }: { flat: boolean }) {
   );
 }
 
+const STATUS_LABEL: Record<ShaderStatus, string> = {
+  pending: 'starting…',
+  running: 'webgl2 · animating',
+  still: 'webgl2 · reduced-motion still frame',
+  unsupported: 'css fallback (no webgl2)',
+};
+
 function ShaderHero() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const status = useShaderHero(canvasRef);
+  const [status, setStatus] = useState<ShaderStatus>('pending');
 
   return (
     <div className="relative h-[60vh] min-h-[320px] w-full overflow-hidden border-2 border-white">
       <HeroBackdrop flat={status === 'unsupported'} />
-      <canvas
-        ref={canvasRef}
-        aria-hidden
+      <ShaderStage
+        hero={SYNTHWAVE.hero}
+        mode="follow"
+        onStatus={setStatus}
         className="absolute inset-0 h-full w-full"
-        style={{ display: status === 'unsupported' ? 'none' : 'block' }}
       />
       <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
         <h2 className="font-display text-4xl font-bold uppercase text-white md:text-6xl">
@@ -388,13 +76,6 @@ function ShaderHero() {
     </div>
   );
 }
-
-const STATUS_LABEL: Record<Status, string> = {
-  pending: 'starting…',
-  running: 'webgl2 · animating',
-  still: 'webgl2 · reduced-motion still frame',
-  unsupported: 'css fallback (no webgl2)',
-};
 
 /**
  * Measured on this repo at three@0.185.1 / @react-three/fiber@9.7.0 /
@@ -499,6 +180,16 @@ export default function WebglHeroes() {
               <br />
               {'>'} Scroll it out of view or background the tab — the render
               loop parks itself.
+              <br />
+              {'>'} Five more ideas, each showing both themes at once, are in
+              the{' '}
+              <Link
+                href="/design-sandbox/hero-lab"
+                className="text-brutalist-cyan"
+              >
+                hero lab
+              </Link>
+              .
             </p>
           </div>
         </div>

--- a/pages/design-sandbox/webgl-heroes.tsx
+++ b/pages/design-sandbox/webgl-heroes.tsx
@@ -19,7 +19,7 @@ import siteMetadata from '@/data/siteMetadata';
  * go to /design-sandbox/hero-lab.
  */
 
-const SYNTHWAVE = HERO_IDEAS[0];
+const SYNTHWAVE = HERO_IDEAS.find((idea) => idea.id === 'synthwave');
 
 /**
  * The CSS backdrop that shows through when WebGL is unavailable — and that the
@@ -57,7 +57,7 @@ function ShaderHero() {
     <div className="relative h-[60vh] min-h-[320px] w-full overflow-hidden border-2 border-white">
       <HeroBackdrop flat={status === 'unsupported'} />
       <ShaderStage
-        hero={SYNTHWAVE.hero}
+        hero={SYNTHWAVE?.variants[0].hero ?? ''}
         mode="follow"
         onStatus={setStatus}
         className="absolute inset-0 h-full w-full"

--- a/pages/design-sandbox/webgl-heroes.tsx
+++ b/pages/design-sandbox/webgl-heroes.tsx
@@ -1,0 +1,508 @@
+import { useEffect, useRef, useState } from 'react';
+import Link from '@/components/Link';
+import PageHeader from '@/components/PageHeader';
+import { PageSEO } from '@/components/SEO';
+import siteMetadata from '@/data/siteMetadata';
+
+/**
+ * WebGL hero research prototype.
+ *
+ * The question this page exists to answer: does the homepage hero want a 3D
+ * engine (three.js / react-three-fiber), or does the look it actually has —
+ * a perspective grid and a glowing ring — come out of one fragment shader for
+ * a fraction of the bytes? Measurements and the verdict live in
+ * docs/hero-webgl-research.md; this page is the working end of it.
+ *
+ * The prototype deliberately carries the production-shaped concerns rather
+ * than just the pretty part, because those are what the comparison turns on:
+ * design-system tokens read at runtime (so dark / dim / sketch all work), a
+ * reduced-motion path that renders one still frame, pausing when off-screen or
+ * backgrounded, DPR-aware resize, and a CSS fallback when WebGL is missing or
+ * the context is lost.
+ */
+
+const VERT = `#version 300 es
+in vec2 aPos;
+void main() { gl_Position = vec4(aPos, 0.0, 1.0); }`;
+
+/**
+ * Grid + horizon glow + ring, all procedural. Colours arrive as uniforms so the
+ * shader never hardcodes the palette — the theme owns it.
+ */
+const FRAG = `#version 300 es
+precision highp float;
+
+uniform vec2  uRes;
+uniform float uTime;
+uniform vec3  uGrid;
+uniform vec3  uRing;
+uniform float uMotion;   // 1 = animated, 0 = reduced motion (still frame)
+uniform float uInk;      // 0 = glow on a dark surface, 1 = ink on paper
+
+out vec4 outColor;
+
+// Perspective floor grid: project screen space onto a plane below the horizon,
+// then draw anti-aliased lines with derivative-based width so the lines stay
+// one pixel wide as they recede instead of aliasing into noise.
+float floorGrid(vec2 uv, float t) {
+  float horizon = uv.y + 0.16;
+  if (horizon >= -0.001) return 0.0;
+
+  vec2 plane = vec2(uv.x / -horizon, (0.5 / -horizon) + t * 0.25);
+  vec2 cell = abs(fract(plane) - 0.5);
+  vec2 w = fwidth(plane);
+  vec2 line = smoothstep(w * 1.5, vec2(0.0), cell);
+  float g = max(line.x, line.y);
+
+  // Fade the far field so the grid dissolves into the background.
+  return g * smoothstep(0.0, 0.22, -horizon);
+}
+
+// On a dark surface the ring is a light source, so it blooms. On paper a bloom
+// reads as a smudge — there the ring becomes a weightier ink stroke instead.
+float ring(vec2 uv, float pulse, float ink) {
+  float d = abs(length(uv * vec2(1.0, 1.25)) - 0.30);
+  float core = smoothstep(mix(0.010, 0.016, ink), 0.002, d);
+  float glow = smoothstep(0.180, 0.0, d) * 0.35 * (1.0 - ink);
+  return core + glow * pulse;
+}
+
+void main() {
+  vec2 uv = (gl_FragCoord.xy - 0.5 * uRes) / uRes.y;
+  float t = uTime * uMotion;
+
+  float g = floorGrid(uv, t) * mix(0.55, 0.75, uInk);
+  float pulse = 0.75 + 0.25 * sin(t * 1.2);
+  float r = ring(uv, pulse, uInk);
+
+  // A soft band of light sitting on the horizon line, tying grid to ring —
+  // light only, so paper gets none of it.
+  float horizonGlow =
+    smoothstep(0.12, 0.0, abs(uv.y + 0.16)) * 0.25 * (1.0 - uInk);
+
+  vec3 col = uGrid * (g + horizonGlow) + uRing * r;
+  float alpha = clamp(g + horizonGlow + r, 0.0, 1.0);
+  outColor = vec4(col * alpha, alpha);
+}`;
+
+/**
+ * Turn a computed CSS colour into 0..1 RGB, dropping alpha — the shader owns
+ * opacity. Browsers do not hand these back in the form the stylesheet wrote
+ * them: `rgba(35, 38, 46, 0.14)` comes out of `getComputedStyle` as the
+ * 8-digit hex `#23262e24`, so every notation has to be handled or the token
+ * silently falls through to the fallback.
+ */
+function readColor(value: string, fallback: [number, number, number]) {
+  const hex = value.trim().match(/^#([0-9a-f]{3,8})$/i);
+  if (hex) {
+    const h = hex[1];
+    const full =
+      h.length <= 4
+        ? h
+            .slice(0, 3)
+            .split('')
+            .map((c) => c + c)
+            .join('')
+        : h.slice(0, 6);
+    return [0, 2, 4].map(
+      (i) => Number.parseInt(full.slice(i, i + 2), 16) / 255,
+    ) as [number, number, number];
+  }
+  const rgb = value.match(/rgba?\(([^)]+)\)/i);
+  if (rgb) {
+    const parts = rgb[1]
+      .split(/[,\s/]+/)
+      .filter(Boolean)
+      .map(Number);
+    if (
+      parts.length >= 3 &&
+      parts.slice(0, 3).every((n) => Number.isFinite(n))
+    ) {
+      return [parts[0] / 255, parts[1] / 255, parts[2] / 255] as [
+        number,
+        number,
+        number,
+      ];
+    }
+  }
+  return fallback;
+}
+
+function compile(gl: WebGL2RenderingContext, type: number, src: string) {
+  const shader = gl.createShader(type);
+  if (!shader) return null;
+  gl.shaderSource(shader, src);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    gl.deleteShader(shader);
+    return null;
+  }
+  return shader;
+}
+
+/**
+ * Compile, link and activate the shader pair. Returns null on any failure so
+ * the caller can drop straight to the CSS fallback.
+ */
+function createProgram(gl: WebGL2RenderingContext) {
+  const program = gl.createProgram();
+  const vs = compile(gl, gl.VERTEX_SHADER, VERT);
+  const fs = compile(gl, gl.FRAGMENT_SHADER, FRAG);
+  if (!program || !vs || !fs) return null;
+
+  gl.attachShader(program, vs);
+  gl.attachShader(program, fs);
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    gl.deleteProgram(program);
+    return null;
+  }
+  // biome-ignore lint/correctness/useHookAtTopLevel: gl.useProgram is a WebGL call, not a React hook
+  gl.useProgram(program);
+  return { program, vs, fs };
+}
+
+type Status = 'pending' | 'running' | 'still' | 'unsupported';
+
+function useShaderHero(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
+  const [status, setStatus] = useState<Status>('pending');
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const gl = canvas.getContext('webgl2', {
+      alpha: true,
+      antialias: false,
+      powerPreference: 'low-power',
+    });
+    if (!gl) {
+      setStatus('unsupported');
+      return;
+    }
+
+    const built = createProgram(gl);
+    if (!built) {
+      setStatus('unsupported');
+      return;
+    }
+    const { program, vs, fs } = built;
+
+    // One full-screen triangle — cheaper than a quad and needs no index buffer.
+    const buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array([-1, -1, 3, -1, -1, 3]),
+      gl.STATIC_DRAW,
+    );
+    const aPos = gl.getAttribLocation(program, 'aPos');
+    gl.enableVertexAttribArray(aPos);
+    gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0);
+
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+
+    const uRes = gl.getUniformLocation(program, 'uRes');
+    const uTime = gl.getUniformLocation(program, 'uTime');
+    const uGrid = gl.getUniformLocation(program, 'uGrid');
+    const uRing = gl.getUniformLocation(program, 'uRing');
+    const uMotion = gl.getUniformLocation(program, 'uMotion');
+    const uInk = gl.getUniformLocation(program, 'uInk');
+
+    // The design system owns the palette: read the same custom properties
+    // CyberHero uses, and re-read them when the theme class flips.
+    // The dark themes deliberately leave --hero-* unset and lean on the inline
+    // fallbacks (CyberHero does the same); sketch is the mode that overrides
+    // them. So the fallbacks below are the neon palette, not a safety net.
+    const applyTheme = () => {
+      const styles = getComputedStyle(document.documentElement);
+      const grid = readColor(
+        styles.getPropertyValue('--hero-grid-strong'),
+        [0.22, 1.0, 0.08],
+      );
+      const ring = readColor(
+        styles.getPropertyValue('--hero-ring'),
+        [0.53, 0.94, 0.68],
+      );
+      const bg = readColor(
+        styles.getPropertyValue('--brutalist-darkBg'),
+        [0.04, 0.04, 0.04],
+      );
+      gl.uniform3f(uGrid, grid[0], grid[1], grid[2]);
+      gl.uniform3f(uRing, ring[0], ring[1], ring[2]);
+      // Sketch mode remaps the hero background to paper. Glow is a dark-surface
+      // idiom, so the luminance of that token decides which one we draw.
+      const luminance = 0.2126 * bg[0] + 0.7152 * bg[1] + 0.0722 * bg[2];
+      gl.uniform1f(uInk, luminance > 0.5 ? 1 : 0);
+    };
+    applyTheme();
+
+    const themeObserver = new MutationObserver(applyTheme);
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style', 'data-theme'],
+    });
+
+    const resize = () => {
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const w = Math.max(1, Math.round(canvas.clientWidth * dpr));
+      const h = Math.max(1, Math.round(canvas.clientHeight * dpr));
+      if (canvas.width !== w || canvas.height !== h) {
+        canvas.width = w;
+        canvas.height = h;
+        gl.viewport(0, 0, w, h);
+      }
+      gl.uniform2f(uRes, canvas.width, canvas.height);
+    };
+    resize();
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(canvas);
+
+    const draw = (seconds: number) => {
+      gl.uniform1f(uTime, seconds);
+      gl.clearColor(0, 0, 0, 0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+    };
+
+    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    let raf = 0;
+    let visible = true;
+    let start = performance.now();
+
+    const stop = () => {
+      if (raf) cancelAnimationFrame(raf);
+      raf = 0;
+    };
+
+    const loop = (now: number) => {
+      draw((now - start) / 1000);
+      raf = requestAnimationFrame(loop);
+    };
+
+    const sync = () => {
+      stop();
+      if (motionQuery.matches) {
+        // Reduced motion: one still frame, no clock, no rAF at all.
+        gl.uniform1f(uMotion, 0);
+        draw(0);
+        setStatus('still');
+        return;
+      }
+      gl.uniform1f(uMotion, 1);
+      setStatus('running');
+      if (!visible || document.hidden) {
+        draw((performance.now() - start) / 1000);
+        return;
+      }
+      start = performance.now();
+      raf = requestAnimationFrame(loop);
+    };
+
+    // Idle when scrolled away or the tab is backgrounded — a hero that keeps a
+    // GPU busy below the fold is the main reason WebGL heroes get a bad name.
+    const intersectionObserver = new IntersectionObserver(
+      ([entry]) => {
+        visible = entry.isIntersecting;
+        sync();
+      },
+      { threshold: 0 },
+    );
+    intersectionObserver.observe(canvas);
+
+    const onContextLost = (event: Event) => {
+      event.preventDefault();
+      stop();
+      setStatus('unsupported');
+    };
+    canvas.addEventListener('webglcontextlost', onContextLost);
+    document.addEventListener('visibilitychange', sync);
+    motionQuery.addEventListener('change', sync);
+    sync();
+
+    return () => {
+      stop();
+      themeObserver.disconnect();
+      resizeObserver.disconnect();
+      intersectionObserver.disconnect();
+      canvas.removeEventListener('webglcontextlost', onContextLost);
+      document.removeEventListener('visibilitychange', sync);
+      motionQuery.removeEventListener('change', sync);
+      gl.deleteProgram(program);
+      gl.deleteShader(vs);
+      gl.deleteShader(fs);
+      gl.deleteBuffer(buffer);
+    };
+  }, [canvasRef]);
+
+  return status;
+}
+
+/**
+ * The CSS backdrop that shows through when WebGL is unavailable — and that the
+ * shader composites over the rest of the time, so the two never disagree about
+ * the background colour.
+ */
+function HeroBackdrop({ flat }: { flat: boolean }) {
+  return (
+    <div
+      aria-hidden
+      className="absolute inset-0"
+      style={{
+        background: 'var(--brutalist-darkBg, #0a0a0a)',
+        backgroundImage: flat
+          ? `linear-gradient(to right, var(--hero-grid, rgba(57,255,20,0.1)) 1px, transparent 1px),
+             linear-gradient(to bottom, var(--hero-grid, rgba(57,255,20,0.1)) 1px, transparent 1px)`
+          : undefined,
+        backgroundSize: flat ? '50px 50px' : undefined,
+      }}
+    />
+  );
+}
+
+function ShaderHero() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const status = useShaderHero(canvasRef);
+
+  return (
+    <div className="relative h-[60vh] min-h-[320px] w-full overflow-hidden border-2 border-white">
+      <HeroBackdrop flat={status === 'unsupported'} />
+      <canvas
+        ref={canvasRef}
+        aria-hidden
+        className="absolute inset-0 h-full w-full"
+        style={{ display: status === 'unsupported' ? 'none' : 'block' }}
+      />
+      <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
+        <h2 className="font-display text-4xl font-bold uppercase text-white md:text-6xl">
+          RYAN KELLY
+        </h2>
+        <p className="mt-3 font-mono text-sm text-brutalist-cyan md:text-base">
+          FULL_STACK_ENGINEER.exe
+        </p>
+      </div>
+      <p className="absolute bottom-3 left-3 font-mono text-xs text-zinc-400">
+        {'>'} renderer: {STATUS_LABEL[status]}
+      </p>
+    </div>
+  );
+}
+
+const STATUS_LABEL: Record<Status, string> = {
+  pending: 'starting…',
+  running: 'webgl2 · animating',
+  still: 'webgl2 · reduced-motion still frame',
+  unsupported: 'css fallback (no webgl2)',
+};
+
+/**
+ * Measured on this repo at three@0.185.1 / @react-three/fiber@9.7.0 /
+ * ogl@1.0.11 — esbuild, minified, gzipped, react + react-dom external.
+ * Method and caveats: docs/hero-webgl-research.md.
+ */
+const COSTS: { approach: string; gzip: string; note: string }[] = [
+  {
+    approach: 'raw WebGL2 (this page)',
+    gzip: '0.8 KB',
+    note: 'One fragment shader. No dependency, no lazy chunk worth splitting.',
+  },
+  {
+    approach: 'ogl',
+    gzip: '13.0 KB',
+    note: 'Thin WebGL wrapper. Worth it once there is real geometry to manage.',
+  },
+  {
+    approach: 'three.js',
+    gzip: '129.6 KB',
+    note: 'A minimal scene still pulls the core renderer; it barely tree-shakes.',
+  },
+  {
+    approach: 'react-three-fiber + three',
+    gzip: '237.9 KB',
+    note: 'Adds its own reconciler on top of three. Pays off with scene graphs, not backdrops.',
+  },
+];
+
+export default function WebglHeroes() {
+  return (
+    <>
+      <PageSEO
+        title={`WebGL Heroes - ${siteMetadata.author}`}
+        description="Shader-driven hero prototype, and what a 3D engine would cost instead"
+      />
+      <div className="divide-y divide-white border-2 border-white bg-black">
+        <PageHeader
+          title="WEBGL_HEROES"
+          subtitle="Shader-driven hero prototype, and what a 3D engine would cost instead"
+        />
+
+        <div className="container py-12">
+          <ShaderHero />
+
+          <div className="mt-8 border-2 border-brutalist-yellow bg-zinc-900 p-6">
+            <h3 className="mb-4 font-display text-xl font-bold uppercase text-brutalist-yellow">
+              [ WHAT_IT_COSTS ]
+            </h3>
+            <div className="overflow-x-auto">
+              <table className="w-full font-mono text-sm">
+                <thead>
+                  <tr className="text-left text-zinc-400">
+                    <th className="py-2 pr-4 font-normal">APPROACH</th>
+                    <th className="py-2 pr-4 font-normal">GZIP</th>
+                    <th className="py-2 font-normal">NOTE</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {COSTS.map((row) => (
+                    <tr
+                      key={row.approach}
+                      className="border-t border-zinc-700 align-top"
+                    >
+                      <td className="py-2 pr-4 text-white">{row.approach}</td>
+                      <td className="py-2 pr-4 text-brutalist-cyan">
+                        {row.gzip}
+                      </td>
+                      <td className="py-2 text-zinc-400">{row.note}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="mt-4 font-mono text-sm leading-relaxed text-zinc-400">
+              {'>'} The homepage ships ~230 KB gzip of JS today, so three.js is
+              a 56% increase for a backdrop.
+              <br />
+              {'>'} Full method, per-theme behaviour, and the case for picking
+              three.js anyway live in{' '}
+              <Link
+                href="https://github.com/rtkelly13/blog/blob/main/docs/hero-webgl-research.md"
+                className="text-brutalist-cyan"
+              >
+                docs/hero-webgl-research.md
+              </Link>
+              .
+            </p>
+          </div>
+
+          <div className="mt-6 border-2 border-white bg-zinc-900 p-6">
+            <h3 className="mb-4 font-display text-xl font-bold uppercase text-white">
+              [ TRY_IT ]
+            </h3>
+            <p className="font-mono text-sm leading-relaxed text-zinc-400">
+              {'>'} Cycle the theme (HIGH → DIM → SKETCH) — the shader reads the
+              same <span className="text-white">--hero-*</span> tokens CyberHero
+              does, so the palette follows.
+              <br />
+              {'>'} Turn on reduced motion — the loop stops and one still frame
+              is drawn.
+              <br />
+              {'>'} Scroll it out of view or background the tab — the render
+              loop parks itself.
+            </p>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Sandbox-only. Nothing shipped-facing changes: no route outside `/design-sandbox`, no layout, no `CyberHero`, no `pages/index.tsx`, and no new dependency.

## Why

Does the homepage hero want a 3D engine? Answered with numbers, then used as the excuse to explore what a generative hero could actually be.

**Verdict: no.** The current hero is a *backdrop*, not a scene. One WebGL2 fragment shader reproduces it for **0.8 KB gzip and no dependency**, against **127 KB gzip** for the smallest useful three.js — a 56% increase on a homepage that ships ~230 KB gzip today. three.js earns its weight the moment the hero wants loaded models, lighting, a moving camera or post-processing. It doesn't yet.

## Measured

Same hero implemented four ways (esbuild, minified, gzipped, react external):

| Approach | gzip |
| --- | ---: |
| raw WebGL2, no library | **0.8 KB** |
| `ogl` | **13.0 KB** |
| `three` | **129.6 KB** |
| `@react-three/fiber` + `three` | **237.9 KB** |

And in the real build — a three.js hero wired onto `pages/index.tsx` via `next/dynamic`, built with `next build`, then reverted:

| Build | Homepage first-load JS | Lazy hero chunk |
| --- | ---: | ---: |
| `main` | 229.9 KB gzip | — |
| + three.js hero, named imports | 231.3 KB gzip | **127.2 KB gzip** |
| + three.js hero, `import * as THREE` | 231.3 KB gzip | **178.9 KB gzip** |

`next/dynamic` moves the cost, it doesn't remove it — the chunk still downloads on every homepage visit. And the namespace import costs 52 KB gzip for nothing, because Turbopack only tree-shakes three when you destructure named exports.

## What's in it

**`components/hero/`** — `ShaderStage`, the harness: WebGL2 context, full-screen triangle, DPR-aware sizing, reduced motion as one still frame with no rAF, parking when off-screen or backgrounded, CSS fallback for no-WebGL and lost contexts. An idea is just a `vec4 hero(vec2 uv, float t, Theme th)`. Imported only by the two sandbox pages.

**`/design-sandbox/hero-lab`** — six ideas, each rendered so both themes are visible *at once*, split by a draggable seam. One canvas, one pass: the shader picks its palette **and its shading model** per pixel from which side it lands on. CONTOUR and CROSSHATCH carry three variants each.

**`/design-sandbox/webgl-heroes`** — the single-hero prototype following the page theme, plus the cost table.

**`docs/hero-webgl-research.md`** — constraints, method, numbers, when three.js *would* be right, and what adoption would require.

## Findings worth keeping

These are properties of this design system meeting a GPU, not of the shader — a three.js hero would hit all four:

- **Recolouring is not theming; the shading model has to change.** A glow is additive light, and light on paper reads as a smudge. `th.ink` swaps bloom for ink weight, a continuous fade for a hard stamp, a coarse LED screen for a fine 45° halftone.
- **Design tokens don't come back as written.** `--hero-grid-strong` is authored `rgba(35, 38, 46, 0.14)` and `getComputedStyle` returns `#23262e24` — a parser that only knows 3/6-digit hex silently falls through to its fallback.
- **The dark themes leave `--hero-*` unset on purpose**, carrying the neon values as inline `var()` fallbacks (as `CyberHero` does), so the fallbacks are the palette, not a safety net.
- **Contrast against the background colour says nothing about contrast against the content.** The subtitle measures 10:1 on black and 5.5:1 on paper and is still unreadable where a bright contour line crosses it. The harness now fades every field to 13% inside a feathered box across the middle; a page toggle shows the raw field.

## Verification

- `next build` green; homepage first-load JS unchanged at 229.9 KB gzip (byte-for-byte).
- `biome check` and `tsc --noEmit` clean.
- Every idea and variant compiled and rendered in headless Chromium against the production build — both themes, seam dragged, reduced motion drawing a still frame with the knock-back applied, no console errors.

## Not in scope

Not wired into the homepage. The visual-regression suite snapshots it in four themes plus mobile and tablet, and freezing an animated canvas under test is the work standing between the sandbox and `pages/index.tsx` — the same work for every option above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EA8e3zQh9E64NiiVDeum7g)_