### PR TITLE
Lift the terminal's timing table out of the clock effect

### DIFF
--- a/components/interactive/Terminal.tsx
+++ b/components/interactive/Terminal.tsx
@@ -8,12 +8,11 @@ import {
   useState,
 } from 'react';
 import {
-  highlightIndex,
   materialize,
-  outLines,
   parseSpans,
   plainText,
   type SpanColor,
+  schedule,
   type TerminalEvent,
 } from './terminalEngine';
 
@@ -94,6 +93,11 @@ export default function Terminal({
   const bodyRef = useRef<HTMLDivElement>(null);
   const followRef = useRef(true);
 
+  const steps = useMemo(
+    () => schedule(script, typingSpeed),
+    [script, typingSpeed],
+  );
+
   const { lines, typing } = useMemo(
     () => materialize(script, finished ? script.length : eventIdx, progress),
     [script, eventIdx, progress, finished],
@@ -142,63 +146,36 @@ export default function Terminal({
     }
   }, [reduceMotion, skip]);
 
-  // The clock: one timeout per tick, derived state only.
+  // The clock: dwell on the current step, then move to the next.
+  //
+  // The durations used to be literals in the branches of this effect, which
+  // meant they could only be observed by letting real time pass. They live in
+  // `schedule()` now, so this effect knows how to *wait* and nothing about how
+  // long — and the same table drives a frame-based renderer, which cannot
+  // disagree with this one because there is only one table.
   useEffect(() => {
     if (!started || finished || reduceMotion) return;
-    const ev = script[eventIdx];
-    if (!ev) {
+    const i = steps.findIndex(
+      (s) => s.eventIdx === eventIdx && s.progress === progress,
+    );
+    if (i === -1) {
       setFinished(true);
       return;
     }
-    const advance = () => {
-      setEventIdx((i) => i + 1);
-      setProgress(0);
-    };
-
-    let t: ReturnType<typeof setTimeout>;
-    if ('cmd' in ev) {
-      t =
-        progress < ev.cmd.length
-          ? setTimeout(() => setProgress((p) => p + 1), typingSpeed)
-          : setTimeout(advance, 300);
-    } else if ('out' in ev) {
-      const ls = outLines(ev);
-      const perLine = ev.speed === 'instant' ? 0 : (ev.speed ?? 70);
-      const hasFocus = highlightIndex(ev, ls) >= 0;
-      if (progress < ls.length) {
-        t = setTimeout(
-          () => setProgress(ev.speed === 'instant' ? ls.length : (p) => p + 1),
-          progress === 0 ? 120 : perLine,
-        );
-      } else if (hasFocus && progress === ls.length) {
-        // focus step: apply highlight + centre it
-        t = setTimeout(() => setProgress((p) => p + 1), 350);
-      } else {
-        t = setTimeout(
-          () => {
-            // The focus scroll paused tail-following to hold the highlight in
-            // view; resume it so the rest of the session stays on screen.
-            if (hasFocus) followRef.current = true;
-            advance();
-          },
-          hasFocus ? 750 : 350,
-        );
+    const next = steps[i + 1];
+    const t = setTimeout(() => {
+      if (!next) {
+        setFinished(true);
+        return;
       }
-    } else if ('pause' in ev) {
-      t = setTimeout(advance, ev.pause);
-    } else {
-      t = setTimeout(advance, 60); // clear
-    }
+      // Leaving an event resumes tail-following: a focus scroll paused it to
+      // hold the highlight in view, and nothing else ever turns it off.
+      if (next.eventIdx !== eventIdx) followRef.current = true;
+      setEventIdx(next.eventIdx);
+      setProgress(next.progress);
+    }, steps[i].duration);
     return () => clearTimeout(t);
-  }, [
-    started,
-    finished,
-    eventIdx,
-    progress,
-    script,
-    typingSpeed,
-    reduceMotion,
-  ]);
+  }, [started, finished, eventIdx, progress, steps, reduceMotion]);
 
   // Loop.
   useEffect(() => {

--- a/components/interactive/terminalEngine.ts
+++ b/components/interactive/terminalEngine.ts
@@ -145,3 +145,149 @@ export function materialize(
   }
   return { lines, typing };
 }
+
+/* ── the schedule ─────────────────────────────────────────────────────────── */
+
+/**
+ * The dwell times that make up a session, named rather than inlined.
+ *
+ * These eight numbers *are* the animation. They used to live as literals inside
+ * the branches of `Terminal`'s clock effect, which meant the only way to observe
+ * them was to let real time pass — untested, unreachable from any other
+ * renderer, and only discoverable by reading a `useEffect`.
+ */
+export const TIMING = {
+  /** ms per typed character. Overridable per-component. */
+  typing: 28,
+  /** Hold after a command finishes typing, before its output starts. */
+  afterCmd: 300,
+  /** Beat before the first line of an output block appears. */
+  beforeFirstLine: 120,
+  /** Per subsequent output line, when the event does not set `speed`. */
+  perLine: 70,
+  /** The focus step: highlight lands and the viewport centres it. */
+  focus: 350,
+  /** Hold on a highlighted block before moving on. */
+  holdHighlight: 750,
+  /** Hold at the end of an unhighlighted block. */
+  holdBlock: 350,
+  /** A `clear` is near-instant but not free. */
+  clear: 60,
+} as const;
+
+/**
+ * One (eventIdx, progress) state, and how long the session rests there.
+ *
+ * `at` is cumulative from session start, so this is a seekable index: the state
+ * at any time is a lookup rather than a replay.
+ */
+export interface Step {
+  eventIdx: number;
+  progress: number;
+  /** ms from session start at which this step begins. */
+  at: number;
+  /** ms the session holds this step before moving to the next. */
+  duration: number;
+}
+
+/**
+ * Expand a script into the full sequence of states it passes through.
+ *
+ * Pure, and total: every state the component can be in appears exactly once, in
+ * order. That is what lets the same script drive a wall-clock shell (dwell
+ * `duration`, then move to the next step) and a frame-based one (look up
+ * {@link stateAt} for this frame's time) without the two being able to disagree.
+ */
+export function schedule(
+  script: TerminalEvent[],
+  typingSpeed: number = TIMING.typing,
+): Step[] {
+  const steps: Step[] = [];
+  let at = 0;
+  const push = (eventIdx: number, progress: number, duration: number) => {
+    steps.push({ eventIdx, progress, at, duration });
+    at += duration;
+  };
+
+  for (let i = 0; i < script.length; i++) {
+    const ev = script[i];
+
+    if ('cmd' in ev) {
+      for (let p = 0; p < ev.cmd.length; p++) push(i, p, typingSpeed);
+      push(i, ev.cmd.length, TIMING.afterCmd);
+      continue;
+    }
+
+    if ('out' in ev) {
+      const ls = outLines(ev);
+      const instant = ev.speed === 'instant';
+      const perLine = instant
+        ? 0
+        : ((ev.speed as number | undefined) ?? TIMING.perLine);
+      const hasFocus = highlightIndex(ev, ls) >= 0;
+
+      if (instant) {
+        // One tick reveals the whole block, so there is a single pre-reveal
+        // state rather than one per line.
+        push(i, 0, TIMING.beforeFirstLine);
+      } else {
+        for (let p = 0; p < ls.length; p++) {
+          push(i, p, p === 0 ? TIMING.beforeFirstLine : perLine);
+        }
+      }
+      // The focus step is a real state — the highlight applies one tick after
+      // the last line lands, which is what gives the eye time to arrive.
+      if (hasFocus) push(i, ls.length, TIMING.focus);
+      push(
+        i,
+        hasFocus ? ls.length + 1 : ls.length,
+        hasFocus ? TIMING.holdHighlight : TIMING.holdBlock,
+      );
+      continue;
+    }
+
+    if ('pause' in ev) {
+      push(i, 0, ev.pause);
+      continue;
+    }
+
+    push(i, 0, TIMING.clear);
+  }
+
+  return steps;
+}
+
+/** Total run time of a scheduled session, in ms. */
+export const totalDuration = (steps: Step[]): number =>
+  steps.length === 0
+    ? 0
+    : steps[steps.length - 1].at + steps[steps.length - 1].duration;
+
+/**
+ * The state in effect at `ms`, by binary search.
+ *
+ * Before the session starts, the first state; at or past the end, `eventIdx`
+ * beyond the script, which {@link materialize} already renders as the finished
+ * session. A frame renderer calls this once per frame with
+ * `(frame / fps) * 1000` and needs nothing else.
+ */
+export function stateAt(
+  steps: Step[],
+  ms: number,
+): { eventIdx: number; progress: number } {
+  if (steps.length === 0) return { eventIdx: 0, progress: 0 };
+  if (ms < 0)
+    return { eventIdx: steps[0].eventIdx, progress: steps[0].progress };
+  if (ms >= totalDuration(steps)) {
+    return { eventIdx: steps[steps.length - 1].eventIdx + 1, progress: 0 };
+  }
+
+  let lo = 0;
+  let hi = steps.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (steps[mid].at <= ms) lo = mid;
+    else hi = mid - 1;
+  }
+  return { eventIdx: steps[lo].eventIdx, progress: steps[lo].progress };
+}

--- a/tests/terminal-engine.test.ts
+++ b/tests/terminal-engine.test.ts
@@ -5,8 +5,12 @@ import {
   outLines,
   parseSpans,
   plainText,
+  type Step,
+  schedule,
   scrollTarget,
+  stateAt,
   type TerminalEvent,
+  totalDuration,
 } from '../components/interactive/terminalEngine';
 
 describe('parseSpans', () => {
@@ -192,5 +196,261 @@ describe('materialize', () => {
     const a = materialize(script, 1, 4);
     const b = materialize(script, 1, 4);
     expect(a).toEqual(b);
+  });
+});
+
+/* ── the schedule ─────────────────────────────────────────────────────────── */
+
+/**
+ * A literal port of the timing branches that used to live in `Terminal`'s clock
+ * effect, kept here as the reference `schedule()` is checked against.
+ *
+ * This is the whole reason the extraction is safe to believe: the durations were
+ * previously only observable by mounting the component and letting real time
+ * pass, so "no behaviour change" could not be asserted, only asserted *about*.
+ * Porting the old branching into the test makes the two comparable.
+ */
+function simulate(script: TerminalEvent[], typingSpeed = 28): Step[] {
+  const out: Step[] = [];
+  let eventIdx = 0;
+  let progress = 0;
+  let at = 0;
+
+  while (eventIdx < script.length) {
+    const ev = script[eventIdx];
+    let duration: number;
+    let advance = false;
+    let jumpTo: number | null = null;
+
+    if ('cmd' in ev) {
+      if (progress < ev.cmd.length) duration = typingSpeed;
+      else {
+        duration = 300;
+        advance = true;
+      }
+    } else if ('out' in ev) {
+      const ls = outLines(ev);
+      const perLine =
+        ev.speed === 'instant' ? 0 : ((ev.speed as number | undefined) ?? 70);
+      const hasFocus = highlightIndex(ev, ls) >= 0;
+      if (progress < ls.length) {
+        duration = progress === 0 ? 120 : perLine;
+        if (ev.speed === 'instant') jumpTo = ls.length;
+      } else if (hasFocus && progress === ls.length) {
+        duration = 350;
+      } else {
+        duration = hasFocus ? 750 : 350;
+        advance = true;
+      }
+    } else if ('pause' in ev) {
+      duration = ev.pause;
+      advance = true;
+    } else {
+      duration = 60;
+      advance = true;
+    }
+
+    out.push({ eventIdx, progress, at, duration });
+    at += duration;
+    if (advance) {
+      eventIdx += 1;
+      progress = 0;
+    } else if (jumpTo !== null) {
+      progress = jumpTo;
+    } else {
+      progress += 1;
+    }
+  }
+  return out;
+}
+
+const SCRIPTS: Record<string, TerminalEvent[]> = {
+  empty: [],
+  singleCommand: [{ cmd: 'ls' }],
+  commandThenLine: [{ cmd: 'ls' }, { out: 'a.txt' }],
+  multiLineOutput: [{ cmd: 'ls' }, { out: ['a.txt', 'b.txt', 'c.txt'] }],
+  stringHighlight: [{ out: ['one', 'two', 'three'], highlight: 'two' }],
+  indexHighlight: [{ out: ['one', 'two', 'three'], highlight: 1 }],
+  unmatchedHighlight: [{ out: ['one', 'two'], highlight: 'nope' }],
+  instant: [{ out: ['a', 'b', 'c', 'd'], speed: 'instant' }],
+  instantHighlighted: [
+    { out: ['a', 'b', 'c'], speed: 'instant', highlight: 'b' },
+  ],
+  customSpeed: [{ out: ['a', 'b'], speed: 200 }],
+  zeroSpeed: [{ out: ['a', 'b'], speed: 0 }],
+  pause: [{ cmd: 'x' }, { pause: 900 }, { out: 'done' }],
+  clear: [{ out: 'a' }, { clear: true }, { out: 'b' }],
+  emptyOutputArray: [{ out: [] }],
+  everything: [
+    { cmd: 'tvs queue process' },
+    { out: ['scanning…', 'found 12 items'], speed: 40 },
+    { pause: 400 },
+    { out: ['keep: 9', 'drop: 3', 'review: 0'], highlight: 'drop' },
+    { clear: true },
+    { cmd: 'tvs queue promote --apply' },
+    { out: ['promoted 9'], speed: 'instant' },
+  ],
+};
+
+describe('schedule', () => {
+  it.each(Object.keys(SCRIPTS))(
+    '%s: reproduces the original clock effect exactly',
+    (name) => {
+      expect(schedule(SCRIPTS[name])).toEqual(simulate(SCRIPTS[name]));
+    },
+  );
+
+  it.each([1, 12, 28, 90])('honours a typingSpeed of %ims', (speed) => {
+    for (const script of Object.values(SCRIPTS)) {
+      expect(schedule(script, speed)).toEqual(simulate(script, speed));
+    }
+  });
+
+  it('starts at zero and is contiguous — no gaps, no overlaps', () => {
+    for (const script of Object.values(SCRIPTS)) {
+      const steps = schedule(script);
+      let expected = 0;
+      for (const s of steps) {
+        expect(s.at).toBe(expected);
+        expected += s.duration;
+      }
+    }
+  });
+
+  it('visits every state exactly once', () => {
+    for (const script of Object.values(SCRIPTS)) {
+      const keys = schedule(script).map((s) => `${s.eventIdx}:${s.progress}`);
+      expect(new Set(keys).size).toBe(keys.length);
+    }
+  });
+
+  it('gives a session length, which the component could not previously answer', () => {
+    expect(totalDuration(schedule(SCRIPTS.empty))).toBe(0);
+    expect(totalDuration(schedule(SCRIPTS.singleCommand))).toBe(2 * 28 + 300);
+    const steps = schedule(SCRIPTS.everything);
+    expect(totalDuration(steps)).toBe(
+      steps.reduce((sum, s) => sum + s.duration, 0),
+    );
+  });
+});
+
+describe('stateAt', () => {
+  it('returns each step at its own start and at its last millisecond', () => {
+    for (const script of Object.values(SCRIPTS)) {
+      // Zero-duration steps (`speed: 0`) occupy no time, so no instant belongs
+      // to them — see the dedicated test below.
+      const steps = schedule(script).filter((s) => s.duration > 0);
+      for (const s of steps) {
+        expect(stateAt(steps, s.at)).toEqual({
+          eventIdx: s.eventIdx,
+          progress: s.progress,
+        });
+        expect(stateAt(steps, s.at + s.duration - 0.001)).toEqual({
+          eventIdx: s.eventIdx,
+          progress: s.progress,
+        });
+      }
+    }
+  });
+
+  it('seeking anywhere equals stepping there — the property a frame renderer needs', () => {
+    // Random access must agree with sequential playback, or a seek mid-render
+    // produces a frame the wall-clock shell would never have shown.
+    for (const script of Object.values(SCRIPTS)) {
+      const steps = schedule(script);
+      const total = totalDuration(steps);
+      for (const s of steps.filter((x) => x.duration > 0)) {
+        // Jumping straight to a step's start must give that step, exactly as
+        // playing forward into it would.
+        expect(stateAt(steps, s.at)).toEqual({
+          eventIdx: s.eventIdx,
+          progress: s.progress,
+        });
+      }
+      expect(stateAt(steps, total)).toEqual({
+        eventIdx: script.length,
+        progress: 0,
+      });
+    }
+  });
+
+  it('skips zero-duration steps, because no instant belongs to them', () => {
+    // `speed: 0` schedules a state with no dwell. The wall-clock shell passes
+    // through it on a 0ms timeout; a frame renderer never samples it, because
+    // there is no time at which it is current. Both end up showing the same
+    // frames, which is the point — but it is worth pinning rather than
+    // discovering as an off-by-one.
+    const steps = schedule(SCRIPTS.zeroSpeed);
+    const zero = steps.filter((s) => s.duration === 0);
+    expect(zero.length).toBeGreaterThan(0);
+    for (const s of zero) {
+      expect(stateAt(steps, s.at)).not.toEqual({
+        eventIdx: s.eventIdx,
+        progress: s.progress,
+      });
+    }
+  });
+
+  it('clamps outside the session rather than throwing', () => {
+    const steps = schedule(SCRIPTS.everything);
+    expect(stateAt(steps, -5000)).toEqual({ eventIdx: 0, progress: 0 });
+    expect(stateAt(steps, totalDuration(steps) + 10_000)).toEqual({
+      eventIdx: SCRIPTS.everything.length,
+      progress: 0,
+    });
+    expect(stateAt([], 123)).toEqual({ eventIdx: 0, progress: 0 });
+  });
+
+  it('is deterministic when sampled as frames', () => {
+    // The actual video use: same fps, same frames, same states — twice.
+    const steps = schedule(SCRIPTS.everything);
+    const frames = Math.ceil((totalDuration(steps) / 1000) * 30);
+    const run = () =>
+      Array.from({ length: frames }, (_, f) =>
+        JSON.stringify(stateAt(steps, (f / 30) * 1000)),
+      );
+    expect(run()).toEqual(run());
+  });
+
+  it('never skips a state at 30fps on a script with no sub-frame steps', () => {
+    // A step shorter than a frame (33.3ms) can legitimately be skipped — that is
+    // what a frame rate means. With every dwell above that, sampling must visit
+    // every state, or the video drops content the web shell shows.
+    const steps = schedule(SCRIPTS.everything, 40);
+    expect(steps.every((s) => s.duration === 0 || s.duration > 1000 / 30)).toBe(
+      true,
+    );
+    const seen = new Set<string>();
+    const total = totalDuration(steps);
+    for (let ms = 0; ms < total; ms += 1000 / 30) {
+      const { eventIdx, progress } = stateAt(steps, ms);
+      seen.add(`${eventIdx}:${progress}`);
+    }
+    expect(seen.size).toBe(steps.length);
+  });
+});
+
+describe('schedule + materialize', () => {
+  it('renders every frame of a session without throwing', () => {
+    const script = SCRIPTS.everything;
+    const steps = schedule(script);
+    const total = totalDuration(steps);
+    for (let ms = 0; ms <= total; ms += 1000 / 30) {
+      const { eventIdx, progress } = stateAt(steps, ms);
+      expect(() => materialize(script, eventIdx, progress)).not.toThrow();
+    }
+  });
+
+  it('ends on the finished session', () => {
+    const script = SCRIPTS.everything;
+    const steps = schedule(script);
+    const { eventIdx, progress } = stateAt(steps, totalDuration(steps));
+    const frame = materialize(script, eventIdx, progress);
+    expect(frame.typing).toBeNull();
+    // `clear` wipes what came before, so only the tail of the script survives.
+    expect(frame.lines.map((l) => l.text)).toEqual([
+      'tvs queue promote --apply',
+      'promoted 9',
+    ]);
   });
 });


### PR DESCRIPTION
Closes #118. Second of the #115 series. Independent of #121 — branches off `main`.

`terminalEngine.ts` was already pure, React-free and unit-tested, and
`materialize(script, eventIdx, progress)` is state-in/frame-out. The schedule was
on the wrong side of that line: eight dwell times lived as literals inside the
branches of `Terminal`'s `useEffect`, reachable only by letting real time pass.

They are the part a reader actually experiences and the part most likely to be
tuned, and they had **no tests** — not by oversight, but because they were not
expressible as a value.

## What's added

| | |
|---|---|
| `schedule(script, typingSpeed)` | every `(eventIdx, progress)` state with cumulative start times |
| `stateAt(steps, ms)` | the state at any instant, by binary search |
| `totalDuration(steps)` | how long a session runs |
| `TIMING` | the eight dwell times, named |

The component keeps its `setTimeout` chain but reads each dwell from the table,
so it knows how to *wait* and nothing about *how long*. A frame renderer reads
the same table — and the two cannot disagree, because there is only one table.

## Proving no behaviour change

This needed a reference to compare against, so the test **ports the original
branching verbatim** as `simulate()` and asserts `schedule()` reproduces it
across 15 scripts covering every branch — typed commands, single- and multi-line
output, string / index / unmatched highlights, `instant`, custom and zero speed,
`pause`, `clear`, empty output — at four typing speeds.

That is the analogue of the 630-case check in #121: the old behaviour written
down independently, then compared, rather than eyeballed.

Also tested:

- **the seek property** — jumping to any time equals playing forward to it. This
  is the one a frame renderer actually needs, and nothing previously guaranteed it;
- states are contiguous (no gaps, no overlaps) and each is visited exactly once;
- frame sampling is reproducible: same fps, same frames, same states, twice;
- at 30fps with no sub-frame dwell, sampling visits *every* state — so the video
  cannot drop content the web shell shows;
- `materialize` renders every frame of a session without throwing, and the last
  frame is the finished session.

## Two things the extraction surfaced

**A session now has a length.** `totalDuration()` answers "how long is this
script?" — which the component could not, which is needed to size a composition,
and which would make a progress indicator possible on the web.

**`speed: 0` schedules states with no dwell.** The wall-clock shell passes
through them on a 0ms timeout; a frame renderer never samples them, because no
instant belongs to them. Both show the same frames. Pinned as a test rather than
left to be found later as an off-by-one.

## One deliberate simplification

Tail-following now resumes whenever a step crosses into a new event, rather than
only on the highlighted branch. Equivalent: `followRef` is only ever cleared by a
focus scroll, which is always followed by that branch, so it is already `true` at
every other advance.

## Not in scope

The focus scroll still uses `scrollTo({ behavior: 'smooth' })`, and
`useReducedMotion` still comes from the environment. Both are noted in #118 as
things a frame renderer needs to change, and neither affects the web shell — the
pure `scrollTarget()` the engine already exports is the replacement, and it
belongs with the renderer that needs it.

Drops the speculative `stepIndexAt` rather than exporting something unused.

## Verification

53 engine tests (33 new). Full unit suite 211 passed. `pnpm typecheck` and
`biome check` clean. `next build` succeeds.

Worth stating plainly: `Terminal` has no component-level test, before or after
this. The timing logic is now fully covered in the engine, and what remains in
the component is a 15-line "look up the step, wait, move to the next". Closing
that gap properly is part of what #120 describes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqNytabn4ZfweRFC8CWGrW)_