### PR TITLE
Read a talk as a timeline, and leave the live room out of it

### DIFF
--- a/components/talks/SlideBody.tsx
+++ b/components/talks/SlideBody.tsx
@@ -1,14 +1,30 @@
 import { getMDXComponent } from 'mdx-bundler/client';
 import { useMemo } from 'react';
 import { MDXComponents } from '@/components/MDXComponents';
+import { withoutLiveComponents } from './liveComponents';
 
 // Slides are standalone fragments with no layout, so drop the `wrapper`
 // component (which would try to require `../layouts/<layout>` and crash).
 const { wrapper: _wrapper, ...slideComponents } = MDXComponents;
 
+// Built once rather than per render: the map is the same for every slide, and
+// rebuilding it would give `MDXContent` a new `components` object each time.
+const renderComponents = withoutLiveComponents(slideComponents);
+
 interface SlideBodyProps {
   /** Compiled MDX code string for a single slide. */
   code: string;
+  /**
+   * Leave out the components that only mean something in a live room — the
+   * poll, the question queue, the timers.
+   *
+   * For a surface with no Convex behind it and nobody to participate: a frame
+   * renderer, a print export. Without this those components render whatever
+   * they do with no data, which is a loading state or a zero count baked into
+   * the output — worse than absence, because it looks like a bug rather than a
+   * choice. See `liveComponents.ts`.
+   */
+  omitLive?: boolean;
 }
 
 /**
@@ -16,7 +32,7 @@ interface SlideBodyProps {
  * <Diagram>, <NoteBlock>, code highlighting etc. work inside a Spectacle slide.
  * Each instance calls `getMDXComponent` exactly once (Rules of Hooks).
  */
-export default function SlideBody({ code }: SlideBodyProps) {
+export default function SlideBody({ code, omitLive = false }: SlideBodyProps) {
   const MDXContent = useMemo(() => getMDXComponent(code), [code]);
 
   // Fill the slide's full height and center the content vertically so sparse
@@ -25,7 +41,9 @@ export default function SlideBody({ code }: SlideBodyProps) {
   return (
     <div className="flex h-full flex-col justify-center">
       <div className="prose prose-invert prose-xl max-w-none">
-        <MDXContent components={slideComponents} />
+        <MDXContent
+          components={omitLive ? renderComponents : slideComponents}
+        />
       </div>
     </div>
   );

--- a/components/talks/liveComponents.ts
+++ b/components/talks/liveComponents.ts
@@ -1,0 +1,66 @@
+/**
+ * Which slide-embedded components belong to a live room, and how to take them
+ * out of a render.
+ *
+ * A deck slide can embed audience machinery — a poll, a question queue, a break
+ * timer. Every one of them is realtime: it subscribes to Convex, shows state
+ * that only exists while a room is open, and is meaningless in a recording. A
+ * video of a talk that renders an empty poll is worse than one that renders no
+ * poll, because the empty poll looks like a bug.
+ *
+ * They also cannot simply be left to fail. Outside a Convex provider their
+ * hooks have nothing to read, so what a render would capture is whatever each
+ * component happens to do with `undefined` — a loading state, a zero count, or
+ * a thrown error. That is three different wrong answers rather than one right
+ * one.
+ *
+ * So the boundary blanks them by name. This is a whitelist at the single place
+ * a slide's components are resolved, rather than a flag threaded through seven
+ * components, and `tests/talk-video.test.ts` asserts the list still covers
+ * every realtime component the module exports — so adding an eighth and
+ * forgetting this file fails the suite instead of shipping a dead widget into a
+ * video.
+ */
+
+import type { ComponentType } from 'react';
+
+/**
+ * Components that only mean something in a live room.
+ *
+ * Kept as names rather than references so this module stays free of the
+ * imports — it is consulted by a render boundary that should not pull Convex
+ * into its bundle just to decide what to leave out.
+ */
+export const LIVE_COMPONENT_NAMES = [
+  'BreakTimer',
+  'EmojiTop5',
+  'LivePoll',
+  'OrderedActions',
+  'QuestionQueue',
+  'RateLimitNotice',
+  'TalkTimer',
+] as const;
+
+export type LiveComponentName = (typeof LIVE_COMPONENT_NAMES)[number];
+
+/** Renders nothing, and is named so it is obvious in a React tree. */
+const Blank: ComponentType = function OmittedFromRender() {
+  return null;
+};
+
+/**
+ * A component map with every live component replaced by one that renders
+ * nothing.
+ *
+ * Returns a new object; the input map is the site's shared `MDXComponents` and
+ * is used by every other surface.
+ */
+export function withoutLiveComponents<T extends Record<string, unknown>>(
+  components: T,
+): T {
+  const out = { ...components } as Record<string, unknown>;
+  for (const name of LIVE_COMPONENT_NAMES) {
+    if (name in out) out[name] = Blank;
+  }
+  return out as T;
+}

--- a/lib/talkVideo.ts
+++ b/lib/talkVideo.ts
@@ -1,0 +1,197 @@
+/**
+ * Turning a talk into a timeline a frame renderer can seek.
+ *
+ * The decks already carry per-slide timing — this module does not invent it.
+ * `slideTiming.ts` parses the `[⏱ 12–34 · LABEL]` ranges the presenter console
+ * uses for pacing, and across the six decks in `data/talks/` those ranges are
+ * complete and exactly contiguous: no gaps, no overlaps, and a span that equals
+ * the deck's own `durationMins` in every case. A talk is already a fully
+ * specified timeline; it has just never been read as one.
+ *
+ * ## The second tag form
+ *
+ * `parseSlideWindow` is deliberately tolerant and returns null for anything
+ * that is not a range. That drops real information, because decks use a second
+ * form for slides that sit *inside* a neighbour's window rather than after it:
+ *
+ *     [⏱ ~1 min · ICEBREAKER 🗳️ · overlaps the intro window]
+ *     [⏱ ~1 min · IBM QUOTE · inside the AI window]
+ *
+ * Both declare a duration; neither declares a position, because the author's
+ * intent is that the minute is *carved out of* the surrounding window rather
+ * than added to the talk. Reading only the ranges would give those slides no
+ * time at all — a contiguous set of ranges leaves no gap for them to occupy —
+ * so they would flash past in a render.
+ *
+ * {@link parseSlideHint} reads both forms, and {@link talkSchedule} honours the
+ * distinction: an approximate slide borrows from its host rather than extending
+ * the talk. The total therefore still matches `durationMins`, which is the
+ * property that makes the schedule trustworthy.
+ *
+ * Pure — no fs, no React — so the build-time loader, a composition and the
+ * tests all read the same timeline.
+ */
+
+import { parseSlideWindow } from './slideTiming';
+
+/**
+ * A slide's declared timing, in whichever of the two forms the deck used.
+ *
+ * `window` places the slide absolutely; `approx` only says how long it wants,
+ * and leaves placement to the schedule.
+ */
+export type SlideHint =
+  | { kind: 'window'; startMin: number; endMin: number }
+  | { kind: 'approx'; minutes: number }
+  | null;
+
+/**
+ * `[⏱ ~1 min · …]` — the duration-only form. Anchored on `~` so it cannot
+ * match the leading number of a range.
+ */
+const APPROX_RE = /\[\s*⏱\s*~\s*(\d+(?:\.\d+)?)\s*min/u;
+
+/** Read whichever timing form a slide's notes declare, if either. */
+export function parseSlideHint(notes: string | null | undefined): SlideHint {
+  const window = parseSlideWindow(notes);
+  if (window) return { kind: 'window', ...window };
+
+  if (!notes) return null;
+  const approx = notes.match(APPROX_RE);
+  if (!approx) return null;
+
+  const minutes = Number(approx[1]);
+  if (!Number.isFinite(minutes) || minutes <= 0) return null;
+  return { kind: 'approx', minutes };
+}
+
+/** One slide's place in the rendered timeline. */
+export interface SlideCue {
+  index: number;
+  /** Seconds from the start of the video. */
+  atSec: number;
+  /** Seconds this slide holds. */
+  durationSec: number;
+  /**
+   * Where the duration came from — worth carrying, because a schedule made
+   * mostly of `default` means the deck has not been timed and the video will
+   * be evenly paced rather than authored.
+   */
+  source: 'window' | 'approx' | 'default';
+}
+
+export interface ScheduleOpts {
+  /** Seconds for a slide that declares no timing at all. Default 20. */
+  defaultSec?: number;
+  /**
+   * Multiplier on every duration. 1 is the talk's real pace.
+   *
+   * A hundred-minute conference talk is a hundred-minute video, which is
+   * correct for a recording and wrong for anything else — so the knob exists,
+   * but it scales the whole timeline rather than letting slides drift apart.
+   */
+  speed?: number;
+}
+
+/** A host window never gives up so much that it stops being a beat of its own. */
+const MIN_HOST_SEC = 15;
+
+/**
+ * Lay a deck out as a seekable timeline.
+ *
+ * Two passes and then a cumulative sum, because an `approx` slide's time comes
+ * *out of* a neighbour rather than being appended: the deduction has to happen
+ * before anything is placed, or the borrowed minute would push every later
+ * slide off the window its notes claim.
+ */
+export function talkSchedule(
+  hints: SlideHint[],
+  opts: ScheduleOpts = {},
+): SlideCue[] {
+  const defaultSec = opts.defaultSec ?? 20;
+  const speed = opts.speed ?? 1;
+
+  // Pass 1 — what each slide asks for, before anyone lends.
+  const raw = hints.map((hint) => {
+    if (!hint) return { sec: defaultSec, source: 'default' as const };
+    if (hint.kind === 'approx') {
+      return { sec: hint.minutes * 60, source: 'approx' as const };
+    }
+    return {
+      sec: (hint.endMin - hint.startMin) * 60,
+      source: 'window' as const,
+    };
+  });
+
+  // Pass 2 — every `approx` slide borrows from its host.
+  //
+  // The host is the nearest ranged slide *before* it, because the notes say
+  // "overlaps"/"inside" the window that is already running when the slide
+  // appears. Falling forward to the next window covers a deck that opens on an
+  // approximate slide, which nothing does today but costs one branch.
+  for (let i = 0; i < raw.length; i++) {
+    if (raw[i].source !== 'approx') continue;
+
+    let host = -1;
+    for (let j = i - 1; j >= 0; j--) {
+      if (raw[j].source === 'window') {
+        host = j;
+        break;
+      }
+    }
+    if (host === -1) {
+      for (let j = i + 1; j < raw.length; j++) {
+        if (raw[j].source === 'window') {
+          host = j;
+          break;
+        }
+      }
+    }
+    if (host === -1) continue; // nothing to borrow from; the slide extends the talk
+
+    const lendable = Math.max(0, raw[host].sec - MIN_HOST_SEC);
+    raw[host].sec -= Math.min(raw[i].sec, lendable);
+  }
+
+  // Pass 3 — place them.
+  let at = 0;
+  return raw.map((slide, index) => {
+    const durationSec = slide.sec * speed;
+    const cue: SlideCue = {
+      index,
+      atSec: at,
+      durationSec,
+      source: slide.source,
+    };
+    at += durationSec;
+    return cue;
+  });
+}
+
+/** Total run time of a scheduled talk, in seconds. */
+export const totalSec = (cues: SlideCue[]): number =>
+  cues.length === 0
+    ? 0
+    : cues[cues.length - 1].atSec + cues[cues.length - 1].durationSec;
+
+/**
+ * The slide showing at `sec`, by binary search.
+ *
+ * Before the start, the first slide; at or past the end, the last — a renderer
+ * overshooting the final frame holds on the closing slide rather than falling
+ * off the deck.
+ */
+export function cueAt(cues: SlideCue[], sec: number): SlideCue | null {
+  if (cues.length === 0) return null;
+  if (sec < 0) return cues[0];
+  if (sec >= totalSec(cues)) return cues[cues.length - 1];
+
+  let lo = 0;
+  let hi = cues.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (cues[mid].atSec <= sec) lo = mid;
+    else hi = mid - 1;
+  }
+  return cues[lo];
+}

--- a/tests/talk-video.test.ts
+++ b/tests/talk-video.test.ts
@@ -1,0 +1,307 @@
+/**
+ * A talk as a seekable timeline, and the live machinery left out of it.
+ *
+ * The schedule tests run against the real decks in `data/talks/` rather than
+ * fixtures, because the interesting claim is about the content: the decks are
+ * already timed, the timings already tile the talk, and the total already
+ * matches what the frontmatter says. Fixtures would prove the arithmetic and
+ * miss all three.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  LIVE_COMPONENT_NAMES,
+  withoutLiveComponents,
+} from '../components/talks/liveComponents';
+import {
+  cueAt,
+  parseSlideHint,
+  type SlideHint,
+  talkSchedule,
+  totalSec,
+} from '../lib/talkVideo';
+
+/* ── the real decks ───────────────────────────────────────────────────────── */
+
+const TALK_DIR = join(__dirname, '..', 'data', 'talks');
+
+interface Deck {
+  slug: string;
+  durationMins: number | null;
+  hints: SlideHint[];
+}
+
+/**
+ * Split a deck the way `lib/talks.ts` does — frontmatter, then `---` between
+ * slides, then `???` between body and notes. Deliberately a plain parse rather
+ * than importing the loader, which compiles MDX through the whole pipeline to
+ * answer a question about text.
+ */
+function loadDecks(): Deck[] {
+  return readdirSync(TALK_DIR)
+    .filter((f) => f.endsWith('.mdx'))
+    .sort()
+    .map((file) => {
+      const src = readFileSync(join(TALK_DIR, file), 'utf8');
+      // Strip the frontmatter block first rather than splitting the whole file
+      // on `---`: the slide separator is the same token, so a plain split
+      // returns the frontmatter *and* every slide as siblings, and taking
+      // index 2 silently yields only the first slide.
+      const frontmatter = src.match(/^---\n([\s\S]*?)\n---\n/)?.[1] ?? '';
+      const body = src.replace(/^---\n[\s\S]*?\n---\n/, '');
+      const declared = frontmatter.match(/^durationMins:\s*(\d+)/m);
+      return {
+        slug: file.replace(/\.mdx$/, ''),
+        durationMins: declared ? Number(declared[1]) : null,
+        hints: body
+          .split(/^---$/m)
+          .map((slide) => parseSlideHint(slide.split('???')[1] ?? null)),
+      };
+    });
+}
+
+const DECKS = loadDecks();
+
+describe('parseSlideHint', () => {
+  it('reads the ranged form the presenter console already uses', () => {
+    expect(parseSlideHint('[⏱ 12–34 · SOME LABEL] notes')).toEqual({
+      kind: 'window',
+      startMin: 12,
+      endMin: 34,
+    });
+  });
+
+  it('reads the duration-only form, which the range parser drops', () => {
+    // The gap this module exists to close. `parseSlideWindow` returns null for
+    // both of these, which would leave the slides with no time at all.
+    expect(
+      parseSlideHint('[⏱ ~1 min · ICEBREAKER 🗳️ · overlaps the intro window]'),
+    ).toEqual({ kind: 'approx', minutes: 1 });
+    expect(
+      parseSlideHint('[⏱ ~2.5 min · IBM QUOTE · inside the AI window]'),
+    ).toEqual({ kind: 'approx', minutes: 2.5 });
+  });
+
+  it('prefers a range when a slide somehow declares both', () => {
+    expect(parseSlideHint('[⏱ 5–9 · X] and later [⏱ ~1 min · Y]')).toEqual({
+      kind: 'window',
+      startMin: 5,
+      endMin: 9,
+    });
+  });
+
+  it('returns null for notes with no timing, and for nonsense', () => {
+    expect(parseSlideHint(null)).toBeNull();
+    expect(parseSlideHint('just some speaker notes')).toBeNull();
+    expect(parseSlideHint('[⏱ ~0 min · nothing]')).toBeNull();
+    expect(parseSlideHint('[⏱ 9–5 · reversed]')).toBeNull();
+  });
+});
+
+describe('talkSchedule', () => {
+  it('gives a window slide exactly its window', () => {
+    const cues = talkSchedule([{ kind: 'window', startMin: 0, endMin: 5 }]);
+    expect(cues[0].durationSec).toBe(300);
+    expect(cues[0].source).toBe('window');
+  });
+
+  it('borrows an approximate slide out of its host, not out of the talk', () => {
+    // The whole point of the second tag form. The author wrote "overlaps the
+    // intro window", so the minute comes from the intro — the talk does not
+    // get a minute longer, and every later slide stays on the window its own
+    // notes claim.
+    const cues = talkSchedule([
+      { kind: 'window', startMin: 0, endMin: 5 },
+      { kind: 'approx', minutes: 1 },
+      { kind: 'window', startMin: 5, endMin: 9 },
+    ]);
+    expect(cues[0].durationSec).toBe(240); // 5 min, less the borrowed minute
+    expect(cues[1].durationSec).toBe(60);
+    expect(cues[2].durationSec).toBe(240);
+    expect(totalSec(cues)).toBe(9 * 60); // unchanged
+    expect(cues[2].atSec).toBe(5 * 60); // still lands on its own window
+  });
+
+  it('leaves a host with a beat of its own rather than borrowing it flat', () => {
+    const cues = talkSchedule([
+      { kind: 'window', startMin: 0, endMin: 0.5 },
+      { kind: 'approx', minutes: 10 },
+    ]);
+    expect(cues[0].durationSec).toBe(15);
+  });
+
+  it('falls forward when a deck opens on an approximate slide', () => {
+    const cues = talkSchedule([
+      { kind: 'approx', minutes: 1 },
+      { kind: 'window', startMin: 0, endMin: 5 },
+    ]);
+    expect(cues[1].durationSec).toBe(240);
+    expect(totalSec(cues)).toBe(300);
+  });
+
+  it('gives an untimed slide the default, and says so', () => {
+    const cues = talkSchedule([null, null], { defaultSec: 12 });
+    expect(cues.map((c) => c.durationSec)).toEqual([12, 12]);
+    expect(cues.map((c) => c.source)).toEqual(['default', 'default']);
+  });
+
+  it('scales the whole timeline together', () => {
+    const hints: SlideHint[] = [
+      { kind: 'window', startMin: 0, endMin: 4 },
+      { kind: 'window', startMin: 4, endMin: 10 },
+    ];
+    const real = talkSchedule(hints);
+    const quick = talkSchedule(hints, { speed: 0.25 });
+    expect(totalSec(quick)).toBe(totalSec(real) * 0.25);
+    // Proportions hold — a speed knob that let slides drift apart would be a
+    // different deck, not a faster one.
+    expect(quick[1].durationSec / quick[0].durationSec).toBeCloseTo(
+      real[1].durationSec / real[0].durationSec,
+      10,
+    );
+  });
+
+  it('is contiguous: every slide starts where the last one ended', () => {
+    for (const deck of DECKS) {
+      const cues = talkSchedule(deck.hints);
+      let expected = 0;
+      for (const cue of cues) {
+        expect(cue.atSec, deck.slug).toBeCloseTo(expected, 6);
+        expected += cue.durationSec;
+      }
+    }
+  });
+
+  it('gives every slide a positive duration', () => {
+    // The failure the second tag form prevents: with only ranges parsed, the
+    // two `~1 min` slides in so-you-want-to-build-software would sit inside a
+    // contiguous set of windows with no room, and flash past.
+    for (const deck of DECKS) {
+      for (const cue of talkSchedule(deck.hints)) {
+        expect(
+          cue.durationSec,
+          `${deck.slug} slide ${cue.index}`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('the decks are already a timeline', () => {
+  it('finds timing on every slide of every authored deck', () => {
+    // e2e-debug-deck is a test fixture with no notes at all, so it is the one
+    // deck that legitimately schedules on defaults.
+    for (const deck of DECKS.filter((d) => d.slug !== 'e2e-debug-deck')) {
+      const untimed = deck.hints.filter((h) => h === null).length;
+      expect(untimed, `${deck.slug} has ${untimed} untimed slides`).toBe(0);
+    }
+  });
+
+  it('runs for as long as the frontmatter says it will', () => {
+    // The claim that makes the schedule trustworthy: the windows an author
+    // wrote for pacing already add up to the talk they declared. Nothing
+    // enforced that before — this test is the first thing that does.
+    for (const deck of DECKS.filter((d) => d.slug !== 'e2e-debug-deck')) {
+      if (deck.durationMins === null) continue;
+      expect(totalSec(talkSchedule(deck.hints)) / 60, deck.slug).toBeCloseTo(
+        deck.durationMins,
+        6,
+      );
+    }
+  });
+
+  it('covers a real deck end to end without a gap', () => {
+    const deck = DECKS.find((d) => d.slug === 'so-you-want-to-build-software');
+    if (!deck) throw new Error('deck missing');
+    const cues = talkSchedule(deck.hints);
+    expect(cues).toHaveLength(deck.hints.length);
+    expect(cues.filter((c) => c.source === 'approx')).toHaveLength(2);
+    expect(totalSec(cues)).toBe(100 * 60);
+  });
+});
+
+describe('cueAt', () => {
+  const cues = talkSchedule([
+    { kind: 'window', startMin: 0, endMin: 2 },
+    { kind: 'window', startMin: 2, endMin: 5 },
+    { kind: 'window', startMin: 5, endMin: 6 },
+  ]);
+
+  it('returns each slide at its start and last moment', () => {
+    for (const cue of cues) {
+      expect(cueAt(cues, cue.atSec)).toEqual(cue);
+      expect(cueAt(cues, cue.atSec + cue.durationSec - 0.001)).toEqual(cue);
+    }
+  });
+
+  it('seeking anywhere equals playing there', () => {
+    // The property a frame renderer needs: a jump mid-render must produce the
+    // frame playback would have shown.
+    for (let sec = 0; sec < totalSec(cues); sec += 1 / 30) {
+      const seek = cueAt(cues, sec);
+      expect(seek).not.toBeNull();
+      expect(sec).toBeGreaterThanOrEqual(seek?.atSec ?? -1);
+      expect(sec).toBeLessThan((seek?.atSec ?? 0) + (seek?.durationSec ?? 0));
+    }
+  });
+
+  it('holds the last slide past the end rather than falling off the deck', () => {
+    expect(cueAt(cues, totalSec(cues))).toEqual(cues[2]);
+    expect(cueAt(cues, 1e6)).toEqual(cues[2]);
+    expect(cueAt(cues, -50)).toEqual(cues[0]);
+    expect(cueAt([], 5)).toBeNull();
+  });
+});
+
+/* ── live components ──────────────────────────────────────────────────────── */
+
+describe('live components are left out of a render', () => {
+  it('blanks each one, and leaves everything else alone', () => {
+    type Stub = (props: Record<string, unknown>) => unknown;
+    const map: Record<string, Stub> = {
+      LivePoll: () => 'poll',
+      Diagram: () => 'diagram',
+      NoteBlock: () => 'note',
+    };
+    const rendered = withoutLiveComponents(map);
+    expect(rendered.LivePoll({})).toBeNull();
+    expect(rendered.Diagram({})).toBe('diagram');
+    expect(rendered.NoteBlock({})).toBe('note');
+  });
+
+  it('does not add components a map never had', () => {
+    expect(Object.keys(withoutLiveComponents({ Diagram: () => null }))).toEqual(
+      ['Diagram'],
+    );
+  });
+
+  it('covers every realtime component the talks module exports', () => {
+    // The guard that matters. A new live widget added to the barrel and not to
+    // the list would render its loading state into a video, silently — so the
+    // list is checked against the source rather than against memory.
+    const dir = join(__dirname, '..', 'components', 'talks');
+    const barrel = readFileSync(join(dir, 'index.ts'), 'utf8');
+    const exported = [...barrel.matchAll(/from '\.\/(\w+)'/g)].map((m) => m[1]);
+    expect(exported.length).toBeGreaterThan(0);
+
+    const realtime = exported.filter((name) => {
+      const src = readFileSync(join(dir, `${name}.tsx`), 'utf8');
+      return /useQuery|useMutation|convex/i.test(src);
+    });
+    expect(realtime.length).toBeGreaterThan(0);
+
+    const missing = realtime.filter(
+      (name) => !(LIVE_COMPONENT_NAMES as readonly string[]).includes(name),
+    );
+    expect(missing, `not blanked for video: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('names nothing that does not exist', () => {
+    const dir = join(__dirname, '..', 'components', 'talks');
+    const files = readdirSync(dir);
+    for (const name of LIVE_COMPONENT_NAMES) {
+      expect(files, name).toContain(`${name}.tsx`);
+    }
+  });
+});


### PR DESCRIPTION
Closes #133. Independent — branches off `main`, touches only `lib/` and `components/talks/`.

**The headline: the decks are already timed, and nothing was reading it.**

`lib/slideTiming.ts` parses `[⏱ 12–34 · LABEL]` out of presenter notes so the
console can show pacing. That is its only consumer. Measured across
`data/talks/`:

| deck | slides | timed | span | `durationMins` |
|---|---|---|---|---|
| `aws-batch-mapreduce` | 6 | 6 | 0–20 | 20 |
| `paket-and-its-perks` | 10 | 10 | 0–25 | 25 |
| `railway-oriented-programming` | 16 | 16 | 0–30 | 30 |
| `so-you-want-to-build-software` | 24 | 22 | 0–100 | 100 |
| `the-safe-stack` | 7 | 7 | 0–20 | 20 |
| `e2e-debug-deck` | 4 | 0 | — | 1 |

**Zero gaps, zero overlaps, and the span equals the declared duration in every
authored deck.** So there was no metadata to design. There was metadata to read.

## The tag form that was being dropped

`parseSlideWindow` is deliberately tolerant and returns null for anything that
is not a range. That loses real information:

```
[⏱ ~1 min · ICEBREAKER 🗳️ · overlaps the intro window]
[⏱ ~1 min · IBM QUOTE · inside the AI window]
```

Both declare a duration. Neither declares a position — and the tag says why: the
minute is **carved out of** the surrounding window, not added to the talk.

This matters more than "two slides" suggests. Because the ranges are exactly
contiguous, there is no gap for an unranged slide to occupy — so reading only
ranges gives those slides **no time at all**, and they flash past in a render.
The two forms are not redundant; the second is load-bearing.

## `lib/talkVideo.ts`

Pure — no fs, no React — so the loader, a composition and the tests read one
timeline.

| | |
|---|---|
| `parseSlideHint(notes)` | both forms, as a discriminated union |
| `talkSchedule(hints, opts)` | cues with `atSec`, `durationSec`, `source` |
| `cueAt(cues, sec)` | seek, holding the last slide past the end |
| `totalSec(cues)` | how long the video runs |

An `approx` slide **borrows from its host** rather than extending the talk, so
the total still matches `durationMins` and every later slide stays on the window
its own notes claim. A host never lends below a 15-second floor, so it keeps a
beat of its own.

Cues carry `source` deliberately: a schedule that is mostly `default` means the
deck was never timed and the video will be evenly paced rather than authored —
something a renderer should be able to notice.

`speed` scales the whole timeline together. A hundred-minute conference talk is
a hundred-minute video, which is right for a recording and wrong for anything
else; the test asserts proportions hold, because a speed knob that let slides
drift apart would produce a different deck rather than a faster one.

## Leaving the live room out

A slide can embed `LivePoll`, `QuestionQueue`, `EmojiTop5`, `OrderedActions`,
`BreakTimer`. All realtime, all Convex-backed, all meaningless in a recording.

They can't just be left to fail: outside a provider their hooks have nothing to
read, so a render captures whatever each does with `undefined` — a loading
state, a zero count, or a throw. Three wrong answers instead of one right one.
**An empty poll in a video is worse than no poll, because it looks like a bug.**

`SlideBody` is the single place a slide's components resolve, so the boundary
blanks them there by name — `<SlideBody omitLive />` — rather than threading a
flag through seven components. Default behaviour is unchanged.

The part that matters is that **the list can't rot**: a test reads
`components/talks/index.ts`, greps each exported component's source for Convex
usage, and asserts every realtime one is in the list. A new widget added to the
barrel and not to the list fails the suite instead of shipping a dead component
into a video.

## Testing

22 tests, and the deck tests run against **real content rather than fixtures**,
because the interesting claims are about the content:

- every authored slide is timed (0 untimed, excluding the `e2e-debug-deck`
  fixture);
- every schedule is contiguous — each slide starts exactly where the last ended;
- every slide gets a positive duration — the failure the second tag form
  prevents;
- **every total matches `durationMins`**, which nothing enforced before;
- seeking anywhere equals playing there, at 30fps across a whole talk.

Fixtures would have proved the arithmetic and missed all five.

One bug I hit and fixed in my own test: splitting the file on `/^---$/m` returns
the frontmatter *and* every slide as siblings, so taking index 2 silently yields
only the first slide — and the schedule came out at 2 minutes instead of 20. The
loader strips frontmatter first; the test now does too.

## Out of scope

Rendering. This produces the timeline and the render-safe component map; the
composition that consumes them is #117, still blocked on the licence question.

## Verification

203 unit tests. `pnpm typecheck`, `biome check` and `next build` all clean. No
existing behaviour changes — `omitLive` defaults to `false`.

Part of #115.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqNytabn4ZfweRFC8CWGrW)_