### PR TITLE
Stop a bot comment cancelling a snapshot regeneration

### DIFF
--- a/.github/workflows/update-snapshots-command.yml
+++ b/.github/workflows/update-snapshots-command.yml
@@ -39,10 +39,6 @@ on:
   issue_comment:
     types: [created]
 
-concurrency:
-  group: update-snapshots-${{ github.event.issue.number }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 
@@ -56,6 +52,16 @@ jobs:
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # Job-level, deliberately. At workflow level GitHub evaluates concurrency
+    # *before* the `if:` above, so every comment on the PR joins the group —
+    # including bot comments, which then skip. A skipping run still cancels the
+    # one in progress, so a regeneration could be killed several minutes in by
+    # Vercel posting a preview link, and the only trace was a `cancelled` run
+    # with no explanation. Here the group is only ever entered by a real
+    # invocation.
+    concurrency:
+      group: update-snapshots-${{ github.event.issue.number }}
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
`concurrency` sat at **workflow level**, keyed on the issue number, with
`cancel-in-progress: true`. GitHub evaluates workflow-level concurrency *before*
the job's `if:`, so **every** comment on the PR joins the group — including bot
comments, which then skip.

A skipping run still cancels the one in progress.

So a snapshot regeneration could be killed several minutes in by Vercel posting a
preview link, and the only trace was a `cancelled` run with no explanation and no
output. Observed on #160:

    11:54:59  update-snapshots  (real invocation)   cancelled
    12:00:11  vercel[bot] comment                   skipped

Moving `concurrency` to the job puts it after the `if:`, so only a real
`/update-snapshots` invocation ever enters the group — which is what the group
was for. Two `/update-snapshots` commands on the same PR still supersede each
other, as intended.

Has to land on `main` to take effect: `issue_comment` always runs the workflow
from the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)