### PR TITLE
fix(ci): stop the PR gate re-baselining itself green

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,17 +1,30 @@
 name: Update visual snapshots
 
-# Manual-only. Visual regression now runs inside the consolidated PR gate
-# (pr-checks.yml → e2e-visual) against a locally built site, so this workflow's
+# Manual-only. Visual regression runs inside the consolidated PR gate
+# (pr-checks.yml → e2e-visual), which never writes a baseline, so this workflow's
 # sole job is to (re)generate the committed Linux snapshots on demand. Snapshots
 # must be produced on the CI runner so they match what pr-checks compares against.
+#
+# For a PR, prefer commenting `/update-snapshots` — it does this on the PR's head
+# branch and reports back. This dispatch is the path for baselining `main`, and
+# the one `pnpm test:snapshots:remote` drives.
 on:
   workflow_dispatch:
     inputs:
-      update_snapshots:
-        description: "Update visual regression snapshots"
+      mode:
+        description: >-
+          Which baselines to write. "missing" (the default) only creates ones
+          that do not exist, so a run meant to add a page's screenshot cannot
+          also re-record an existing baseline that has drifted — which is how a
+          regression becomes the expectation. Choose "changed" or "all"
+          deliberately, when a change is *meant* to alter rendering.
         required: false
-        default: true
-        type: boolean
+        default: missing
+        type: choice
+        options:
+          - missing
+          - changed
+          - all
 
 permissions:
   contents: write
@@ -32,9 +45,20 @@ jobs:
         working-directory: blog
         run: pnpm build
 
+      # `missing` mode reports a test that *creates* a baseline as failed, on
+      # purpose, so bootstrapping a screenshot exits non-zero. Tolerated here and
+      # gated by the verify step below, which re-runs with no write flag: a
+      # baseline that does not reproduce fails there and nothing is committed.
       - name: Update snapshots
+        continue-on-error: true
         working-directory: blog
-        run: pnpm exec playwright test --update-snapshots
+        env:
+          MODE: ${{ inputs.mode }}
+        run: pnpm exec playwright test --update-snapshots="${MODE:-missing}"
+
+      - name: Verify the suite passes against the new baselines
+        working-directory: blog
+        run: pnpm exec playwright test --update-snapshots=none
 
       # Commit the regenerated snapshots straight back to the branch this run
       # was dispatched on, so intentional visual changes don't need a manual

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,7 +15,12 @@ on:
 # merge — it fails only when a *blocking* check failed.
 #
 #   Blocking : lockfile, lint, typecheck, unit (+coverage), build, e2e-visual
-#              (visual regression — regenerate snapshots for intentional changes)
+#
+# Nothing here writes to the repository. The visual baselines in
+# `tests/__snapshots__` are compared against, never regenerated: a visual diff
+# fails the gate and stays failed until a human looks at it and asks for a new
+# baseline by commenting `/update-snapshots` on the PR
+# (`update-snapshots-command.yml` is the only workflow that pushes them).
 #
 # No Sentric composite actions, no `gh aw` agentic layer — the report is built
 # deterministically from the job outcomes.
@@ -137,19 +142,23 @@ jobs:
     name: E2E + visual regression
     runs-on: ubuntu-latest
     needs: build
-    # Needs write access so intentional visual changes can be committed back to
-    # the PR branch (see "Commit regenerated snapshots" below).
+    # Read-only. This job compares against the committed baselines and never
+    # writes them; re-baselining is a `/update-snapshots` comment away
+    # (update-snapshots-command.yml), which is the only path that pushes.
     permissions:
-      contents: write
+      contents: read
     outputs:
       outcome: ${{ steps.e2e.outcome }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: blog
-          # Check out the PR branch tip (not the detached pull_request merge
-          # ref) so regenerated snapshots commit cleanly back onto the branch.
-          ref: ${{ github.head_ref }}
+          # The default `pull_request` merge ref, deliberately: the build job
+          # checks out the same ref, so the baselines and specs used here
+          # describe the tree that produced the artifact being served. Checking
+          # out the branch tip instead (as this job did while it committed
+          # snapshots back) diffs a merge-ref build against branch-tip
+          # baselines, which invents differences on any branch behind main.
       - uses: ./blog/.github/actions/setup-blog
         with:
           install-playwright: "true"
@@ -168,31 +177,22 @@ jobs:
         # against the downloaded build; this includes visual.spec.ts /
         # visual-responsive.spec.ts regression specs.
         #
-        # --update-snapshots regenerates the visual baselines in place, so an
-        # intentional visual change is auto-accepted (and committed back to the
-        # branch below) instead of failing the gate. Functional E2E assertions
-        # still fail loudly — only image baselines are refreshed.
-        run: pnpm exec playwright test --update-snapshots
-      - name: Commit regenerated snapshots
-        # Runs on every ordinary PR commit, but NOT on the bot's own snapshot
-        # commits — so the push below can never trigger an endless loop. (A
-        # GITHUB_TOKEN push does not start new workflow runs anyway; the actor
-        # guard is the explicit backstop.) Skipped on forks, where we can't push.
-        if: >-
-          steps.e2e.outcome == 'success' &&
-          github.actor != 'github-actions[bot]' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        working-directory: blog
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if [ -z "$(git status --porcelain tests/__snapshots__)" ]; then
-            echo "No snapshot changes — baselines already current."
-            exit 0
-          fi
-          git add tests/__snapshots__
-          git commit -m "test: regenerate visual regression snapshots"
-          git push origin "HEAD:${{ github.head_ref }}"
+        # `--update-snapshots=none` is the whole point of this gate: nothing on
+        # this runner may write a baseline. A bare `--update-snapshots` presets
+        # to `changed`, and this step ran exactly that until now — every visual
+        # diff was re-recorded as the new expectation, the suite passed, and a
+        # bot commit pushed the rewritten PNGs back to the branch. The check
+        # reported "E2E + visual regression ✅ Passed" on a PR it had just
+        # silently re-baselined 13 files for (#109, 0a436e2). A gate that
+        # rewrites the thing it compares against cannot fail, so it was not a
+        # gate.
+        #
+        # `none` also covers the missing-baseline case: a new screenshot fails
+        # here rather than being written to a runner that is about to be
+        # destroyed. Either way the answer is the same — look at the diff in the
+        # Playwright report, and if the change is intended, say so out loud by
+        # commenting `/update-snapshots` on the PR.
+        run: pnpm exec playwright test --update-snapshots=none
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -268,6 +268,8 @@ jobs:
         run: |
           set -euo pipefail
 
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
           icon() {
             case "$1" in
               success) echo "✅ Passed" ;;
@@ -297,6 +299,14 @@ jobs:
             echo "| Build | $(icon "$BUILD") | blocking |"
             echo "| E2E + visual regression | $(icon "$E2E") | blocking |"
             echo ""
+            if [ "$E2E" = "failure" ]; then
+              echo "> **Visual diff?** Open the \`playwright-report\` artifact on the"
+              echo "> [E2E job]($run_url) to see expected / actual / diff. The baselines are"
+              echo "> never regenerated automatically — if the change is intended, comment"
+              echo "> \`/update-snapshots\` (add \`all\` to re-record baselines that already"
+              echo "> exist) and CI will rebuild them and push them to this branch."
+              echo ""
+            fi
             echo "### Coverage (vs \`main\`)"
             echo ""
             echo "$coverage_md"

--- a/.github/workflows/update-snapshots-command.yml
+++ b/.github/workflows/update-snapshots-command.yml
@@ -9,9 +9,25 @@ name: Update snapshots (command)
 # `pnpm test:snapshots:remote` locally, downloading the artifact, and
 # hand-committing the files.
 #
-# Human-gated by design: a maintainer decides when a visual diff is an
-# INTENTIONAL change worth baking in. CI never blindly accepts a diff, so a
-# genuine regression still fails the gate instead of being silently absorbed.
+# Human-gated by design, and now the ONLY way a baseline changes: pr-checks.yml
+# runs the suite with `--update-snapshots=none`, so a visual diff fails the gate
+# and stays failed until a maintainer looks at it and says here that the change
+# is intentional. Nothing absorbs a diff on its own.
+#
+# Two modes, because "regenerate the baselines" is two different requests:
+#
+#   /update-snapshots       → `missing` — writes only baselines that do not
+#                             exist yet (a new page, a new viewport). Cannot
+#                             overwrite an existing baseline, so adding a
+#                             screenshot can never quietly re-record a
+#                             regression somewhere else in the suite.
+#   /update-snapshots all   → re-records every baseline. The deliberate one,
+#                             for a change that is *meant* to alter rendering.
+#   /update-snapshots changed → re-records only the ones that differ.
+#
+# `all`/`changed` overwrite evidence, so they have to be typed. The mode is
+# echoed back in the result comment, so a reviewer can tell "two added" from
+# "the whole library re-recorded".
 #
 # Note on re-runs: pushes made with the default GITHUB_TOKEN do not themselves
 # re-trigger the `pull_request` gate. Set a `SNAPSHOT_PAT` repo secret (a PAT or
@@ -85,6 +101,27 @@ jobs:
           # default token, which commits fine but won't re-trigger workflows.
           token: ${{ secrets.SNAPSHOT_PAT || secrets.GITHUB_TOKEN }}
 
+      # The SHA every baseline below is rendered against. Checked against the
+      # branch tip again before pushing: a run that generates from one tree and
+      # commits onto another records an expectation nothing has verified.
+      - name: Record the commit under test
+        id: base
+        working-directory: blog
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve mode from the comment
+        id: mode
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          mode=missing
+          case "$BODY" in
+            *"/update-snapshots all"*) mode=all ;;
+            *"/update-snapshots changed"*) mode=changed ;;
+          esac
+          echo "mode=${mode}" >> "$GITHUB_OUTPUT"
+
       - uses: ./blog/.github/actions/setup-blog
         with:
           install-playwright: "true"
@@ -93,27 +130,72 @@ jobs:
         working-directory: blog
         run: pnpm build
 
+      # Tolerated, not ignored. In `missing` mode Playwright reports a test that
+      # *creates* a baseline as failed on purpose, so bootstrapping a screenshot
+      # exits non-zero — failing the job on that is how this command would never
+      # manage to create one. The verify step below is the actual gate: it re-runs
+      # the suite with no write flag, so a baseline that does not reproduce fails
+      # there and nothing is committed.
       - name: Regenerate snapshots
+        continue-on-error: true
         working-directory: blog
-        # Same command playwright.yml uses; webServer serves the build just built.
-        run: pnpm exec playwright test --update-snapshots
+        env:
+          MODE: ${{ steps.mode.outputs.mode }}
+        run: pnpm exec playwright test --update-snapshots="${MODE}"
+
+      # Proves the new baselines are self-consistent before they are committed.
+      # Worth the extra couple of minutes: a GITHUB_TOKEN push does not start
+      # workflow runs, so without this the PR's own visual check keeps its old
+      # result and the only signal a reviewer gets is "some PNGs changed".
+      - name: Verify the suite passes against the new baselines
+        working-directory: blog
+        run: pnpm exec playwright test --update-snapshots=none
 
       - name: Commit & push snapshots
         id: commit
         working-directory: blog
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet -- tests/__snapshots__; then
+          if [ -z "$(git status --porcelain tests/__snapshots__)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "Committed snapshots already match the freshly generated ones — nothing to commit."
             exit 0
           fi
+
+          git fetch --depth=1 origin "${{ steps.pr.outputs.ref }}"
+          tip=$(git rev-parse FETCH_HEAD)
+          if [ "${tip}" != "${BASE_SHA}" ]; then
+            {
+              echo "changed=false"
+              echo "raced=true"
+              echo "moved_to=${tip}"
+            } >> "$GITHUB_OUTPUT"
+            echo "::error::${{ steps.pr.outputs.ref }} moved from ${BASE_SHA} to ${tip} while this run was rendering baselines. Nothing committed — re-run /update-snapshots on the new tip."
+            exit 1
+          fi
+
           git add tests/__snapshots__
           git commit -m "test(visual): regenerate snapshots via /update-snapshots"
           git push origin "HEAD:${{ steps.pr.outputs.ref }}"
           echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Show what changed
+        if: steps.commit.outputs.changed == 'true'
+        working-directory: blog
+        run: git show --stat HEAD -- tests/__snapshots__
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-report-update-snapshots
+          path: blog/playwright-report/
+          retention-days: 30
+          if-no-files-found: ignore
 
       - name: Report result
         if: always()
@@ -122,16 +204,81 @@ jobs:
           script: |
             const status = '${{ job.status }}';
             const changed = '${{ steps.commit.outputs.changed }}';
+            const raced = '${{ steps.commit.outputs.raced }}';
+            const mode = '${{ steps.mode.outputs.mode }}';
+            const base = '${{ steps.base.outputs.sha }}'.slice(0, 7);
+            const movedTo = '${{ steps.commit.outputs.moved_to }}'.slice(0, 7);
+            const runUrl =
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             let body;
-            if (status !== 'success') {
-              body = '❌ `/update-snapshots` failed before it could commit — see the [workflow run](' +
-                `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})` +
-                ' for details.';
+            if (raced === 'true') {
+              body = [
+                '### ❌ Snapshot update raced a push',
+                '',
+                `Baselines were rendered against \`${base}\`, but the branch is now at`,
+                `\`${movedTo}\`. They were **not** committed — they describe a tree that is`,
+                'no longer the tip, so committing them would record an expectation nothing',
+                'has checked. Re-run `/update-snapshots` and let it finish.',
+                '',
+                `[Run log](${runUrl})`,
+              ].join('\n');
+            } else if (status !== 'success') {
+              body = [
+                '### ❌ `/update-snapshots` failed',
+                '',
+                'No baselines were committed. The **verify** step re-runs the suite with',
+                'no write flag, and it went red. Two things look like this:',
+                '',
+                mode === 'missing'
+                  ? '- **The diffs are in baselines that already exist.** `missing` mode'
+                    + ' refuses to overwrite them, so it wrote nothing and the suite is'
+                    + ' still red for the same reason it was before. If those renders are'
+                    + ' *meant* to change, comment `/update-snapshots all`.'
+                  : '- **A baseline did not reproduce on a second run**, so something on the'
+                    + ' page renders non-deterministically. That is a real bug, not a'
+                    + ' snapshot problem.',
+                mode === 'missing'
+                  ? '- **A new baseline did not reproduce on a second run** — something on'
+                    + ' the page renders non-deterministically.'
+                  : '- **A functional E2E assertion failed** — the suite covers more than'
+                    + ' screenshots.',
+                '',
+                `The [run log](${runUrl}) says which, and the`,
+                '`playwright-report-update-snapshots` artifact has the diffs.',
+              ].join('\n');
             } else if (changed === 'true') {
-              body = '✅ Regenerated the visual snapshots and pushed them to this branch. ' +
-                'If the PR gate does not re-run on its own, re-run **PR checks** (a `SNAPSHOT_PAT` secret makes this automatic).';
+              body = [
+                `### 📸 Baselines updated (mode: \`${mode}\`)`,
+                '',
+                'Regenerated on Linux, re-run against the new baselines to prove they',
+                'reproduce, and pushed to this branch.',
+                '',
+                '> [!IMPORTANT]',
+                '> Look at the images in that commit before merging — a regenerated',
+                '> baseline records whatever rendered, including a regression.',
+                '',
+                "This PR's visual check still shows its previous result: GitHub does not",
+                'start workflow runs from `GITHUB_TOKEN` pushes. Re-run **PR checks**, or',
+                'push any commit, to see it go green. (A `SNAPSHOT_PAT` secret makes that',
+                'automatic.)',
+                '',
+                `[Run log](${runUrl})`,
+              ].join('\n');
             } else {
-              body = 'ℹ️ Ran `--update-snapshots`, but the committed snapshots already matched — nothing to commit.';
+              body = [
+                `### 📸 Baselines already current (mode: \`${mode}\`)`,
+                '',
+                'Nothing to commit — the committed baselines already match what this',
+                'branch renders.',
+                '',
+                mode === 'missing'
+                  ? 'Note that `missing` mode only writes baselines that do not exist. If you'
+                    + ' meant to re-record ones that *have* changed, comment'
+                    + ' `/update-snapshots all`.'
+                  : '',
+                '',
+                `[Run log](${runUrl})`,
+              ].filter((line, i, all) => !(line === '' && all[i - 1] === '')).join('\n');
             }
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,10 @@ when you work there:
 
 - **Tailwind v4** — `css/tailwind.css` uses `@import "tailwindcss"`, not
   `@tailwind` directives; PostCSS uses `@tailwindcss/postcss`.
-- **Visual snapshots regenerate on CI only** — `pnpm test:snapshots:remote` (or
-  a `/update-snapshots` PR comment). Never commit macOS-rendered PNGs.
+- **Visual snapshots regenerate on CI only, and only when asked** — the PR gate
+  compares, never writes. Comment `/update-snapshots` (or run
+  `pnpm test:snapshots:remote`) once you've confirmed the diff is intentional.
+  Never commit macOS-rendered PNGs.
 - **Linear history** — rebase onto `main`, squash-merge PRs; no merge commits.
 - **Build needs `@rtkelly/mermaid-toolkit`** built first (handled in CI).
 

--- a/scripts/update-snapshots.mjs
+++ b/scripts/update-snapshots.mjs
@@ -20,6 +20,26 @@ function run(command, ignoreError = false) {
   }
 }
 
+const MODES = ['missing', 'changed', 'all'];
+
+/**
+ * Which baselines the CI run may write. `missing` only creates ones that do not
+ * exist yet, so fetching a baseline for a new page cannot also re-record an
+ * existing one that has drifted — that is how a regression becomes the
+ * expectation. Pass `--mode all` when the change is *meant* to alter rendering.
+ */
+function resolveMode() {
+  const flag = process.argv.indexOf('--mode');
+  const mode = flag === -1 ? 'missing' : process.argv[flag + 1];
+  if (!MODES.includes(mode)) {
+    console.error(
+      `❌ Unknown --mode "${mode}". Expected one of: ${MODES.join(', ')}.`,
+    );
+    process.exit(1);
+  }
+  return mode;
+}
+
 async function updateSnapshots() {
   console.log('\x1b[36m--- Automated Visual Snapshot Updater ---\x1b[0m');
 
@@ -28,10 +48,14 @@ async function updateSnapshots() {
   console.log(`Branch: ${branch}`);
 
   // 2. Trigger Workflow
-  console.log('Triggering "playwright.yml" with update_snapshots=true...');
-  run(
-    `gh workflow run playwright.yml --ref "${branch}" -f update_snapshots=true`,
-  );
+  const mode = resolveMode();
+  console.log(`Triggering "playwright.yml" with mode=${mode}...`);
+  if (mode === 'missing') {
+    console.log(
+      '  (only baselines that do not exist yet — pass "--mode all" to re-record)',
+    );
+  }
+  run(`gh workflow run playwright.yml --ref "${branch}" -f mode="${mode}"`);
 
   // 3. Find the run ID
   console.log('Waiting for run to start...');

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -82,28 +82,53 @@ throwaway config rather than editing `vitest.config.ts`.
 
 **Platform-specific**: Snapshots generated on Linux (CI). Tests skip on macOS/Windows.
 
+**The PR gate never writes a baseline.** `pr-checks.yml` → `e2e-visual` runs
+`playwright test --update-snapshots=none`, so a visual diff fails the check and
+stays failed. Regenerating is a separate, explicitly requested act.
+
+Why it is spelled out this way: the gate used to run a bare `--update-snapshots`
+and push the rewritten PNGs back to the branch. A bare flag presets to
+`changed`, so every diff was re-recorded as the new expectation and the check
+went green — it re-baselined 13 responsive screenshots on PR #109 (commit
+`0a436e2`) and reported "E2E + visual regression ✅ Passed". A check that
+rewrites what it compares against cannot fail.
+
+**Reading a failure:** download the `playwright-report` artifact from the E2E
+job — it carries expected / actual / diff for each screenshot. Decide whether
+the change is intended *before* asking for a new baseline.
+
 **Update flow:**
 
 ```bash
-# Option 1 (PRs): comment on the PR — CI regenerates AND commits the
-# snapshots back to the branch for you (update-snapshots-command.yml).
-/update-snapshots
+# Option 1 (PRs): comment on the PR. CI regenerates on Linux, re-runs the suite
+# against the new baselines to prove they reproduce, and commits them back to
+# the branch (update-snapshots-command.yml).
+/update-snapshots          # `missing` — only baselines that don't exist yet
+/update-snapshots all      # re-record every baseline (a deliberate act)
+/update-snapshots changed  # re-record only the ones that differ
 
 # Option 2: trigger CI, then pull the artifact down locally
-pnpm test:update-snapshots
+pnpm test:snapshots:remote            # missing
+pnpm test:snapshots:remote --mode all # re-record
 
 # Option 3: manual via GitHub Actions
-gh workflow run playwright.yml --ref <branch> -f update_snapshots=true
-
-# For options 2 & 3, download and commit the regenerated files
-gh run download <run-id> -n playwright-snapshots
-cp -r playwright-snapshots/* tests/__snapshots__/
-git add tests/__snapshots__ && git commit
+gh workflow run playwright.yml --ref <branch> -f mode=all
 ```
 
-Option 1 is human-gated on purpose: you only comment `/update-snapshots` once
-you've confirmed the visual diff is intentional, so a genuine regression still
-fails the gate rather than being auto-absorbed.
+`missing` is the default everywhere on purpose. A run meant to add one new
+screenshot would, in `changed` mode, also re-record every other baseline that
+had drifted — which is exactly how a regression becomes the expectation. The
+mode is echoed back in the PR comment, so a reviewer can tell "two added" from
+"everything re-recorded".
+
+Whichever route: **look at the images in the resulting commit before merging.**
+A regenerated baseline records whatever rendered, including a regression.
+
+Note that a `GITHUB_TOKEN` push does not start new workflow runs, so the PR's
+own visual check keeps its previous result until you re-run **PR checks** or
+push again. The update run verifies the new baselines itself, so you are not
+flying blind in the meantime. A `SNAPSHOT_PAT` repo secret (`contents: write`)
+makes the re-run automatic.
 
 **Snapshot path template:**
 


### PR DESCRIPTION
`pr-checks.yml` → `e2e-visual` ran `playwright test --update-snapshots`. A bare
`--update-snapshots` presets to `changed`, so every screenshot that differed
from its committed baseline was rewritten in place, the test passed, and a bot
commit pushed the new PNGs back to the PR branch. The job held `contents: write`
for exactly that.

So the blocking check could not fail on a visual diff — it rewrote the thing it
compares against.

- **PR #109 is the worked example.** Commit [`0a436e2`](https://github.com/rtkelly13/blog/commit/0a436e2d435338ce3c98e918d3960b9edb854d4b)
  re-recorded **13 responsive baselines** on a mobile-nav fix, unreviewed, and
  the sticky comment reported `E2E + visual regression ✅ Passed`.
- **13 squashed commits on `main`** carry the bot's line in their bodies, so
  this has been the behaviour since #51 in mid-July. Among them: #95, #96 and
  #98 — the design-system bump PRs, i.e. exactly the ones where a visual diff is
  the signal you want.
- It contradicted what `tests/AGENTS.md` has said the whole time: *"you only
  comment `/update-snapshots` once you've confirmed the visual diff is
  intentional, so a genuine regression still fails the gate rather than being
  auto-absorbed."* The docs described the intended system; the workflow did the
  opposite.

Regeneration is now exactly one thing: an explicit request.

## The gate

- `e2e-visual` runs `--update-snapshots=none` and drops to `contents: read`.
  Nothing on that runner can write a baseline, including a missing one.
- The commit-back step is gone, and the checkout returns to the `pull_request`
  merge ref — the same ref the `build` job it serves the artifact from uses.
  `ref: github.head_ref` existed only so the bot could push, and meanwhile
  diffed a merge-ref build against branch-tip baselines: spurious differences on
  any branch behind `main`, which the same step then committed as the new truth.
- On failure the sticky comment now says where the diff images are and what to
  type.

## `/update-snapshots`

Gains the parts the design system's equivalent already had, so the two repos
behave the same way:

- **A mode.** Bare `/update-snapshots` is `missing` — it cannot overwrite an
  existing baseline, so adding a screenshot can never quietly re-record a
  regression elsewhere in the suite. `all` / `changed` overwrite evidence, so
  they have to be typed. The mode is echoed back in the result comment.
- **A verify step.** The suite is re-run with no write flag before anything is
  committed, so a baseline that does not reproduce fails there rather than
  landing as an expectation nothing has checked.
- **A race guard.** Baselines rendered against one SHA are not committed onto a
  branch that has since moved.
- Result comments that name the actual cause — including the common "you wanted
  `all`" case — and a `playwright-report-update-snapshots` artifact.

`playwright.yml` (dispatch, and what `pnpm test:snapshots:remote` drives) gets
the same mode input and verify step. Its `update_snapshots: boolean` input was
dead: nothing read it, the step always overwrote.

## Validation

Both workflows parse, the three embedded `github-script` blocks are
syntactically valid, and biome passes on the changed `.mjs`. The suite itself
needs a CI runner — this PR's own gate is the first real exercise of it.

## Not in this PR

- **`0a436e2` is still on PR #110's branch** — 13 baselines nothing reviewed.
  The first run under the new gate compares against them.
- **`maxDiffPixelRatio: 0.002`** against the design system's `maxDiffPixels: 0`.
  On a `fullPage` blog-post shot (~10M pixels) that is a ~20,000-pixel budget,
  and it scales *up* with page height — the tall compositions, where a small
  regression hides best, get the largest allowance. Worth tightening, but
  separately: it will surface whatever drift the auto-accept has been absorbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtBPiDaWdsivu3XvsXRL2f

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtBPiDaWdsivu3XvsXRL2f)_