### PR TITLE
Resolve @rtkelly13 from npm, which is where it is published

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@rtkelly13:registry=https://npm.pkg.github.com


### PR DESCRIPTION
One deleted line. `.npmrc` routed the `@rtkelly13` scope to
`npm.pkg.github.com`, and **the design system has never been published there.**

`publish-package.yml` uses `registry-url: https://registry.npmjs.org` with npm
trusted publishing, and `/publish-dev` dispatches that same workflow. All seven
versions — 0.0.4 through 0.3.0 — are on npmjs, public. GitHub Packages answers
**403 rather than 404** when unauthenticated, which is why this reads like a
missing token and is actually a missing package.

## Why CI has been green anyway

`setup-blog` keys its pnpm cache on `pnpm-lock.yaml`. A branch whose lockfile
matches a warm cache restores the store and **never contacts a registry at
all**. Only a branch that *changes dependencies* misses the cache and actually
resolves.

So the one class of PR that most needs its install verified is the only class
that ever attempts it — and every other green run is green because nothing was
downloaded.

Found via #113, which adds ten d3 packages:

    ERR_PNPM_FETCH_403  GET https://npm.pkg.github.com/@rtkelly13/design-system/-/design-system-0.1.3.tgz

Reproducible across three runs, while #121 and #122 hit the identical cache key
and passed without touching the network.

## No lockfile change, and why that is safe

pnpm derives the tarball URL from registry config at install time and verifies
the integrity already recorded. The npmjs tarball for 0.1.3 hashes to exactly
what the lockfile pins:

    sha512-aMIhBQIdYLWQ68BZydRO6suwbYuMOnMiBRq3RpcgESuCNsuVtyLySP01TOhdA023KUACJ/LPFBXHLLa4UKsmqA==

Same artifact, resolvable without credentials.

## Verified rather than reasoned

Installed `@rtkelly13/design-system@0.1.3` in a scratch project with **no
`.npmrc` and an empty `HOME`**, so no user-level GitHub token was visible.
Resolved from npmjs and installed 0.1.3.

Locally this never bit anyone because a personal token and a warm store hide
it; CI has neither.

## Left out deliberately

There is a **second** defect that let this hide, and it wants its own change:
a job that dies inside the `setup-blog` composite action never reaches the step
that sets its `outcome` output, the aggregate reads the unset value as
`skipped`, and `pr-checks` — the only required check — reports **pass**. #113
currently has five red jobs and a green required check.

That is a gate correctness fix, not a registry fix, so it is not in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)