### PR TITLE
Graphics reads the palette instead of restating it

### DIFF
--- a/components/graphics/palette.ts
+++ b/components/graphics/palette.ts
@@ -1,48 +1,103 @@
+import type { Hue, ThemeLevel } from '@rtkelly13/design-system';
+import {
+  FIXED_COLOURS,
+  isThemeLevel,
+  LEVELS,
+  PALETTE_HUES,
+} from '@rtkelly13/design-system';
+
 /**
- * The brutalist accent palette. These are the *dark-theme* accent values — they
- * match the fallbacks of the Tailwind `brutalist` colours, which are now
- * CSS-variable-driven (`var(--ds-accent-primary)` …) so the site can
- * re-theme them. Generators receive an explicit `accent`, so they aren't bound
- * to these — see `graphicThemeDefaults` for the per-theme defaults.
+ * The graphics palette, read from the design system rather than restated here.
+ *
+ * ## Why this file used to hold hex, and why it no longer may
+ *
+ * It declared two hue-keyed records of hardcoded literals —
+ * `BRUTALIST_ACCENTS` and `PAPER_ACCENTS` — because the package offered no hue
+ * vocabulary to read. A generated diagram needs N mutually distinguishable
+ * colours, not four levels of emphasis, and `accent.primary…quiet` cannot
+ * express that.
+ *
+ * `ADR 0002` in the design system cites this exact file as the evidence for
+ * rejecting per-surface palettes: *"the two sets then drift silently, and there
+ * is no arithmetic that can catch it"*. It did drift. `PAPER_ACCENTS` held
+ * `#2563eb`, `#dc2626` and `#15803d` — all three of which fail WCAG AA against
+ * the sketch ground, at 4.31:1, 4.03:1 and 4.18:1 — while the package's own
+ * light accents had been solved to clear 5.5:1.
+ *
+ * The package now declares a `palette` Group of ten Hues per Level, gated once
+ * per Hue. So this file is an adapter: it maps the shapes the generators
+ * already take onto the package's values, and holds **no colour of its own**.
+ * `graphics.test.ts` asserts that.
+ *
+ * ## What is still missing, named rather than worked around
+ *
+ * `ADR 0004` makes `graphic` a Medium and records that it "needs a Group that
+ * does not exist": graphics want an *ordered sequence with a guaranteed
+ * pairwise floor*, and `palette` is a named record while `accent` is four steps
+ * of hierarchy. `CATEGORICAL` below is the closest thing available — the ten
+ * Hues in wheel order, whose pairwise separation the package gates in OKLab ΔE
+ * — but the ordering is the wheel's rather than a chosen perceptual sequence,
+ * and nothing guarantees that hues *adjacent in this list* are the most
+ * distinguishable pair available. A real ordered Group would.
+ *
+ * The `graphic` Medium's contrast floor is also 7:1, which the palette does not
+ * yet clear. A generated diagram is not currently gated against it.
  */
+
+/** The dark Level's Hues, by name. Was `BRUTALIST_ACCENTS`. */
 export const BRUTALIST_ACCENTS = {
-  cyan: '#22d3ee',
-  pink: '#ec4899',
-  yellow: '#facc15',
-  neonGreen: '#39ff14',
-  neonCyan: '#00ffff',
-  white: '#ffffff',
+  ...LEVELS.midnight.palette,
+  /** `paletteBright.cyan` — the ANSI-bright cyan, brighter than `cyan`. */
+  neonCyan: LEVELS.midnight.paletteBright.cyan,
+  /** Level-invariant, so it comes from `fixed` rather than a Level. */
+  white: FIXED_COLOURS.white,
 } as const;
 
 export type AccentName = keyof typeof BRUTALIST_ACCENTS;
 
 /**
- * The light "sketch" (paper & ink) palette — graphite ink plus the sketch
- * accents, matching the `.sketch` theme in css/tailwind.css. Feeding these to a
- * generator turns the neon-on-black look into ink-on-paper (graph paper, pencil
- * hatching, topo contours, …).
+ * The light Level's Hues plus its paper and ink.
+ *
+ * `ink` and `paper` are Roles rather than Hues — a drawing surface and the mark
+ * on it are `surface.base` and `text.primary`, not entries in a hue wheel.
  */
 export const PAPER_ACCENTS = {
-  ink: '#23262e',
-  blue: '#2563eb',
-  red: '#dc2626',
-  green: '#15803d',
-  paper: '#f5f3ec',
+  ...LEVELS.sketch.palette,
+  ink: LEVELS.sketch.text.primary,
+  paper: LEVELS.sketch.surface.base,
 } as const;
 
 /**
- * Default `accent` / `background` for a generator given the current site theme
- * (the next-themes value). The light `sketch` theme draws ink on paper; the
- * dark themes keep neon cyan. `background` stays transparent so the graphic
- * layers over whatever surface it sits on. Callers may still override `accent`.
+ * The ten Hues in wheel order, for a chart or diagram needing N distinguishable
+ * colours. See the caveat in this file's header: the package gates pairwise
+ * separation but not the *ordering*.
+ */
+export function categoricalSequence(level: ThemeLevel): readonly string[] {
+  return PALETTE_HUES.map((hue: Hue) => LEVELS[level].palette[hue]);
+}
+
+/**
+ * Default `accent` / `background` for a generator, given the current theme.
+ *
+ * Reads the Level rather than testing a theme name. The previous version
+ * compared `theme === 'sketch'` and fell through to a dark default, so a theme
+ * name it did not recognise silently drew neon on paper — the same class of bug
+ * as the `theme !== 'light'` comparisons in `lib/themePolarity.ts`.
+ *
+ * `background` stays transparent so the graphic layers over whatever surface it
+ * sits on.
  */
 export function graphicThemeDefaults(theme?: string): {
   accent: string;
   background: string;
 } {
-  return theme === 'sketch'
-    ? { accent: PAPER_ACCENTS.ink, background: 'transparent' }
-    : { accent: BRUTALIST_ACCENTS.cyan, background: 'transparent' };
+  const level: ThemeLevel = isThemeLevel(theme) ? theme : 'midnight';
+  const def = LEVELS[level];
+  return {
+    // On a light ground the mark is ink; on a dark one it is the brand cyan.
+    accent: def.polarity === 'light' ? def.text.primary : def.palette.cyan,
+    background: 'transparent',
+  };
 }
 
 /** Ordered swatch list for the gallery's colour picker. */

--- a/tests/graphics-palette.test.ts
+++ b/tests/graphics-palette.test.ts
@@ -1,0 +1,167 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { FIXED_COLOURS, LEVELS, PALETTE_HUES } from '@rtkelly13/design-system';
+import { describe, expect, it } from 'vitest';
+
+import {
+  ACCENT_SWATCHES,
+  BRUTALIST_ACCENTS,
+  categoricalSequence,
+  graphicThemeDefaults,
+  PAPER_ACCENTS,
+  withAlpha,
+} from '../components/graphics/palette';
+
+const SOURCE = readFileSync(
+  path.join(__dirname, '..', 'components', 'graphics', 'palette.ts'),
+  'utf8',
+);
+
+describe('the graphics palette holds no colour of its own', () => {
+  /**
+   * The arithmetic ADR 0002 says was missing.
+   *
+   * That ADR cites this file by name as the evidence for rejecting per-surface
+   * palettes — "the two sets then drift silently, and there is no arithmetic
+   * that can catch it". It drifted: `PAPER_ACCENTS` held #2563eb, #dc2626 and
+   * #15803d, all three of which fail WCAG AA on the sketch ground, while the
+   * package's own light accents had been solved to clear 5.5:1.
+   *
+   * This is the arithmetic. A hex literal reappearing in this file is the
+   * failure, whatever value it holds.
+   */
+  it('contains no hex literal outside a comment', () => {
+    const code = SOURCE.replace(/\/\*[\s\S]*?\*\//g, '').replace(
+      /\/\/[^\n]*/g,
+      '',
+    );
+    const literals = code.match(/#[0-9a-fA-F]{3,8}\b/g) ?? [];
+    expect(literals).toEqual([]);
+  });
+
+  it('sources every dark accent from the design system', () => {
+    for (const hue of PALETTE_HUES) {
+      expect(BRUTALIST_ACCENTS[hue]).toBe(LEVELS.midnight.palette[hue]);
+    }
+    expect(BRUTALIST_ACCENTS.neonCyan).toBe(LEVELS.midnight.paletteBright.cyan);
+    expect(BRUTALIST_ACCENTS.white).toBe(FIXED_COLOURS.white);
+  });
+
+  it('sources every light accent from the design system', () => {
+    for (const hue of PALETTE_HUES) {
+      expect(PAPER_ACCENTS[hue]).toBe(LEVELS.sketch.palette[hue]);
+    }
+    expect(PAPER_ACCENTS.ink).toBe(LEVELS.sketch.text.primary);
+    expect(PAPER_ACCENTS.paper).toBe(LEVELS.sketch.surface.base);
+  });
+
+  it('no longer carries the three values that failed WCAG AA', () => {
+    // Named explicitly so a revert is loud. These were the sketch pen colours.
+    const values = Object.values(PAPER_ACCENTS) as string[];
+    for (const failed of ['#2563eb', '#dc2626', '#15803d']) {
+      expect(values).not.toContain(failed);
+    }
+  });
+});
+
+describe('graphicThemeDefaults', () => {
+  it('draws ink on a light ground and the brand cyan on a dark one', () => {
+    expect(graphicThemeDefaults('sketch').accent).toBe(
+      LEVELS.sketch.text.primary,
+    );
+    expect(graphicThemeDefaults('midnight').accent).toBe(
+      LEVELS.midnight.palette.cyan,
+    );
+  });
+
+  it('falls back to the dark Level for an unknown theme, and says so', () => {
+    // The previous version compared `theme === 'sketch'` and fell through to a
+    // dark default, so an unrecognised name silently drew neon on paper — the
+    // same shape of bug as the `theme !== 'light'` comparisons this repo had.
+    // The fallback is still dark, but now it is a Level lookup rather than a
+    // string comparison, so a renamed Level is a type error at the call site.
+    expect(graphicThemeDefaults('bright').accent).toBe(
+      LEVELS.midnight.palette.cyan,
+    );
+    expect(graphicThemeDefaults(undefined).accent).toBe(
+      LEVELS.midnight.palette.cyan,
+    );
+  });
+
+  it('keeps the background transparent so a graphic layers over its surface', () => {
+    for (const theme of ['midnight', 'sketch', undefined]) {
+      expect(graphicThemeDefaults(theme).background).toBe('transparent');
+    }
+  });
+});
+
+describe('the categorical sequence', () => {
+  it('offers all ten hues, per Level', () => {
+    for (const level of ['midnight', 'sketch'] as const) {
+      const seq = categoricalSequence(level);
+      expect(seq).toHaveLength(PALETTE_HUES.length);
+      expect(new Set(seq).size).toBe(PALETTE_HUES.length);
+    }
+  });
+
+  it('is distinguishable pairwise, which is the property a chart needs', () => {
+    // The package gates this in OKLab ΔE. Re-asserted here because a diagram
+    // is the consumer that actually depends on it — `accent.primary…quiet` is
+    // four steps of hierarchy and cannot serve a ten-series chart.
+    const decode = (v: number) =>
+      v <= 0.04045 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+    const oklab = (hex: string) => {
+      const [r, g, b] = [1, 3, 5].map((i) =>
+        decode(Number.parseInt(hex.slice(i, i + 2), 16) / 255),
+      );
+      const l = Math.cbrt(
+        0.4122214708 * r! + 0.5363325363 * g! + 0.0514459929 * b!,
+      );
+      const m = Math.cbrt(
+        0.2119034982 * r! + 0.6806995451 * g! + 0.1073969566 * b!,
+      );
+      const s = Math.cbrt(
+        0.0883024619 * r! + 0.2817188376 * g! + 0.6299787005 * b!,
+      );
+      return [
+        0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+        1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+        0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+      ] as const;
+    };
+    for (const level of ['midnight', 'sketch'] as const) {
+      const seq = categoricalSequence(level);
+      const tight: string[] = [];
+      for (let i = 0; i < seq.length; i += 1) {
+        for (let j = i + 1; j < seq.length; j += 1) {
+          const a = oklab(seq[i]!);
+          const b = oklab(seq[j]!);
+          const d = Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+          if (d < 0.04) tight.push(`${level} ${i}/${j} ΔE ${d.toFixed(3)}`);
+        }
+      }
+      expect(tight).toEqual([]);
+    }
+  });
+});
+
+describe('ACCENT_SWATCHES', () => {
+  it('exposes every accent, in declaration order', () => {
+    expect(ACCENT_SWATCHES.map((s) => s.name)).toEqual(
+      Object.keys(BRUTALIST_ACCENTS),
+    );
+    for (const s of ACCENT_SWATCHES) expect(s.value).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+});
+
+describe('withAlpha', () => {
+  it('converts a package hex to rgba', () => {
+    expect(withAlpha(LEVELS.midnight.palette.cyan, 0.5)).toMatch(
+      /^rgba\(\d+, \d+, \d+, 0\.5\)$/,
+    );
+  });
+
+  it('passes a non-hex through untouched', () => {
+    expect(withAlpha('transparent', 0.5)).toBe('transparent');
+  });
+});


### PR DESCRIPTION
Companion to design-system #123's `palette` Group. Retires the fork that ADR 0002 cites by name.

## The file this is about

`components/graphics/palette.ts` is the evidence design-system ADR 0002 uses to reject per-surface palettes. It declared two hue-keyed records of hardcoded literals because the package offered no hue vocabulary to read — a generated diagram needs N mutually distinguishable colours, not four levels of emphasis, and `accent.primary…quiet` cannot express that. A fork was the only option available.

**The ADR's prediction was that the two sets would drift with no arithmetic able to catch it. They did.** `PAPER_ACCENTS` held `#2563eb`, `#dc2626` and `#15803d` — all three of which fail WCAG AA against the sketch ground at 4.31:1, 4.03:1 and 4.18:1 — while the package's own light accents had been solved to clear 5.5:1.

The package now declares ten Hues per Level, gated once per Hue. So the file is an adapter holding **no colour of its own**.

## The arithmetic that was missing

`tests/graphics-palette.test.ts`:

- fails on **any hex literal** in the file outside a comment, whatever value it holds
- asserts every accent equals its package source
- names the three WCAG failures explicitly, so a revert is loud
- re-asserts pairwise OKLab ΔE separation across the ten hues — the package gates that already, but a diagram is the consumer that actually depends on it

Verified against the fault: reintroducing `ink: '#23262e'` fails it.

## A bug fixed in passing

`graphicThemeDefaults` compared `theme === 'sketch'` and fell through to a dark default, so an unrecognised theme name **silently drew neon on paper** — the same shape as the `theme !== 'light'` comparisons this repo had. It now resolves a Level and reads its `polarity`, so a renamed Level is a type error rather than a wrong colour.

## What is still missing, named rather than worked around

ADR 0004 makes `graphic` a Medium and records that it needs a Group that does not exist: an **ordered sequence with a guaranteed pairwise floor**. `palette` is a named record and `accent` is four steps of hierarchy, so `categoricalSequence` is the closest available — the ten Hues in wheel order — and the file says plainly that the ordering is the wheel's rather than a chosen perceptual one.

The `graphic` Medium's contrast floor is also 7:1, which the palette does not yet clear, and a generated diagram is not currently gated against it.

## Checks

biome · tsc · `check:ds` reports **no token drift** · **450 unit tests across 36 files**. Consumer API unchanged — `PAPER_ACCENTS.ink` is the only key used outside this file and it still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
