### PR TITLE
ci(vercel): add ignoreCommand to govern build quota on Next.js and Storybook

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -39,7 +39,7 @@ design and identity is enforced where writes happen.
 | Local dev (localhost:3002) | `keen-shark-231` (dev) | ✅ own OAuth app | ✅ enabled | `SITE_URL=http://localhost:3002`; dev server **must run on 3002** |
 | Feature-branch previews (Vercel) | Convex **preview deployments**, one per branch | ❌ (ephemeral callback URL — ADR-0004) | ✅ via project-default env vars; **sign-in button auto-offered** (`NEXT_PUBLIC_VERCEL_ENV === 'preview'`) | The recommended way to test feature branches — admin-gated pages (/ideas, /admin) are reachable on previews; see §6 |
 | CI (live-e2e workflow) | dedicated E2E deployment (or a preview) | ❌ | ✅ | Secrets in GitHub Actions; job self-activates when provisioned |
-| `test-github` branch | *none yet — deliberately* | (would be ✅) | ❌ hard-coded off in the client | Stable branch URL `https://my-blog-0j5s-git-test-github-rtkelly13s-projects.vercel.app` reserved for a pre-prod OAuth rehearsal env. With the per-ship prod OAuth check (§8) it may never be needed — dormant until decided |
+| `test-github` branch | *none yet — deliberately* | (would be ✅) | ❌ hard-coded off in the client | Stable branch URL `https://blog-git-test-github-rtkelly13s-projects.vercel.app` reserved for a pre-prod OAuth rehearsal env. With the per-ship prod OAuth check (§8) it may never be needed — dormant until decided |
 
 ## 4. The `e2e` bypass provider (shipped, PR #48)
 
@@ -160,7 +160,7 @@ Per-branch, zero-setup, isolated full-stack environments:
    preview deployment named for the branch, inheriting the defaults — so the
    bypass is armed on every preview automatically. Previews expire after ~5
    days' inactivity (free tier).
-3. **Testing**: `pnpm signin:e2e https://my-blog-0j5s-git-<branch>-….vercel.app`
+3. **Testing**: `pnpm signin:e2e https://blog-git-<branch>-….vercel.app`
    for a human; the harness/CI uses the same primitives headlessly. Branch
    URLs are deterministic aliases and stable across pushes.
 

--- a/storybook-site/README.md
+++ b/storybook-site/README.md
@@ -59,7 +59,7 @@ to be ticked by hand once, per project.
 
 | Vercel project | Root directory | Builds |
 | --- | --- | --- |
-| `my-blog-0j5s` | repo root | the Next.js blog, at `ryankelly.dev` |
+| `blog` | repo root | the Next.js blog, at `ryankelly.dev` / `blog.ryankelly.dev` |
 | `blog-storybook` | `storybook-site` | this Storybook |
 
 `blog-storybook` is served on its generated `*.vercel.app` URL and composed into

--- a/storybook-site/vercel.json
+++ b/storybook-site/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
+  "ignoreCommand": "bash -c 'if [[ \"$VERCEL_GIT_COMMIT_REF\" == \"main\" || \"$VERCEL_GIT_COMMIT_REF\" =~ ^slot/[0-9]+$ || \"$VERCEL_GIT_COMMIT_MESSAGE\" =~ \\[(deploy-storybook|storybook|deploy|preview)\\] ]]; then exit 1; else exit 0; fi'",
   "installCommand": "cd .. && pnpm install --frozen-lockfile",
   "buildCommand": "cd .. && pnpm build-storybook -o storybook-site/dist",
   "outputDirectory": "dist",

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "ignoreCommand": "bash -c 'if [[ \"$VERCEL_GIT_COMMIT_REF\" == \"main\" || \"$VERCEL_GIT_COMMIT_REF\" =~ ^slot/[0-9]+$ || \"$VERCEL_GIT_COMMIT_MESSAGE\" =~ \\[(deploy|preview)\\] ]]; then exit 1; else exit 0; fi'"
 }


### PR DESCRIPTION
### Summary

Adds `ignoreCommand` to both `vercel.json` (Next.js app) and `storybook-site/vercel.json` (Storybook site) to protect against Vercel's daily build limit on the Hobby plan (100 deployments / 24h).

### Rules Enforced

- **Next.js app (`vercel.json`)**: Only builds on `main`, preview slots (`slot/1`..`slot/3`), or if the commit message contains `[deploy]` / `[preview]`.
- **Storybook site (`storybook-site/vercel.json`)**: Only builds on `main`, preview slots (`slot/1`..`slot/3`), or if the commit message contains `[deploy-storybook]` / `[storybook]` / `[deploy]` / `[preview]`.
- Feature branches and draft commits exit with `0` to skip the build and preserve deployment quota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)