### PR TITLE
feat(experiments): icon-pack evaluation, argued live at /experiments/…

### DIFF
--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -10,6 +10,7 @@ React components: UI primitives, feature modules (diagrams, search, comments), a
 components/
 ├── diagrams/         # Diagram renderers (Mermaid, SVG, ReactFlow)
 ├── hero/             # Shader hero harness + the lab's generative ideas
+├── iconlab/          # Icon-pack evaluation specimens (/experiments/icon-packs)
 ├── search/           # KBar command palette (Cmd+K)
 ├── comments/         # Comment providers (Giscus, Utterances, Disqus)
 ├── social-icons/     # SVG social icons
@@ -27,6 +28,8 @@ Use these for imports:
 
 - `diagrams/index.ts` → Diagram, MermaidDiagram, SvgDiagram, ReactFlowDiagram
 - `hero/index.ts` → ShaderStage, HERO_IDEAS, readColor, SHADER_PRELUDE/POSTLUDE
+- `iconlab/index.ts` → GeometryStrip, CapFixDemo, BakedCorners, StrokeWeight,
+  ThemeSurvival, LicenceLedger, BrandProvenance, PixelPairing, PACKS
 - `social-icons/index.tsx` → SocialIcon
 - `comments/index.tsx` → Comments (auto-selects provider)
 - `analytics/index.tsx` → Analytics (auto-selects provider)
@@ -97,6 +100,21 @@ values. So the rule for any new component is:
   so they follow dark ↔ sketch.
 - Verify both: cycle the theme switch (HIGH → DIM → SKETCH) and confirm the
   component reads on paper as well as on black.
+
+## ICON PACKS (iconlab/)
+
+The pack choice itself is argued at **`/experiments/icon-packs`** — every panel
+renders published path data from the pack it names, so the geometry, theming
+and licence claims can be checked rather than taken on trust. Three rules come
+out of it and apply to any new icon work:
+
+- **Lucide stays the primary set.** ISC, `currentColor`, 2px on a 24 grid, and
+  the only real mismatch (round caps) is reachable from a stylesheet.
+- **Nothing the design system re-exports may carry an attribution licence.**
+  `@rtkelly13/design-system` publishes to public npm, so a CC BY 4.0 pack hands
+  every consumer an obligation. CC0, MIT and ISC only.
+- **Depend, never vendor.** Hand-copied paths (see `social-icons/icons.tsx`)
+  lose their provenance and stop tracking upstream.
 
 ## INTERACTIVE MDX (interactive/)
 

--- a/components/iconlab/BrandProvenance.tsx
+++ b/components/iconlab/BrandProvenance.tsx
@@ -1,0 +1,66 @@
+import { Check, TriangleAlert } from 'lucide-react';
+import { BRAND_MARKS } from './packs';
+
+/**
+ * What `components/social-icons/icons.tsx` actually ships today: five paths
+ * copied by hand, four of them from Simple Icons and one from nowhere the
+ * file names. The licence argument is easier to see than to describe.
+ */
+export default function BrandProvenance() {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-0.5 bg-white sm:grid-cols-5">
+        {BRAND_MARKS.map((mark) => (
+          <div
+            key={mark.kind}
+            className="flex flex-col items-center gap-3 bg-black px-3 py-5"
+          >
+            <svg
+              role="img"
+              aria-label={`${mark.kind} mark`}
+              viewBox={mark.viewBox}
+              width={36}
+              height={36}
+              fill="currentColor"
+              className={
+                mark.declared ? 'text-brutalist-cyan' : 'text-brutalist-pink'
+              }
+            >
+              <path d={mark.path} />
+            </svg>
+            <span className="font-mono text-[11px] uppercase text-white">
+              {mark.kind}
+            </span>
+            <span
+              className={`flex items-center gap-1 border px-1 font-mono text-[9px] uppercase ${
+                mark.declared
+                  ? 'border-brutalist-cyan text-brutalist-cyan'
+                  : 'border-brutalist-pink text-brutalist-pink'
+              }`}
+            >
+              {mark.declared ? (
+                <Check className="h-3 w-3" strokeLinecap="square" />
+              ) : (
+                <TriangleAlert className="h-3 w-3" strokeLinecap="square" />
+              )}
+              {mark.licence}
+            </span>
+            <span className="text-center font-mono text-[9px] leading-relaxed text-zinc-400">
+              {mark.provenance}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <p className="max-w-3xl font-mono text-xs text-zinc-400">
+        <span className="text-brutalist-yellow">&gt;</span> The header comment
+        in <code>icons.tsx</code> already says these came from Simple Icons, and
+        the GitHub path still matches upstream byte for byte. So the
+        recommendation is not "switch packs" — it is{' '}
+        <span className="text-white">stop vendoring</span>. A dependency
+        version-tracks the marks, ships its own CC0 declaration, and would have
+        surfaced that the mail glyph is not a brand mark at all.
+      </p>
+    </div>
+  );
+}

--- a/components/iconlab/CapFix.tsx
+++ b/components/iconlab/CapFix.tsx
@@ -1,0 +1,174 @@
+import { ChevronRight, ExternalLink, FileText, Star } from 'lucide-react';
+import { useState } from 'react';
+import { LUCIDE_FILE_TEXT } from './packs';
+
+/** Lucide accepts SVG presentation props, and the child paths inherit them. */
+const ROUND = { strokeLinecap: 'round', strokeLinejoin: 'round' } as const;
+const SQUARE = { strokeLinecap: 'square', strokeLinejoin: 'miter' } as const;
+
+/**
+ * The proposed rule, applied to real chrome rather than an icon grid: the
+ * same header, button and metadata row rendered as shipped and as the rule
+ * would render it, so the caps can be judged against the 2px borders they
+ * actually sit next to.
+ */
+function Chrome({ square }: { square: boolean }) {
+  const caps = square ? SQUARE : ROUND;
+
+  return (
+    <div className="space-y-4 p-5">
+      <div className="flex items-center gap-3 border-2 border-white bg-black px-3 py-2">
+        <FileText className="h-6 w-6 text-brutalist-cyan" {...caps} />
+        <span className="font-display text-lg font-bold uppercase text-white">
+          [ BLOG ]
+        </span>
+      </div>
+
+      <button className="flex items-center gap-2 border-2 border-white bg-brutalist-cyan px-4 py-2 font-mono text-sm font-bold uppercase text-black shadow-hard-sm">
+        Read post
+        <ChevronRight className="h-4 w-4" {...caps} />
+      </button>
+
+      <div className="flex flex-wrap items-center gap-4 font-mono text-xs text-zinc-400">
+        <span className="flex items-center gap-1.5">
+          <Star className="h-4 w-4 text-brutalist-yellow" {...caps} />
+          featured
+        </span>
+        <span className="flex items-center gap-1.5">
+          <ExternalLink className="h-4 w-4 text-brutalist-pink" {...caps} />
+          archived link
+        </span>
+      </div>
+
+      <div className="flex items-end gap-4 border-t-2 border-zinc-700 pt-4">
+        <ChevronRight className="h-24 w-24 text-white" {...caps} />
+        <span className="pb-2 font-mono text-[10px] uppercase text-zinc-400">
+          96px — the same
+          <br />
+          terminal, magnified
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function CapFixDemo() {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="border-2 border-zinc-600 bg-zinc-900">
+          <div className="border-b-2 border-zinc-600 px-3 py-1.5">
+            <span className="font-mono text-xs font-bold uppercase text-zinc-400">
+              as shipped · round caps
+            </span>
+          </div>
+          <Chrome square={false} />
+        </div>
+
+        <div className="border-2 border-brutalist-cyan bg-zinc-900 shadow-hard-cyan">
+          <div className="border-b-2 border-brutalist-cyan px-3 py-1.5">
+            <span className="font-mono text-xs font-bold uppercase text-brutalist-cyan">
+              with the rule · square caps
+            </span>
+          </div>
+          <Chrome square={true} />
+        </div>
+      </div>
+
+      <pre className="overflow-x-auto border-2 border-white bg-black p-4 font-mono text-xs text-white">
+        <span className="text-zinc-500">{'/* css/tailwind.css */'}</span>
+        {'\n'}
+        <span className="text-brutalist-cyan">.lucide</span>
+        {' {\n  '}
+        <span className="text-brutalist-yellow">stroke-linecap</span>
+        {': square;\n  '}
+        <span className="text-brutalist-yellow">stroke-linejoin</span>
+        {': miter;\n}'}
+      </pre>
+
+      <p className="max-w-3xl font-mono text-xs text-zinc-400">
+        <span className="text-brutalist-yellow">&gt;</span> Lucide sets both as
+        presentation attributes on the root <code>&lt;svg&gt;</code> and the
+        child paths inherit them. Presentation attributes lose to any CSS rule,
+        so one selector re-cuts every icon on the site — including the ones
+        added next year. No import site changes.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * The caveat, made visible: squaring the caps does not remove the corner
+ * radii baked into the path data. Lucide draws the document corners of
+ * `file-text` as `a 2 2 0 0 1` arcs.
+ */
+export function BakedCorners() {
+  const [annotate, setAnnotate] = useState(true);
+
+  return (
+    <div className="space-y-4">
+      <button
+        onClick={() => setAnnotate((a) => !a)}
+        aria-pressed={annotate}
+        className={`border-2 px-3 py-1.5 font-mono text-xs uppercase shadow-hard-sm transition-colors ${
+          annotate
+            ? 'border-brutalist-pink bg-brutalist-pink text-black'
+            : 'border-white bg-zinc-900 text-white hover:text-brutalist-pink'
+        }`}
+      >
+        {annotate ? 'hide the arcs' : 'mark the arcs'}
+      </button>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {[false, true].map((square) => (
+          <div
+            key={String(square)}
+            className="border-2 border-white bg-black p-6"
+          >
+            <span className="mb-4 block font-mono text-xs uppercase text-zinc-400">
+              {square ? 'square caps' : 'round caps'}
+            </span>
+            <svg
+              role="img"
+              aria-label={`Lucide file-text with ${
+                square ? 'square' : 'round'
+              } caps`}
+              viewBox="0 0 24 24"
+              width={160}
+              height={160}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap={square ? 'square' : 'round'}
+              strokeLinejoin={square ? 'miter' : 'round'}
+              className="text-white"
+            >
+              {LUCIDE_FILE_TEXT.map((d) => (
+                <path key={d} d={d} />
+              ))}
+              {annotate ? (
+                <g
+                  className="text-brutalist-pink"
+                  stroke="currentColor"
+                  strokeWidth={0.6}
+                  fill="none"
+                >
+                  <circle cx={6} cy={4} r={2.6} />
+                  <circle cx={6} cy={20} r={2.6} />
+                  <circle cx={18} cy={20} r={2.6} />
+                </g>
+              ) : null}
+            </svg>
+          </div>
+        ))}
+      </div>
+
+      <p className="max-w-3xl font-mono text-xs text-zinc-400">
+        <span className="text-brutalist-pink">&gt;</span> The circled corners do
+        not move. The terminals square, the shape does not — nothing short of
+        redrawing the paths gets a truly zero-radius icon out of Lucide. Worth
+        knowing before the rule is sold as a complete fix.
+      </p>
+    </div>
+  );
+}

--- a/components/iconlab/GeometryStrip.tsx
+++ b/components/iconlab/GeometryStrip.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import GlyphSpecimen from './Glyph';
+import { ARROW_SPECIMENS } from './packs';
+
+const SIZES = [16, 20, 24, 44] as const;
+
+/**
+ * The same arrow-up from ten packs, at the sizes the site actually renders
+ * icons at. Toggling the caps shows which packs a stylesheet can re-cut and
+ * which have the terminal shape baked into the outline.
+ */
+export default function GeometryStrip() {
+  const [square, setSquare] = useState(false);
+  const [size, setSize] = useState<number>(44);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          onClick={() => setSquare((s) => !s)}
+          aria-pressed={square}
+          className={`border-2 px-3 py-1.5 font-mono text-xs uppercase shadow-hard-sm transition-colors ${
+            square
+              ? 'border-brutalist-cyan bg-brutalist-cyan text-black'
+              : 'border-white bg-zinc-900 text-white hover:text-brutalist-cyan'
+          }`}
+        >
+          stroke-linecap: {square ? 'square' : 'round'}
+        </button>
+
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[10px] uppercase text-zinc-400">
+            size
+          </span>
+          {SIZES.map((s) => (
+            <button
+              key={s}
+              onClick={() => setSize(s)}
+              aria-pressed={size === s}
+              className={`border-2 px-2 py-1 font-mono text-[10px] transition-colors ${
+                size === s
+                  ? 'border-brutalist-yellow text-brutalist-yellow'
+                  : 'border-zinc-600 text-zinc-400 hover:border-white hover:text-white'
+              }`}
+            >
+              {s}px
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <p className="font-mono text-xs text-zinc-400">
+        <span className="text-brutalist-yellow">&gt;</span>{' '}
+        {square
+          ? 'One CSS rule re-cut every stroke set. The fill sets did not move — nothing in a stylesheet reaches them.'
+          : 'Lucide, Tabler and Iconoir ship round caps and joins by default. Toggle to see which packs a stylesheet can reach.'}
+      </p>
+
+      <div className="grid grid-cols-2 gap-0.5 bg-white lg:grid-cols-5">
+        {ARROW_SPECIMENS.map((glyph) => (
+          <div
+            key={`${glyph.packId}-${glyph.note}`}
+            className={`flex flex-col items-center gap-2 px-2 py-4 ${
+              glyph.packId === 'lucide' ? 'bg-zinc-900' : 'bg-black'
+            }`}
+          >
+            <div
+              className="flex items-center justify-center text-white"
+              style={{ height: 48 }}
+            >
+              <GlyphSpecimen glyph={glyph} size={size} square={square} />
+            </div>
+            <span
+              className={`font-mono text-[11px] ${
+                glyph.packId === 'lucide' ? 'text-brutalist-cyan' : 'text-white'
+              }`}
+            >
+              {glyph.label}
+            </span>
+            <span className="text-center font-mono text-[9px] text-zinc-400">
+              {glyph.note}
+            </span>
+            <span
+              className={`border px-1 font-mono text-[9px] uppercase ${
+                glyph.squareable
+                  ? 'border-brutalist-cyan text-brutalist-cyan'
+                  : 'border-zinc-600 text-zinc-500'
+              }`}
+            >
+              {glyph.squareable ? 'CSS reaches it' : 'baked'}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/iconlab/Glyph.tsx
+++ b/components/iconlab/Glyph.tsx
@@ -1,0 +1,43 @@
+import type { Glyph } from './packs';
+
+/**
+ * Renders a specimen from its published path data.
+ *
+ * Stroke sets take `stroke-linecap` / `stroke-linejoin` on the root `<svg>`
+ * and the child paths inherit it — which is the whole mechanism the cap fix
+ * relies on. Fill sets ignore both, because the terminal shape is baked into
+ * the outline.
+ */
+export default function GlyphSpecimen({
+  glyph,
+  size = 44,
+  square = false,
+  className = '',
+}: {
+  glyph: Glyph;
+  size?: number;
+  square?: boolean;
+  className?: string;
+}) {
+  const stroke = glyph.kind === 'stroke';
+
+  return (
+    <svg
+      role="img"
+      aria-label={`${glyph.label} arrow-up, ${glyph.note}`}
+      width={size}
+      height={size}
+      viewBox={glyph.viewBox}
+      fill={stroke ? 'none' : 'currentColor'}
+      stroke={stroke ? 'currentColor' : undefined}
+      strokeWidth={stroke ? glyph.strokeWidth : undefined}
+      strokeLinecap={stroke ? (square ? 'square' : 'round') : undefined}
+      strokeLinejoin={stroke ? (square ? 'miter' : 'round') : undefined}
+      className={className}
+    >
+      {glyph.paths.map((d) => (
+        <path key={d} d={d} />
+      ))}
+    </svg>
+  );
+}

--- a/components/iconlab/LicenceLedger.tsx
+++ b/components/iconlab/LicenceLedger.tsx
@@ -1,0 +1,180 @@
+import type { LicenceTier } from './packs';
+import { PACKS } from './packs';
+
+const TIERS: {
+  id: LicenceTier;
+  title: string;
+  cost: string;
+  accent: string;
+  border: string;
+  detail: string;
+}[] = [
+  {
+    id: 'clear',
+    title: 'CLEAR',
+    cost: 'nothing propagates',
+    accent: 'text-brutalist-cyan',
+    border: 'border-brutalist-cyan',
+    detail:
+      'A public-domain dedication. No notice to keep, no credit to display, nothing that reaches the people who install the package. The only remaining question is trademark, which copyright never covered anyway.',
+  },
+  {
+    id: 'notice',
+    title: 'NOTICE',
+    cost: 'keep the licence with the copy',
+    accent: 'text-white',
+    border: 'border-white',
+    detail:
+      'MIT, ISC and Apache-2.0 all ask that the licence text travels with the code. As an npm dependency that is automatic — the licence sits in node_modules and nobody has to do anything. Copy the paths into a .tsx file instead and the obligation becomes yours to honour by hand.',
+  },
+  {
+    id: 'attribution',
+    title: 'ATTRIBUTION',
+    cost: 'visible credit, forever, downstream',
+    accent: 'text-brutalist-pink',
+    border: 'border-brutalist-pink',
+    detail:
+      'CC BY 4.0 wants credit in a form end users can see, plus a licence link and a note of any changes. Re-export that from a published design system and every consumer inherits the duty. Fine for a site you control; wrong for a package other people install.',
+  },
+  {
+    id: 'bespoke',
+    title: 'BESPOKE',
+    cost: 'read it before you ship it',
+    accent: 'text-brutalist-yellow',
+    border: 'border-brutalist-yellow',
+    detail:
+      'A licence written by the icon vendor rather than drawn from the standard set. It may well permit exactly what you want — but the reader has to establish that, and reviewers of your package have to establish it again.',
+  },
+];
+
+const RULES = [
+  {
+    rule: 'Depend, never vendor',
+    body: 'An npm dependency carries its own licence file and version-tracks the art. A hand-copied path carries neither, and nothing tells you when upstream changed.',
+  },
+  {
+    rule: 'If art must be vendored, declare it inline',
+    body: 'Pack, licence and upstream URL in a comment beside the path, plus a THIRD-PARTY-NOTICES entry. Cheap to write once, impossible to reconstruct later.',
+  },
+  {
+    rule: 'The design system re-exports only CLEAR or NOTICE',
+    body: 'CC0, MIT and ISC. Anything the package hands to a consumer must not hand them an obligation with it.',
+  },
+  {
+    rule: 'Brand marks are a trademark question, not a copyright one',
+    body: 'CC0 waives Simple Icons’ copyright; it grants nothing over the marks themselves. Use them to link to the entity they identify, never restyled as your own identity.',
+  },
+  {
+    rule: 'Never mix a free tier with its paid tier',
+    body: 'Pixelarticons ships 816 icons under MIT and the rest under a commercial licence. Two licences, one npm name — keep the boundary explicit at the import site.',
+  },
+];
+
+/**
+ * The licence view of the same field: packs grouped by what the licence
+ * actually costs a package that gets published to npm, rather than by
+ * whether the licence is "open".
+ */
+export default function LicenceLedger() {
+  return (
+    <div className="space-y-8">
+      <div className="space-y-4">
+        {TIERS.map((tier) => {
+          const packs = PACKS.filter((p) => p.tier === tier.id);
+          return (
+            <div
+              key={tier.id}
+              className={`border-2 ${tier.border} bg-zinc-900`}
+            >
+              <div
+                className={`flex flex-wrap items-baseline gap-x-4 gap-y-1 border-b-2 ${tier.border} px-4 py-2`}
+              >
+                <span
+                  className={`font-display text-lg font-bold uppercase ${tier.accent}`}
+                >
+                  [ {tier.title} ]
+                </span>
+                <span className="font-mono text-[11px] uppercase text-zinc-400">
+                  {tier.cost}
+                </span>
+              </div>
+
+              <div className="space-y-3 p-4">
+                <p className="max-w-3xl font-mono text-xs leading-relaxed text-zinc-400">
+                  {tier.detail}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {packs.map((pack) => (
+                    <span
+                      key={pack.id}
+                      className={`border-2 ${tier.border} px-2 py-1 font-mono text-[11px] ${tier.accent}`}
+                    >
+                      {pack.name}
+                      <span className="ml-2 text-zinc-400">{pack.licence}</span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="border-2 border-brutalist-yellow bg-zinc-900 p-5">
+        <h3 className="mb-4 font-display text-xl font-bold uppercase text-brutalist-yellow">
+          [ LICENCE_RULES ]
+        </h3>
+        <ol className="space-y-3">
+          {RULES.map((r, i) => (
+            <li key={r.rule} className="flex gap-3">
+              <span className="font-mono text-xs text-brutalist-yellow tabular-nums">
+                {String(i + 1).padStart(2, '0')}
+              </span>
+              <div className="space-y-1">
+                <span className="block font-mono text-sm font-bold text-white">
+                  {r.rule}
+                </span>
+                <span className="block max-w-3xl font-mono text-xs leading-relaxed text-zinc-400">
+                  {r.body}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      <div className="overflow-x-auto border-2 border-white">
+        <table className="w-full min-w-[46rem] border-collapse text-left">
+          <thead>
+            <tr className="bg-zinc-900">
+              <th className="border-b-2 border-white px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-zinc-400">
+                Pack
+              </th>
+              <th className="border-b-2 border-white px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-zinc-400">
+                Licence
+              </th>
+              <th className="border-b-2 border-white px-3 py-2 font-mono text-[10px] uppercase tracking-widest text-zinc-400">
+                What it asks of a published package
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {PACKS.map((pack) => (
+              <tr key={pack.id} className="align-top">
+                <td className="border-b border-zinc-700 px-3 py-2 font-display text-sm font-bold whitespace-nowrap text-white">
+                  {pack.name}
+                </td>
+                <td className="border-b border-zinc-700 px-3 py-2 font-mono text-xs whitespace-nowrap text-brutalist-cyan">
+                  {pack.licence}
+                </td>
+                <td className="border-b border-zinc-700 px-3 py-2 font-mono text-xs leading-relaxed text-zinc-400">
+                  {pack.obligation}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/components/iconlab/PixelPairing.tsx
+++ b/components/iconlab/PixelPairing.tsx
@@ -1,0 +1,79 @@
+import { ChevronRight, ExternalLink, File, Menu, Search } from 'lucide-react';
+import { PIXEL_SPECIMENS } from './packs';
+
+const LUCIDE_EQUIVALENTS = {
+  menu: Menu,
+  search: Search,
+  'external-link': ExternalLink,
+  'chevron-right': ChevronRight,
+  file: File,
+} as const;
+
+/**
+ * Pixelarticons against the Lucide equivalents, set beside the VT323 pixel
+ * face the header already uses. The argument is grammar, not preference: the
+ * pixel glyph and the pixel font are drawn on the same grid.
+ */
+export default function PixelPairing() {
+  return (
+    <div className="space-y-4">
+      <div className="border-2 border-white bg-black p-6">
+        <div className="mb-6 flex flex-wrap items-baseline gap-4 border-b-2 border-zinc-700 pb-4">
+          <span className="font-pixel text-5xl text-brutalist-cyan">
+            ryankelly.dev
+          </span>
+          <span className="font-mono text-[10px] uppercase text-zinc-400">
+            VT323 · the face already in the header
+          </span>
+        </div>
+
+        <div className="grid gap-0.5 bg-zinc-700 sm:grid-cols-5">
+          {PIXEL_SPECIMENS.map((spec) => {
+            const Lucide =
+              LUCIDE_EQUIVALENTS[spec.name as keyof typeof LUCIDE_EQUIVALENTS];
+            return (
+              <div
+                key={spec.name}
+                className="flex flex-col items-center gap-3 bg-black px-2 py-4"
+              >
+                <svg
+                  role="img"
+                  aria-label={`Pixelarticons ${spec.name}`}
+                  viewBox="0 0 24 24"
+                  width={40}
+                  height={40}
+                  fill="currentColor"
+                  className="text-brutalist-cyan"
+                >
+                  {spec.paths.map((d) => (
+                    <path key={d} d={d} />
+                  ))}
+                </svg>
+                <Lucide
+                  className="h-10 w-10 text-zinc-500"
+                  strokeLinecap="square"
+                  strokeLinejoin="miter"
+                />
+                <span className="font-mono text-[9px] text-zinc-400">
+                  {spec.name}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+        <div className="mt-3 flex gap-4 font-mono text-[10px] uppercase">
+          <span className="text-brutalist-cyan">top · Pixelarticons (MIT)</span>
+          <span className="text-zinc-500">bottom · Lucide equivalent</span>
+        </div>
+      </div>
+
+      <p className="max-w-3xl font-mono text-xs text-zinc-400">
+        <span className="text-brutalist-yellow">&gt;</span> Not a replacement —
+        an accent, scoped to the surfaces that already speak pixel (the logo,
+        the hero, the Terminal interactive). Site-wide it would fight Lucide
+        rather than accent it, which is a decision the design system should
+        write down rather than drift into.
+      </p>
+    </div>
+  );
+}

--- a/components/iconlab/StrokeWeight.tsx
+++ b/components/iconlab/StrokeWeight.tsx
@@ -1,0 +1,50 @@
+import { Boxes } from 'lucide-react';
+
+const WEIGHTS = [
+  { w: 1.5, label: 'Iconoir · 1.5px', tone: 'text-zinc-400' },
+  { w: 2, label: 'Lucide / Tabler · 2px', tone: 'text-brutalist-cyan' },
+  { w: 2.5, label: 'heavier · 2.5px', tone: 'text-zinc-400' },
+];
+
+/**
+ * Why a 1.5px pack loses on a system whose every border is 2px: the icon is
+ * shown inside the border it has to live next to, so the weight mismatch is
+ * a comparison rather than a claim.
+ */
+export default function StrokeWeight() {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-3">
+        {WEIGHTS.map(({ w, label, tone }) => (
+          <div key={w} className="border-2 border-white bg-black p-5">
+            <div className="mb-4 flex items-center justify-center border-2 border-white bg-zinc-900 p-6">
+              <Boxes
+                className={`h-16 w-16 ${tone}`}
+                strokeWidth={w}
+                strokeLinecap="square"
+                strokeLinejoin="miter"
+              />
+            </div>
+            <span className="block text-center font-mono text-[11px] uppercase text-white">
+              {label}
+            </span>
+            <span className="mt-1 block text-center font-mono text-[9px] text-zinc-400">
+              {w === 2
+                ? 'matches the frame'
+                : w < 2
+                  ? 'reads lighter than the frame'
+                  : 'reads heavier than the frame'}
+            </span>
+          </div>
+        ))}
+      </div>
+      <p className="max-w-3xl font-mono text-xs text-zinc-400">
+        <span className="text-brutalist-yellow">&gt;</span> The border around
+        each icon is the system's standard 2px. At 1.5px the glyph reads as a
+        lighter weight class than the box it sits in — which is the whole case
+        against Iconoir here, and it has nothing to do with the quality of the
+        drawing.
+      </p>
+    </div>
+  );
+}

--- a/components/iconlab/ThemeSurvival.tsx
+++ b/components/iconlab/ThemeSurvival.tsx
@@ -1,0 +1,109 @@
+import { Lightbulb, Presentation, Tags } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { BAKED_FILL_SPECIMEN } from './packs';
+
+/**
+ * Forces a theme on a subtree by carrying the theme class, the same trick the
+ * component library uses: `.sketch` re-points the colour tokens, so `bg-black`
+ * inside resolves to paper and `text-brutalist-cyan` to blue pen.
+ */
+function ThemePanel({
+  theme,
+  label,
+  children,
+}: {
+  theme: 'dark' | 'sketch';
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={`${theme} border-2 border-white bg-black`}>
+      <div className="border-b-2 border-white bg-zinc-900 px-3 py-1.5">
+        <span className="font-mono text-xs font-bold uppercase text-zinc-400">
+          {label}
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-6 p-6">{children}</div>
+    </div>
+  );
+}
+
+function Specimens() {
+  return (
+    <>
+      <div className="flex flex-col items-center gap-2">
+        <Presentation
+          className="h-10 w-10 text-brutalist-cyan"
+          strokeLinecap="square"
+          strokeLinejoin="miter"
+        />
+        <span className="font-mono text-[9px] uppercase text-zinc-400">
+          currentColor
+        </span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <Lightbulb
+          className="h-10 w-10 text-brutalist-yellow"
+          strokeLinecap="square"
+          strokeLinejoin="miter"
+        />
+        <span className="font-mono text-[9px] uppercase text-zinc-400">
+          currentColor
+        </span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <Tags
+          className="h-10 w-10 text-brutalist-pink"
+          strokeLinecap="square"
+          strokeLinejoin="miter"
+        />
+        <span className="font-mono text-[9px] uppercase text-zinc-400">
+          currentColor
+        </span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <svg
+          role="img"
+          aria-label="A pack that bakes its fill colour"
+          viewBox={BAKED_FILL_SPECIMEN.viewBox}
+          width={40}
+          height={40}
+          fill={BAKED_FILL_SPECIMEN.fill}
+        >
+          <path d={BAKED_FILL_SPECIMEN.path} />
+        </svg>
+        <span className="font-mono text-[9px] uppercase text-brutalist-pink">
+          baked #0D0D0D
+        </span>
+      </div>
+    </>
+  );
+}
+
+/**
+ * The first hard constraint, demonstrated: three token-tinted icons and one
+ * published with a baked hex fill, rendered in both first-class themes.
+ */
+export default function ThemeSurvival() {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 lg:grid-cols-2">
+        <ThemePanel theme="dark" label="dark · neon terminal">
+          <Specimens />
+        </ThemePanel>
+        <ThemePanel theme="sketch" label="sketch · paper & ink">
+          <Specimens />
+        </ThemePanel>
+      </div>
+      <p className="max-w-3xl font-mono text-xs text-zinc-400">
+        <span className="text-brutalist-pink">&gt;</span> The three tinted icons
+        follow the tokens across the flip. The fourth — real published path data
+        from a pack that bakes <code>#0D0D0D</code> into its raw SVG — is
+        near-invisible on black and stays ink-coloured on paper. That is the
+        failure mode the currentColor constraint exists to prevent — and the
+        reason a pack is disqualified here on how it ships its colour, before
+        anyone counts its icons.
+      </p>
+    </div>
+  );
+}

--- a/components/iconlab/index.ts
+++ b/components/iconlab/index.ts
@@ -1,0 +1,9 @@
+export { default as BrandProvenance } from './BrandProvenance';
+export { BakedCorners, CapFixDemo } from './CapFix';
+export { default as GeometryStrip } from './GeometryStrip';
+export { default as GlyphSpecimen } from './Glyph';
+export { default as LicenceLedger } from './LicenceLedger';
+export { default as PixelPairing } from './PixelPairing';
+export * from './packs';
+export { default as StrokeWeight } from './StrokeWeight';
+export { default as ThemeSurvival } from './ThemeSurvival';

--- a/components/iconlab/packs.ts
+++ b/components/iconlab/packs.ts
@@ -1,0 +1,498 @@
+/**
+ * Icon-pack evaluation data.
+ *
+ * Every glyph below is the **real path data** from the pack's own repository,
+ * not a redrawing — the whole point of the experiment is that the geometry
+ * differences are the argument. Provenance and licence for each specimen are
+ * declared in `PACKS` and rendered on the page (see LicenceLedger), which is
+ * how the CC BY 4.0 specimens are attributed.
+ *
+ * Sources (fetched 2026-08-25):
+ * - lucide-icons/lucide .................. ISC
+ * - tabler/tabler-icons .................. MIT
+ * - phosphor-icons/core .................. MIT
+ * - iconoir-icons/iconoir ................ MIT
+ * - halfmage/pixelarticons ............... MIT
+ * - astrit/css.gg ........................ MIT
+ * - google/material-design-icons ......... Apache-2.0
+ * - microsoft/vscode-codicons ............ CC BY 4.0 (assets)
+ * - primer/octicons ...................... MIT
+ * - mono-company/mono-icons .............. MIT
+ * - simple-icons/simple-icons ............ CC0-1.0
+ */
+
+/** How much the licence asks of a package that redistributes the art. */
+export type LicenceTier = 'clear' | 'notice' | 'attribution' | 'bespoke';
+
+export type Verdict = 'keep' | 'adopt' | 'accent' | 'fallback' | 'pass';
+
+export interface IconPack {
+  id: string;
+  name: string;
+  /** Icon count as the project's own repo states it. */
+  count: string;
+  licence: string;
+  tier: LicenceTier;
+  /** What the licence actually asks of `@rtkelly13/design-system` on npm. */
+  obligation: string;
+  geometry: string;
+  delivery: string;
+  verdict: Verdict;
+  why: string;
+  source: string;
+}
+
+export const VERDICT_LABEL: Record<Verdict, string> = {
+  keep: 'keep',
+  adopt: 'adopt',
+  accent: 'accent',
+  fallback: 'fallback',
+  pass: 'pass',
+};
+
+/**
+ * Accent per verdict. Only the three brutalist accents plus the neutral
+ * zinc scale, so every chip re-themes into sketch mode with the tokens.
+ */
+export const VERDICT_ACCENT: Record<Verdict, string> = {
+  keep: 'border-brutalist-cyan text-brutalist-cyan',
+  adopt: 'border-brutalist-yellow text-brutalist-yellow',
+  accent: 'border-brutalist-yellow text-brutalist-yellow',
+  fallback: 'border-zinc-500 text-zinc-400',
+  pass: 'border-brutalist-pink text-brutalist-pink',
+};
+
+export const PACKS: IconPack[] = [
+  {
+    id: 'lucide',
+    name: 'Lucide',
+    count: '1,600+',
+    licence: 'ISC',
+    tier: 'notice',
+    obligation:
+      'Keep the licence text with the copy you ship. Satisfied automatically while it stays an npm dependency.',
+    geometry: '2px stroke on a 24 grid, round caps, ~2px corner arcs in paths',
+    delivery: 'lucide-react, first-party, icon context provider',
+    verdict: 'keep',
+    why: 'Already installed and already correct on four of the five constraints. The one mismatch — round caps — is reachable from CSS.',
+    source: 'https://github.com/lucide-icons/lucide',
+  },
+  {
+    id: 'simple-icons',
+    name: 'Simple Icons',
+    count: '3,400+ brand marks',
+    licence: 'CC0-1.0',
+    tier: 'clear',
+    obligation:
+      'None. Public-domain dedication — no notice to keep, nothing propagates to consumers. Trademark is a separate question from copyright.',
+    geometry: 'Brand marks, single-path fill, 24 grid',
+    delivery: 'simple-icons (paths as data) + community React wrappers',
+    verdict: 'adopt',
+    why: 'The five social icons in this repo were already copied from here by hand. Depending on the package instead makes the provenance real and keeps the marks current.',
+    source: 'https://github.com/simple-icons/simple-icons',
+  },
+  {
+    id: 'pixelarticons',
+    name: 'Pixelarticons',
+    count: '816 free / 4,600 pro',
+    licence: 'MIT (free tier)',
+    tier: 'notice',
+    obligation:
+      'Keep the licence text with the copy you ship. The pro tier is a separate commercial licence — do not mix the two.',
+    geometry: 'Orthogonal pixel grid, zero radius, fill on currentColor',
+    delivery: 'pixelarticons, React components + raw SVG',
+    verdict: 'accent',
+    why: 'The only pack in the field whose grammar matches the VT323 pixel font already in the header. Scoped accent, never a site-wide replacement.',
+    source: 'https://github.com/halfmage/pixelarticons',
+  },
+  {
+    id: 'tabler',
+    name: 'Tabler',
+    count: '6,184 (5,130 outline + 1,054 filled)',
+    licence: 'MIT',
+    tier: 'notice',
+    obligation: 'Keep the licence text with the copy you ship.',
+    geometry: '2px stroke on a 24 grid, round caps, 6px corner radii',
+    delivery: '@tabler/icons-react',
+    verdict: 'fallback',
+    why: 'The migration target if coverage ever blocks a post: same structure as Lucide, so the same cap fix works. Costs 6px corners.',
+    source: 'https://github.com/tabler/tabler-icons',
+  },
+  {
+    id: 'phosphor',
+    name: 'Phosphor',
+    count: '1,248 x 6 weights',
+    licence: 'MIT',
+    tier: 'notice',
+    obligation: 'Keep the licence text with the copy you ship.',
+    geometry: 'Fill-based, round terminals baked into the outline',
+    delivery: '@phosphor-icons/react — 9,000+ modules, needs import tuning',
+    verdict: 'pass',
+    why: 'The six weights are genuinely useful, but a fill set with rounded terminals gives CSS nothing to square. The mismatch is permanent.',
+    source: 'https://github.com/phosphor-icons/core',
+  },
+  {
+    id: 'material',
+    name: 'Material Symbols',
+    count: '~3,600 x 3 styles',
+    licence: 'Apache-2.0',
+    tier: 'notice',
+    obligation:
+      'Keep the licence and any NOTICE file, and state changes you make. Heavier paperwork than MIT, and it propagates.',
+    geometry: 'Sharp style is genuinely square; variable weight/fill axes',
+    delivery: 'Variable font or Iconify — no first-party React package',
+    verdict: 'pass',
+    why: 'Sharp is a real square-geometry candidate, but the font route means a second font load and a CSP entry for icons that cost nothing today.',
+    source: 'https://github.com/google/material-design-icons',
+  },
+  {
+    id: 'iconoir',
+    name: 'Iconoir',
+    count: '1,600+',
+    licence: 'MIT',
+    tier: 'notice',
+    obligation: 'Keep the licence text with the copy you ship.',
+    geometry: '1.5px stroke on a 24 grid',
+    delivery: 'iconoir-react',
+    verdict: 'pass',
+    why: 'Drawn a half-pixel lighter than every border in the system. Inside a 2px frame that reads as a different weight class, not a choice.',
+    source: 'https://github.com/iconoir-icons/iconoir',
+  },
+  {
+    id: 'heroicons',
+    name: 'Heroicons',
+    count: '~300',
+    licence: 'MIT',
+    tier: 'notice',
+    obligation: 'Keep the licence text with the copy you ship.',
+    geometry: 'Outline + solid at 24 / 20 / 16, soft corners',
+    delivery: '@heroicons/react',
+    verdict: 'pass',
+    why: 'No Presentation, FlaskConical, FolderGit2 or Dice5 equivalents. A marketing-site icon set, not a blog-with-experiments one.',
+    source: 'https://github.com/tailwindlabs/heroicons',
+  },
+  {
+    id: 'cssgg',
+    name: 'css.gg',
+    count: '~700',
+    licence: 'MIT',
+    tier: 'notice',
+    obligation: 'Keep the licence text with the copy you ship.',
+    geometry: 'Mitred fills on currentColor, dev-tool vernacular',
+    delivery: 'Raw SVG / CSS; the React wrapper is thin',
+    verdict: 'pass',
+    why: 'Genuinely square geometry and the right vernacular, but too small and too inconsistently covered to carry a whole site.',
+    source: 'https://github.com/astrit/css.gg',
+  },
+  {
+    id: 'octicons',
+    name: 'Octicons',
+    count: '~600',
+    licence: 'MIT',
+    tier: 'notice',
+    obligation: 'Keep the licence text with the copy you ship.',
+    geometry: '16 and 24 grids, fill, soft corners',
+    delivery: '@primer/octicons-react',
+    verdict: 'pass',
+    why: "GitHub's own set, drawn for GitHub's chrome. Nothing wrong with it and nothing here it does better than the incumbent.",
+    source: 'https://github.com/primer/octicons',
+  },
+  {
+    id: 'codicons',
+    name: 'Codicons',
+    count: '~500',
+    licence: 'CC BY 4.0 (assets)',
+    tier: 'attribution',
+    obligation:
+      'Visible credit plus a licence link, in a form that reaches end users — and the obligation travels to everyone who installs your package.',
+    geometry: '16 grid, editor vernacular, fill',
+    delivery: 'Webfont-first',
+    verdict: 'pass',
+    why: 'The most on-theme vernacular in the field, and the licence tier that makes it the wrong thing to re-export.',
+    source: 'https://github.com/microsoft/vscode-codicons',
+  },
+  {
+    id: 'remix',
+    name: 'Remix Icon',
+    count: '3,000+',
+    licence: 'Remix Icon License v1.0',
+    tier: 'bespoke',
+    obligation:
+      'Attribution optional, but distribution is conditional: no standalone icon sale, no competing icon library, no use as brand identity. Read four clauses before shipping.',
+    geometry: '24 grid, line + fill pairs',
+    delivery: 'remixicon-react (community)',
+    verdict: 'pass',
+    why: 'Relicensed in January 2026 off a standard open licence. Design systems are explicitly permitted where icons are a minor component — but a bespoke licence is strictly worse than ISC for a package other people install.',
+    source: 'https://github.com/Remix-Design/RemixIcon',
+  },
+  {
+    id: 'fontawesome',
+    name: 'Font Awesome Free',
+    count: '2,000+',
+    licence: 'CC BY 4.0 (icons)',
+    tier: 'attribution',
+    obligation:
+      'Visible credit plus a licence link, propagating to consumers. Fonts are OFL and the code is MIT — three licences in one dependency.',
+    geometry: 'Mixed weights, legacy geometry',
+    delivery: '@fortawesome/react-fontawesome',
+    verdict: 'pass',
+    why: 'Attribution obligation on a hobby design system, for geometry that fits the brief worse than the incumbent.',
+    source: 'https://github.com/FortAwesome/Font-Awesome',
+  },
+  {
+    id: 'hackernoon',
+    name: 'HackerNoon Pixel',
+    count: '2,300+',
+    licence: 'CC BY 4.0 (assets)',
+    tier: 'attribution',
+    obligation: 'Visible credit plus a licence link, propagating to consumers.',
+    geometry: 'Pixel polygons on a 24 grid — the same idea as Pixelarticons',
+    delivery: '@hackernoon/pixel-icon-library',
+    verdict: 'pass',
+    why: 'Same aesthetic win as Pixelarticons, one licence tier worse. There is no reason to take the attribution obligation when MIT buys the same look.',
+    source: 'https://github.com/hackernoon/pixel-icon-library',
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/* Glyph specimens — real path data, same symbol, drawn nine ways.     */
+/* ------------------------------------------------------------------ */
+
+export interface Glyph {
+  packId: string;
+  label: string;
+  note: string;
+  viewBox: string;
+  paths: string[];
+  kind: 'stroke' | 'fill';
+  strokeWidth?: number;
+  /**
+   * Whether a CSS rule can re-cut the terminals. Stroke sets inherit
+   * stroke-linecap from the root svg; fill sets have the shape baked in.
+   */
+  squareable: boolean;
+}
+
+/** The same arrow-up, from each pack's own repository. */
+export const ARROW_SPECIMENS: Glyph[] = [
+  {
+    packId: 'lucide',
+    label: 'Lucide',
+    note: '24 grid · 2px · round',
+    viewBox: '0 0 24 24',
+    paths: ['m5 12 7-7 7 7', 'M12 19V5'],
+    kind: 'stroke',
+    strokeWidth: 2,
+    squareable: true,
+  },
+  {
+    packId: 'tabler',
+    label: 'Tabler',
+    note: '24 grid · 2px · round',
+    viewBox: '0 0 24 24',
+    paths: ['M12 5l0 14', 'M18 11l-6 -6', 'M6 11l6 -6'],
+    kind: 'stroke',
+    strokeWidth: 2,
+    squareable: true,
+  },
+  {
+    packId: 'iconoir',
+    label: 'Iconoir',
+    note: '24 grid · 1.5px · round',
+    viewBox: '0 0 24 24',
+    paths: ['M12 21L12 3M12 3L20.5 11.5M12 3L3.5 11.5'],
+    kind: 'stroke',
+    strokeWidth: 1.5,
+    squareable: true,
+  },
+  {
+    packId: 'phosphor',
+    label: 'Phosphor',
+    note: 'fill · regular',
+    viewBox: '0 0 256 256',
+    paths: [
+      'M205.66,117.66a8,8,0,0,1-11.32,0L136,59.31V216a8,8,0,0,1-16,0V59.31L61.66,117.66a8,8,0,0,1-11.32-11.32l72-72a8,8,0,0,1,11.32,0l72,72A8,8,0,0,1,205.66,117.66Z',
+    ],
+    kind: 'fill',
+    squareable: false,
+  },
+  {
+    packId: 'phosphor',
+    label: 'Phosphor',
+    note: 'fill · bold',
+    viewBox: '0 0 256 256',
+    paths: [
+      'M208.49,120.49a12,12,0,0,1-17,0L140,69V216a12,12,0,0,1-24,0V69L64.49,120.49a12,12,0,0,1-17-17l72-72a12,12,0,0,1,17,0l72,72A12,12,0,0,1,208.49,120.49Z',
+    ],
+    kind: 'fill',
+    squareable: false,
+  },
+  {
+    packId: 'pixelarticons',
+    label: 'Pixelarticons',
+    note: '24px grid · fill · 0 radius',
+    viewBox: '0 0 24 24',
+    paths: [
+      'M11 20h2V4h-2zm2-12h2V6h-2zm2 2h2V8h-2zm2 2h2v-2h-2zm-6-4H9V6h2z',
+      'M15 10H7V8h8zm2 2H5v-2h12z',
+    ],
+    kind: 'fill',
+    squareable: false,
+  },
+  {
+    packId: 'cssgg',
+    label: 'css.gg',
+    note: 'fill · mitred',
+    viewBox: '0 0 24 24',
+    paths: [
+      'M17.6568 8.96219L16.2393 10.3731L12.9843 7.10285L12.9706 20.7079L10.9706 20.7059L10.9843 7.13806L7.75404 10.3532L6.34314 8.93572L12.0132 3.29211L17.6568 8.96219Z',
+    ],
+    kind: 'fill',
+    squareable: false,
+  },
+  {
+    packId: 'material',
+    label: 'Material Sharp',
+    note: 'fill · variable axes',
+    viewBox: '0 -960 960 960',
+    paths: [
+      'M444-192v-438L243-429l-51-51 288-288 288 288-51 51-201-201v438h-72Z',
+    ],
+    kind: 'fill',
+    squareable: false,
+  },
+  {
+    packId: 'codicons',
+    label: 'Codicons',
+    note: '16 grid · fill',
+    viewBox: '0 0 16 16',
+    paths: [
+      'M13.854 7.14576L8.85401 2.14576C8.65901 1.95076 8.34201 1.95076 8.14701 2.14576L3.14601 7.14576C2.95101 7.34076 2.95101 7.65776 3.14601 7.85276C3.34101 8.04776 3.65801 8.04776 3.85301 7.85276L7.99901 3.70676V13.4998C7.99901 13.7758 8.22301 13.9998 8.49901 13.9998C8.77501 13.9998 8.99901 13.7758 8.99901 13.4998V3.70676L13.145 7.85276C13.243 7.95076 13.371 7.99876 13.499 7.99876C13.627 7.99876 13.755 7.95076 13.853 7.85276C14.049 7.65776 14.049 7.34076 13.854 7.14576Z',
+    ],
+    kind: 'fill',
+    squareable: false,
+  },
+  {
+    packId: 'octicons',
+    label: 'Octicons',
+    note: '16 grid · fill',
+    viewBox: '0 0 16 16',
+    paths: [
+      'M3.47 7.78a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0l4.25 4.25a.751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018L9 4.81v7.44a.75.75 0 0 1-1.5 0V4.81L4.53 7.78a.75.75 0 0 1-1.06 0Z',
+    ],
+    kind: 'fill',
+    squareable: false,
+  },
+];
+
+/**
+ * Lucide `file-text` — the honest caveat. Its document corners are
+ * `a 2 2 0 0 1` arcs, so squaring the caps does not square the shape.
+ */
+export const LUCIDE_FILE_TEXT: string[] = [
+  'M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z',
+  'M14 2v5a1 1 0 0 0 1 1h5',
+  'M10 9H8',
+  'M16 13H8',
+  'M16 17H8',
+];
+
+/**
+ * Mono Icons ships raw SVG with a baked `#0D0D0D` fill. Rendered here
+ * exactly as published, to show what a non-currentColor pack does when the
+ * tokens flip to paper.
+ */
+export const BAKED_FILL_SPECIMEN = {
+  viewBox: '0 0 24 24',
+  fill: '#0D0D0D',
+  path: 'M12 4a1 1 0 0 1 .707.293l6 6a1 1 0 0 1-1.414 1.414L13 7.414V19a1 1 0 1 1-2 0V7.414l-4.293 4.293a1 1 0 0 1-1.414-1.414l6-6A1 1 0 0 1 12 4z',
+};
+
+/** Pixelarticons specimens, paired against their Lucide equivalents. */
+export const PIXEL_SPECIMENS: { name: string; paths: string[] }[] = [
+  { name: 'menu', paths: ['M20 18H4v-2h16v2Zm0-5H4v-2h16v2Zm0-5H4V6h16v2Z'] },
+  {
+    name: 'search',
+    paths: [
+      'M22 22h-2v-2h2v2Zm-2-2h-2v-2h2v2Zm-6-2H6v-2h8v2Zm4 0h-2v-2h2v2ZM6 16H4v-2h2v2Zm10 0h-2v-2h2v2ZM4 14H2V6h2v8Zm14 0h-2V6h2v8ZM6 6H4V4h2v2Zm10 0h-2V4h2v2Zm-2-2H6V2h8v2Z',
+    ],
+  },
+  {
+    name: 'external-link',
+    paths: [
+      'M11 5H5v2h6V5ZM5 7H3v12h2V7Zm12 12H5v2h12v-2Zm2-6h-2v6h2v-6Zm-8 0H9v2h2v-2Zm2-2h-2v2h2v-2Zm2-2h-2v2h2V9Zm2-2h-2v2h2V7Zm2-2h-2v2h2V5Zm2-2h-2v8h2V3Z',
+      'M21 3h-8v2h8V3Z',
+    ],
+  },
+  {
+    name: 'chevron-right',
+    paths: [
+      'M16 13v-2h-2v2h2Zm-2-2V9h-2v2h2Zm0 4v-2h-2v2h2Zm-2-6V7h-2v2h2Zm0 8v-2h-2v2h2ZM10 7V5H8v2h2Zm0 12v-2H8v2h2Z',
+    ],
+  },
+  {
+    name: 'file',
+    paths: [
+      'M6 4H4v16h2zm10-2H6v2h10zm4 4h-2v14h2zm-2 14H6v2h12zM16 4h2v2h-2zm-4 0h2v6h-2z',
+      'M12 8h6v2h-6z',
+    ],
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/* Brand-mark provenance — what components/social-icons actually ships. */
+/* ------------------------------------------------------------------ */
+
+export interface BrandMark {
+  kind: string;
+  /** Where the vendored path actually came from. */
+  provenance: string;
+  licence: string;
+  /** Whether the repo currently declares that provenance anywhere. */
+  declared: boolean;
+  viewBox: string;
+  path: string;
+}
+
+export const BRAND_MARKS: BrandMark[] = [
+  {
+    kind: 'github',
+    provenance: 'Simple Icons — path matches upstream byte for byte',
+    licence: 'CC0-1.0',
+    declared: true,
+    viewBox: '0 0 24 24',
+    path: 'M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12',
+  },
+  {
+    kind: 'linkedin',
+    provenance: 'Simple Icons, hand-copied',
+    licence: 'CC0-1.0',
+    declared: true,
+    viewBox: '0 0 24 24',
+    path: 'M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z',
+  },
+  {
+    kind: 'x',
+    provenance: 'Simple Icons, hand-copied',
+    licence: 'CC0-1.0',
+    declared: true,
+    viewBox: '0 0 24 24',
+    path: 'M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z',
+  },
+  {
+    kind: 'twitter',
+    provenance: 'Simple Icons — the retired pre-2023 bird, still shipping',
+    licence: 'CC0-1.0',
+    declared: true,
+    viewBox: '0 0 24 24',
+    path: 'M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z',
+  },
+  {
+    kind: 'mail',
+    provenance: 'Not a brand mark and not Simple Icons — a stray 20x20 glyph',
+    licence: 'unknown',
+    declared: false,
+    viewBox: '0 0 20 20',
+    path: 'M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884zM18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z',
+  },
+];

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -52,6 +52,10 @@ them (see `tests/theme-toggle.spec.ts`).
 - **No emoji as UI** — native emoji render as fixed full-colour OS glyphs that
   ignore the theme; use lucide icons tinted with a `text-brutalist-*` accent.
 
+Why lucide and not one of the other public packs — geometry, dual-mode
+survival and the licence cost of re-exporting art from a published npm
+package — is argued panel by panel at **`/experiments/icon-packs`**.
+
 ## Tailwind v4 (non-standard)
 
 ```css

--- a/pages/experiments.tsx
+++ b/pages/experiments.tsx
@@ -3,6 +3,7 @@ import {
   Boxes,
   Palette,
   Projector,
+  Shapes,
   Sparkles,
   Terminal,
   Type,
@@ -46,6 +47,15 @@ const experiments = [
     icon: <Sparkles className="w-12 h-12" />,
     status: 'active',
     components: 6,
+  },
+  {
+    name: 'Icon Packs',
+    path: '/experiments/icon-packs',
+    description:
+      'Thirteen public icon packs judged live against the brutalist dual-mode system — geometry, theming and the licence cost of publishing them',
+    icon: <Shapes className="w-12 h-12" />,
+    status: 'active',
+    components: 8,
   },
   {
     name: 'Talk Animations',

--- a/pages/experiments/icon-packs.tsx
+++ b/pages/experiments/icon-packs.tsx
@@ -1,0 +1,283 @@
+import { Shapes } from 'lucide-react';
+import type { ReactNode } from 'react';
+import {
+  BakedCorners,
+  BrandProvenance,
+  CapFixDemo,
+  GeometryStrip,
+  LicenceLedger,
+  PACKS,
+  PixelPairing,
+  StrokeWeight,
+  ThemeSurvival,
+  VERDICT_ACCENT,
+  VERDICT_LABEL,
+} from '@/components/iconlab';
+import PageHeader from '@/components/PageHeader';
+import { PageSEO } from '@/components/SEO';
+import siteMetadata from '@/data/siteMetadata';
+
+/**
+ * One argument per panel. `claim` is the thing being asserted, `shown` is
+ * what the reader is looking at — kept separate so a panel that stops
+ * demonstrating its claim is obvious rather than merely decorative.
+ */
+function Panel({
+  kind,
+  title,
+  claim,
+  children,
+}: {
+  kind: string;
+  title: string;
+  claim: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="border-b-2 border-white px-6 py-10">
+      <div className="mb-1 flex flex-wrap items-baseline gap-3">
+        <span className="bg-brutalist-cyan px-1.5 font-mono text-[10px] font-bold uppercase text-black">
+          {kind}
+        </span>
+        <h2 className="font-display text-2xl font-bold uppercase text-white">
+          {title}
+        </h2>
+      </div>
+      <p className="mb-5 max-w-3xl font-mono text-xs text-zinc-400">
+        <span className="text-brutalist-yellow">&gt;</span> {claim}
+      </p>
+      {children}
+    </section>
+  );
+}
+
+const HEADLINE = [
+  {
+    pack: 'Lucide',
+    verdict: 'keep' as const,
+    line: 'Already installed, already right on four of five constraints. One CSS rule closes the fifth.',
+  },
+  {
+    pack: 'Simple Icons',
+    verdict: 'adopt' as const,
+    line: 'Already the source of the social icons — as hand-copied paths. Depend on it instead.',
+  },
+  {
+    pack: 'Pixelarticons',
+    verdict: 'accent' as const,
+    line: 'MIT pixel glyphs on the same grid as the VT323 logo. Scoped accent, not a replacement.',
+  },
+];
+
+export default function IconPacksExperiment() {
+  const rejected = PACKS.filter((p) => p.verdict === 'pass').length;
+
+  return (
+    <>
+      <PageSEO
+        title={`Icon Packs - ${siteMetadata.author}`}
+        description="Public icon packs judged against the brutalist dual-mode design system, with the geometry, theming and licence arguments rendered live"
+      />
+      <div className="border-2 border-white bg-black">
+        <PageHeader
+          title="ICON_PACKS"
+          icon={Shapes}
+          accent="cyan"
+          subtitle="Fourteen public packs, judged live against zero radius, 2px borders and a token set that flips to paper"
+        />
+
+        {/* ---------------- verdict up front ---------------- */}
+        <section className="border-b-2 border-white px-6 py-10">
+          <div className="grid gap-4 lg:grid-cols-3">
+            {HEADLINE.map((h) => (
+              <div
+                key={h.pack}
+                className="border-2 border-white bg-zinc-900 p-5 shadow-hard-md"
+              >
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <span className="font-display text-xl font-bold uppercase text-white">
+                    {h.pack}
+                  </span>
+                  <span
+                    className={`border-2 px-2 py-0.5 font-mono text-[10px] font-bold uppercase ${VERDICT_ACCENT[h.verdict]}`}
+                  >
+                    {VERDICT_LABEL[h.verdict]}
+                  </span>
+                </div>
+                <p className="font-mono text-xs leading-relaxed text-zinc-400">
+                  {h.line}
+                </p>
+              </div>
+            ))}
+          </div>
+          <p className="mt-5 max-w-3xl font-mono text-xs text-zinc-400">
+            <span className="text-brutalist-pink">&gt;</span> {rejected} packs
+            rejected — every one of them a good icon set that disagrees with
+            this brief. The panels below are the working, not the write-up: each
+            one renders the actual published path data and lets the argument be
+            checked rather than believed.
+          </p>
+        </section>
+
+        <Panel
+          kind="constraint 01"
+          title="It has to survive the theme flip"
+          claim="The design system re-points its colour tokens for sketch mode, so an icon that ships a baked fill colour cannot follow. Both panels below are the same markup — only the theme class differs."
+        >
+          <ThemeSurvival />
+        </Panel>
+
+        <Panel
+          kind="constraint 02"
+          title="The same arrow, ten ways"
+          claim="Every pack claims consistent and geometric. What matters here is narrower: where the stroke terminates, whether corners are arcs, and whether a stylesheet can reach any of it."
+        >
+          <GeometryStrip />
+        </Panel>
+
+        <Panel
+          kind="constraint 03"
+          title="2px icons in a 2px system"
+          claim="Borders in this system are 2px, always. An icon drawn at 1.5px is not lighter by intent — it is a different weight class sitting inside the frame."
+        >
+          <StrokeWeight />
+        </Panel>
+
+        <Panel
+          kind="the fix"
+          title="One rule, no import sites touched"
+          claim="Lucide's round caps are the only real mismatch, and they are set as presentation attributes on the root svg — which CSS outranks. Judge it in chrome, not on a swatch grid."
+        >
+          <CapFixDemo />
+        </Panel>
+
+        <Panel
+          kind="the caveat"
+          title="What the rule does not fix"
+          claim="Squaring the caps does not square the shape. Lucide bakes ~2px corner arcs into the path data, and this is the honest limit of the recommendation."
+        >
+          <BakedCorners />
+        </Panel>
+
+        <Panel
+          kind="licence"
+          title="What each licence costs a published package"
+          claim="The design system publishes to public npm, so a licence is not a footnote — it is an obligation handed to everyone who installs it. Packs grouped by what they actually ask, rather than by whether they call themselves open."
+        >
+          <LicenceLedger />
+        </Panel>
+
+        <Panel
+          kind="licence · applied"
+          title="Five brand marks, one undeclared"
+          claim="The clearest licence finding in the repo is not about a pack it should adopt — it is about art it already vendored by hand."
+        >
+          <BrandProvenance />
+        </Panel>
+
+        <Panel
+          kind="the accent"
+          title="Pixel glyphs, pixel font, same grid"
+          claim="The strongest brand-fit result of the audit, and the one that needs a boundary written down before it drifts site-wide."
+        >
+          <PixelPairing />
+        </Panel>
+
+        {/* ---------------- full matrix ---------------- */}
+        <section className="border-b-2 border-white px-6 py-10">
+          <div className="mb-1 flex flex-wrap items-baseline gap-3">
+            <span className="bg-brutalist-yellow px-1.5 font-mono text-[10px] font-bold uppercase text-black">
+              the field
+            </span>
+            <h2 className="font-display text-2xl font-bold uppercase text-white">
+              Every pack, every verdict
+            </h2>
+          </div>
+          <p className="mb-5 max-w-3xl font-mono text-xs text-zinc-400">
+            <span className="text-brutalist-yellow">&gt;</span> Counts and
+            licences read from each project's own repository, August 2026.
+          </p>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            {PACKS.map((pack) => (
+              <div
+                key={pack.id}
+                className="flex flex-col gap-3 border-2 border-white bg-zinc-900 p-4"
+              >
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <span className="font-display text-lg font-bold uppercase text-white">
+                    {pack.name}
+                  </span>
+                  <span
+                    className={`border-2 px-2 py-0.5 font-mono text-[10px] font-bold uppercase ${VERDICT_ACCENT[pack.verdict]}`}
+                  >
+                    {VERDICT_LABEL[pack.verdict]}
+                  </span>
+                </div>
+
+                <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 font-mono text-[11px]">
+                  <dt className="text-zinc-500">icons</dt>
+                  <dd className="text-white">{pack.count}</dd>
+                  <dt className="text-zinc-500">licence</dt>
+                  <dd className="text-brutalist-cyan">{pack.licence}</dd>
+                  <dt className="text-zinc-500">geometry</dt>
+                  <dd className="text-zinc-400">{pack.geometry}</dd>
+                  <dt className="text-zinc-500">delivery</dt>
+                  <dd className="text-zinc-400">{pack.delivery}</dd>
+                </dl>
+
+                <p className="font-mono text-xs leading-relaxed text-zinc-400">
+                  {pack.why}
+                </p>
+
+                <a
+                  href={pack.source}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono text-[10px] uppercase text-brutalist-cyan hover:text-brutalist-pink"
+                >
+                  source repo
+                </a>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ---------------- attribution ---------------- */}
+        <section className="px-6 py-8">
+          <h2 className="mb-3 font-display text-lg font-bold uppercase text-white">
+            [ SPECIMEN_ATTRIBUTION ]
+          </h2>
+          <p className="max-w-3xl font-mono text-xs leading-relaxed text-zinc-400">
+            Every glyph on this page is unmodified path data from the pack's own
+            repository, reproduced here to compare geometry. Lucide (ISC).
+            Tabler, Phosphor, Iconoir, Pixelarticons, css.gg and Mono Icons
+            (MIT). Material Symbols (Apache-2.0). Simple Icons (CC0-1.0). VS
+            Code Codicons (CC BY 4.0) —{' '}
+            <a
+              href="https://github.com/microsoft/vscode-codicons"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brutalist-cyan hover:text-brutalist-pink"
+            >
+              microsoft/vscode-codicons
+            </a>
+            , licensed under{' '}
+            <a
+              href="https://creativecommons.org/licenses/by/4.0/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brutalist-cyan hover:text-brutalist-pink"
+            >
+              CC BY 4.0
+            </a>
+            . Reproducing that one specimen is itself the demonstration: this
+            paragraph is the obligation the ATTRIBUTION tier describes, and it
+            is the reason none of those packs belong in the published design
+            system.
+          </p>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/tests/icon-packs.test.ts
+++ b/tests/icon-packs.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ARROW_SPECIMENS,
+  BRAND_MARKS,
+  PACKS,
+  VERDICT_ACCENT,
+  VERDICT_LABEL,
+} from '../components/iconlab/packs';
+
+describe('icon pack registry', () => {
+  it('gives every pack an id, a licence and a stated obligation', () => {
+    for (const pack of PACKS) {
+      expect(pack.id, `${pack.name} needs an id`).toBeTruthy();
+      expect(pack.licence, `${pack.name} needs a licence`).toBeTruthy();
+      expect(
+        pack.obligation.length,
+        `${pack.name} must say what its licence asks`,
+      ).toBeGreaterThan(20);
+      expect(pack.source).toMatch(/^https:\/\//);
+    }
+  });
+
+  it('has no duplicate pack ids', () => {
+    const ids = PACKS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('renders every verdict it uses', () => {
+    for (const pack of PACKS) {
+      expect(VERDICT_LABEL[pack.verdict]).toBeTruthy();
+      expect(VERDICT_ACCENT[pack.verdict]).toBeTruthy();
+    }
+  });
+});
+
+describe('licence rules', () => {
+  /**
+   * The rule the page argues for: the design system publishes to public npm,
+   * so nothing it re-exports may hand an obligation to consumers. Only the
+   * `clear` and `notice` tiers qualify.
+   */
+  it('never recommends a pack whose licence propagates an obligation', () => {
+    const recommended = PACKS.filter((p) =>
+      ['keep', 'adopt', 'accent'].includes(p.verdict),
+    );
+
+    expect(recommended.length).toBeGreaterThan(0);
+    for (const pack of recommended) {
+      expect(
+        ['clear', 'notice'],
+        `${pack.name} is recommended but sits in the ${pack.tier} tier`,
+      ).toContain(pack.tier);
+    }
+  });
+
+  it('rejects every attribution-tier pack', () => {
+    for (const pack of PACKS.filter((p) => p.tier === 'attribution')) {
+      expect(pack.verdict, `${pack.name} carries a CC BY obligation`).toBe(
+        'pass',
+      );
+    }
+  });
+
+  it('keeps a declared licence against every vendored brand mark', () => {
+    for (const mark of BRAND_MARKS) {
+      expect(mark.licence, `${mark.kind} needs a licence`).toBeTruthy();
+      // An undeclared mark is allowed to exist — that is the finding — but it
+      // must be flagged rather than quietly passed off as declared.
+      if (!mark.declared) {
+        expect(mark.licence).toBe('unknown');
+      }
+    }
+  });
+});
+
+describe('glyph specimens', () => {
+  it('attributes every specimen to a pack in the registry', () => {
+    const ids = new Set(PACKS.map((p) => p.id));
+    for (const glyph of ARROW_SPECIMENS) {
+      expect(ids, `${glyph.label} is not in the registry`).toContain(
+        glyph.packId,
+      );
+    }
+  });
+
+  it('only claims CSS can re-cut a stroke set', () => {
+    for (const glyph of ARROW_SPECIMENS) {
+      if (glyph.squareable) {
+        expect(glyph.kind).toBe('stroke');
+        expect(glyph.strokeWidth).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('ships real path data for every specimen', () => {
+    for (const glyph of ARROW_SPECIMENS) {
+      expect(glyph.paths.length).toBeGreaterThan(0);
+      for (const d of glyph.paths) {
+        expect(d).toMatch(/^[Mm]/);
+      }
+    }
+  });
+});


### PR DESCRIPTION
…icon-packs

Fourteen public icon packs judged against the brutalist dual-mode system. Every panel renders the pack's own published path data rather than a screenshot, so each claim can be checked in the browser:

- theme survival — token-tinted icons vs a pack that bakes #0D0D0D, in dark and sketch side by side
- geometry — the same arrow-up from ten packs, with a live stroke-linecap toggle showing which sets a stylesheet can re-cut and which are baked
- stroke weight — 1.5 / 2 / 2.5px inside the 2px border they sit next to
- the fix — lucide chrome with round vs square caps, plus the one-line rule
- the caveat — file-text at 160px with its baked 2px corner arcs marked, because squaring the caps does not square the shape
- licence — packs grouped by what their licence costs a package published to npm (clear / notice / attribution / bespoke), with five rules
- brand provenance — the five vendored social marks, one of them undeclared
- pixel pairing — Pixelarticons against the VT323 face already in the header

Verdict: keep Lucide, depend on Simple Icons instead of vendoring its paths, and scope Pixelarticons as an accent. The licence rules are enforced by tests/icon-packs.test.ts — a pack in the attribution tier cannot be marked as recommended.


Claude-Session: https://claude.ai/code/session_01JDSav9WBeFcuQQ3Cye3ZhG