### PR TITLE
fix(nav): make the drawers' scroll lock work, and keep them out of the tab order

### DIFF
--- a/components/BlogActions.tsx
+++ b/components/BlogActions.tsx
@@ -1,8 +1,9 @@
 import { FileText, Menu, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { Toc } from 'types/Toc';
 import siteMetadata from '@/data/siteMetadata';
+import { useDrawer } from '@/lib/useDrawer';
 
 interface BlogActionsProps {
   toc?: Toc;
@@ -17,6 +18,18 @@ const BlogActions = ({ toc, activeId }: BlogActionsProps) => {
   // context of <main> and can render above the sticky header (z-50). Gated on
   // mount so server render and first client render match.
   const [mounted, setMounted] = useState(false);
+
+  const panelRef = useRef<HTMLElement>(null);
+  const tocToggleRef = useRef<HTMLButtonElement>(null);
+
+  const closeToc = useCallback(() => setTocOpen(false), []);
+
+  useDrawer({
+    open: tocOpen,
+    onClose: closeToc,
+    panelRef,
+    triggerRef: tocToggleRef,
+  });
 
   useEffect(() => {
     setMounted(true);
@@ -64,6 +77,9 @@ const BlogActions = ({ toc, activeId }: BlogActionsProps) => {
           {toc && toc.length > 0 && (
             <button
               aria-label="Toggle table of contents"
+              aria-expanded={tocOpen}
+              aria-controls="post-toc-panel"
+              ref={tocToggleRef}
               type="button"
               onClick={handleTocToggle}
               className="border-2 border-white bg-brutalist-cyan text-black p-3 transition-all hover:shadow-hard-md active:translate-x-1 active:translate-y-1"
@@ -132,12 +148,20 @@ const BlogActions = ({ toc, activeId }: BlogActionsProps) => {
         mounted &&
         createPortal(
           <>
+            {/* `inert` while closed keeps the off-screen heading links out of
+                the tab order and the accessibility tree — `translate-x-full`
+                only moves them out of sight. `tabIndex={-1}` lets useDrawer
+                hand focus to the panel on open. */}
             <aside
+              id="post-toc-panel"
+              ref={panelRef}
+              tabIndex={-1}
+              inert={!tocOpen}
               className={`
               fixed top-0 right-0 h-full w-80 max-w-[90vw]
               border-l-2 border-white bg-zinc-900 p-6
               transition-transform duration-300 ease-in-out
-              z-[60]
+              z-[60] focus:outline-hidden
               ${tocOpen ? 'translate-x-0' : 'translate-x-full'}
             `}
             >

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -1,7 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import headerNavLinks from '@/data/headerNavLinks';
+import { useDrawer } from '@/lib/useDrawer';
 import Link from './Link';
+
+// Tailwind's `lg`, where the inline nav takes over and this drawer is hidden.
+const LG = '(min-width: 64rem)';
 
 const MobileNav = () => {
   const [navShow, setNavShow] = useState(false);
@@ -11,16 +15,57 @@ const MobileNav = () => {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
-  const onToggleNav = () => {
-    setNavShow((status) => {
-      if (status) {
-        document.body.style.overflow = 'auto';
-      } else {
-        document.body.style.overflow = 'hidden';
-      }
-      return !status;
-    });
-  };
+  const panelRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+
+  const closeNav = useCallback(() => setNavShow(false), []);
+  const onToggleNav = useCallback(() => setNavShow((shown) => !shown), []);
+
+  useDrawer({
+    open: navShow,
+    onClose: closeNav,
+    panelRef,
+    triggerRef: toggleRef,
+  });
+
+  // Scroll lock. Two fixes over what this used to be:
+  //
+  // 1. It locks <html>, not <body>. `document.scrollingElement` here is <html>
+  //    (nothing constrains the body's height), so `overflow: hidden` on the
+  //    body clipped a box that was not the scroller and the page scrolled
+  //    behind the open drawer regardless. Locking the scrolling element
+  //    actually holds, and leaves the sticky header pinned.
+  // 2. It is an effect keyed on `navShow` rather than something the toggle
+  //    handler does on the side, so the cleanup runs on close, on unmount and
+  //    on the `lg` close below — the old version could leave `hidden` behind
+  //    for good if the drawer was hidden by a resize instead of a click. The
+  //    previous inline value is restored rather than hardcoded back to `auto`,
+  //    so this does not clobber a lock someone else owns.
+  useEffect(() => {
+    if (!navShow) return;
+
+    const root = document.documentElement;
+    const previousOverflow = root.style.overflow;
+    root.style.overflow = 'hidden';
+
+    return () => {
+      root.style.overflow = previousOverflow;
+    };
+  }, [navShow]);
+
+  // Growing past `lg` swaps this drawer for the inline nav, so close it —
+  // otherwise it reopens mid-slide on the way back down, and used to take the
+  // scroll lock with it for good.
+  useEffect(() => {
+    const lg = window.matchMedia(LG);
+    const onChange = () => {
+      if (lg.matches) closeNav();
+    };
+
+    onChange();
+    lg.addEventListener('change', onChange);
+    return () => lg.removeEventListener('change', onChange);
+  }, [closeNav]);
 
   /*
    * Portalled to <body> rather than left inside the header, for two reasons
@@ -44,22 +89,29 @@ const MobileNav = () => {
    * list clear of the header. `lg:hidden` has to live on the panel itself now
    * that it no longer inherits it from the toggle's wrapper.
    *
-   * Covered by tests/responsive.spec.ts → "mobile nav panel covers the
-   * viewport behind its links" and "site header stays interactive".
+   * `inert` while closed is what keeps the off-screen links out of the tab
+   * order and the accessibility tree; `translate-x-full` only moves them out
+   * of sight. `tabIndex={-1}` lets useDrawer hand focus to the panel on open.
    */
   const panel = (
     <div
-      className={`lg:hidden fixed w-full h-screen top-0 right-0 pt-24 bg-black/95 backdrop-blur border-l border-gray-800 z-40 transform ease-in-out duration-300 ${
+      id="mobile-nav-panel"
+      ref={panelRef}
+      tabIndex={-1}
+      inert={!navShow}
+      className={`lg:hidden fixed w-full h-screen top-0 right-0 pt-24 bg-black/95 backdrop-blur border-l border-gray-800 z-40 transform ease-in-out duration-300 focus:outline-hidden ${
         navShow ? 'translate-x-0' : 'translate-x-full'
       }`}
     >
-      <button
-        type="button"
-        aria-label="toggle modal"
-        className="fixed w-full h-full cursor-auto focus:outline-hidden"
+      {/* Click-away. A plain div, not a button: Escape closes the drawer now,
+          so a full-panel focusable control with no visible label would just be
+          a confusing extra tab stop. Mirrors the TOC drawer's backdrop. */}
+      <div
+        className="fixed w-full h-full cursor-auto"
         onClick={onToggleNav}
-      ></button>
-      <nav className="fixed h-full mt-8 w-full">
+        aria-hidden="true"
+      />
+      <nav aria-label="Site" className="fixed h-full mt-8 w-full">
         {headerNavLinks.map((link) => (
           <div key={link.title} className="px-12 py-4 border-b border-gray-800">
             <Link
@@ -79,8 +131,11 @@ const MobileNav = () => {
     <div className="lg:hidden">
       <button
         type="button"
+        ref={toggleRef}
         className="w-8 h-8 ml-1 mr-1 text-white hover:text-brutalist-neonGreen transition-colors drop-shadow-[0_0_5px_rgba(255,255,255,0.3)] hover:drop-shadow-[0_0_8px_rgba(57,255,20,0.8)]"
         aria-label="Toggle Menu"
+        aria-expanded={navShow}
+        aria-controls="mobile-nav-panel"
         onClick={onToggleNav}
       >
         <svg

--- a/lib/useDrawer.ts
+++ b/lib/useDrawer.ts
@@ -1,0 +1,60 @@
+import { type RefObject, useEffect, useRef } from 'react';
+
+interface UseDrawerOptions {
+  /** Whether the drawer is currently shown. */
+  open: boolean;
+  /** Called when the drawer should close (currently: Escape). */
+  onClose: () => void;
+  /** The sliding panel. Needs `tabIndex={-1}` so it can take focus. */
+  panelRef: RefObject<HTMLElement | null>;
+  /** The control that opened the drawer, to hand focus back to. */
+  triggerRef: RefObject<HTMLElement | null>;
+}
+
+/**
+ * Keyboard and focus behaviour shared by the site's off-canvas drawers (the
+ * mobile nav, the post table of contents):
+ *
+ * - Escape closes, which is the shortcut anyone who has met a drawer will try.
+ * - Focus moves into the panel when it opens and back to the trigger when it
+ *   closes, so a keyboard user is never left on a control that has slid off
+ *   screen, or stranded at the end of the document.
+ *
+ * Deliberately *not* a focus trap, and the drawers deliberately do not claim
+ * `role="dialog"` / `aria-modal`. The site header stays visible and clickable
+ * alongside the mobile drawer by design, so trapping focus would lie about the
+ * drawer's modality and fight the header's own controls. Pair this with
+ * `inert` on the closed panel — that, not a trap, is what keeps a shut drawer
+ * out of the tab order.
+ */
+export function useDrawer({
+  open,
+  onClose,
+  panelRef,
+  triggerRef,
+}: UseDrawerOptions) {
+  useEffect(() => {
+    if (!open) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [open, onClose]);
+
+  // Only pull focus back on a genuine open → closed transition, so the first
+  // render does not steal focus from wherever the page put it.
+  const wasOpen = useRef(false);
+
+  useEffect(() => {
+    if (open) {
+      panelRef.current?.focus();
+    } else if (wasOpen.current) {
+      triggerRef.current?.focus();
+    }
+
+    wasOpen.current = open;
+  }, [open, panelRef, triggerRef]);
+}

--- a/tests/responsive.spec.ts
+++ b/tests/responsive.spec.ts
@@ -110,6 +110,106 @@ test.describe('Mobile - iPhone 12 (390x844)', () => {
       .toBeGreaterThanOrEqual(page.viewportSize()?.width ?? 0);
   });
 
+  // The drawer only slides off screen when closed (`translate-x-full`), which
+  // hides it from sight but not from the keyboard. `inert` is what takes it out
+  // of the tab order and the accessibility tree.
+  test('closed mobile nav is out of the tab order', async ({ page }) => {
+    await page.goto('/');
+    // The drawer is portalled on mount, so wait for it to exist rather than
+    // racing hydration and measuring an empty panel.
+    await expect(page.locator('#mobile-nav-panel a').first()).toBeAttached();
+
+    const reachable = await page.evaluate(() => {
+      const links = [
+        ...document.querySelectorAll<HTMLElement>('#mobile-nav-panel a'),
+      ];
+      return {
+        total: links.length,
+        focusable: links.filter((link) => {
+          link.focus();
+          return document.activeElement === link;
+        }).length,
+      };
+    });
+
+    expect(reachable.total).toBeGreaterThan(0);
+    expect(reachable.focusable).toBe(0);
+  });
+
+  test('mobile nav closes on Escape and hands focus back', async ({ page }) => {
+    await page.goto('/');
+
+    const toggle = page.locator('button[aria-label="Toggle Menu"]');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    await page.keyboard.press('Escape');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    // Focus must not be left on a control that has slid off screen.
+    await expect(toggle).toBeFocused();
+  });
+
+  // Regression, two of them. The lock used to be set on <body>, which is not
+  // the scrolling element here, so the page scrolled behind the open drawer.
+  // And it was released only by the toggle handler, so hiding the drawer with
+  // a resize instead of a click left the lock behind for good.
+  //
+  // Drive this with a real wheel gesture: `html` carries
+  // `scroll-behavior: smooth`, so reading `scrollY` straight after a
+  // `scrollTo` measures the animation rather than whether scrolling is
+  // possible at all.
+  test('the mobile nav locks page scroll, and lets go past lg', async ({
+    page,
+  }) => {
+    await page.goto('/blog/aws-batch/cookbook');
+
+    const wheelTo = async (y: number) => {
+      await page.mouse.move(195, 600);
+      await page.mouse.wheel(0, y);
+      await page.waitForTimeout(400);
+      return page.evaluate(() => window.scrollY);
+    };
+
+    // Scrolls freely to begin with.
+    expect(await wheelTo(600)).toBeGreaterThan(0);
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'instant' }));
+
+    await page.locator('button[aria-label="Toggle Menu"]').click();
+    // Held while the drawer is open.
+    expect(await wheelTo(600)).toBe(0);
+
+    // Released when the drawer gives way to the inline nav.
+    await page.setViewportSize({ width: 1280, height: 844 });
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.style.overflow))
+      .not.toBe('hidden');
+    expect(await wheelTo(600)).toBeGreaterThan(0);
+  });
+
+  // Same `translate-x-full` pattern, same fix, on the post TOC drawer.
+  test('closed post TOC is out of the tab order', async ({ page }) => {
+    await page.goto('/blog/aws-batch/cookbook');
+    await expect(page.locator('#post-toc-panel a').first()).toBeAttached();
+
+    const reachable = await page.evaluate(() => {
+      const links = [
+        ...document.querySelectorAll<HTMLElement>('#post-toc-panel a'),
+      ];
+      return {
+        total: links.length,
+        focusable: links.filter((link) => {
+          link.focus();
+          return document.activeElement === link;
+        }).length,
+      };
+    });
+
+    expect(reachable.total).toBeGreaterThan(0);
+    expect(reachable.focusable).toBe(0);
+  });
+
   test('blog post TOC toggle button appears', async ({ page }) => {
     await page.goto('/blog/aws-batch/cookbook');
 


### PR DESCRIPTION
Follow-up to #109. **Stacked on it** — base is `claude/mobile-regression-hidden-elements-ix7osn`, so review #109 first; I'll retarget this to `main` once that merges.

Four defects across the two off-canvas drawers — the mobile nav and the post TOC. All found by driving them in a browser, not by reading the code.

## The scroll lock never worked

The mobile drawer set `overflow: hidden` on `<body>`, but `document.scrollingElement` here is `<html>` — nothing constrains the body's height, so the lock clipped a box that wasn't the scroller. The page scrolled behind the open menu regardless:

| `body.style.overflow` | wheel 600px → `scrollY` |
|---|---|
| unset | 600 |
| `hidden` | **600** |
| `hidden` on `<html>` | **0** |

It locks the scrolling element now. Verified the sticky header stays pinned at `top: 0` mid-page while locked, and that no horizontal scrollbar appears (the base `html { overflow-x: clip }` that keeps the off-canvas drawers from widening the page still holds).

## And it leaked

Releasing the lock was something the toggle handler did on the side, so hiding the drawer by widening past `lg` — rotating a tablet, resizing a window — left `hidden` behind for good. It's an effect keyed on the open state now, so cleanup runs on close, on unmount, and on a new `lg` auto-close. The previous inline value is restored rather than hardcoded back to `auto`, so it can't clobber a lock someone else owns.

## Both closed drawers sat in the tab order

`translate-x-full` moves a panel out of sight, not out of the accessibility tree. Measured with the drawers shut:

- mobile nav: **4 links, 4 focusable**
- post TOC: **9 links, 9 focusable**

So tabbing the header fell into four invisible links. `inert` while closed → both now report `0 focusable`.

## Neither drawer answered the keyboard

No `aria-expanded`, no Escape, and focus left on a control that had slid away. Added through a shared `lib/useDrawer` hook (following the repo's `lib/useX.ts` convention): Escape closes, focus moves into the panel on open and back to the trigger on close.

Deliberately **not** a focus trap, and neither drawer claims `role="dialog"` / `aria-modal`. The site header stays visible and clickable alongside the mobile drawer by design (that's what #109 established), so trapping focus would lie about its modality and fight the header's own controls. `inert`, not a trap, is what keeps a shut drawer out of reach.

The mobile drawer's click-away also becomes a plain `aria-hidden` div instead of a full-panel unlabelled `<button>`, matching how the TOC drawer's backdrop already works — with Escape wired up, that button was only a confusing extra tab stop.

## Tests

Four in `tests/responsive.spec.ts`:

- `closed mobile nav is out of the tab order`
- `closed post TOC is out of the tab order`
- `mobile nav closes on Escape and hands focus back`
- `the mobile nav locks page scroll, and lets go past lg`

The scroll one drives a **real wheel gesture** on purpose. `html` carries `scroll-behavior: smooth`, so reading `scrollY` straight after a `scrollTo` measures the animation, not whether scrolling is possible — which is exactly how the broken lock managed to look like it was working. The two inert tests wait for the portalled panel to attach rather than racing hydration and measuring an empty panel.

## Verification

- `pnpm lint`, `pnpm typecheck` — clean
- `pnpm test:unit` — 255 passed
- `responsive.spec.ts` + `e2e.spec.ts` + `theme-toggle.spec.ts` serially — **47 passed, 1 failed**: `blog post TOC opens and closes`, the same pre-existing dev-server-only failure noted in #109 (the dev-only `✎ edit` button intercepts the click; it isn't rendered in the production build CI uses).
- Final end-to-end check on a post page: closed drawers `0 focusable`, `aria-expanded` tracks open/closed, scroll held at `0` behind the open drawer, Escape closes and returns focus to the toggle, lock released and scrolling restored to `600`.

## Not included

The `/blog` tag sidebar's `xl` → `lg` breakpoint. That's a design judgement about the 1024px layout rather than a bug, so it's yours to call.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FjRxsqRNf1WR5ZgcfV4exH)_